### PR TITLE
cast Nikon EV byte array values to sbyte (signed byte) to correct calc

### DIFF
--- a/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDescriptor.cs
@@ -280,7 +280,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             var values = Directory.GetInt32Array(tagType);
             if (values == null || values.Length < 3 || values[2] == 0)
                 return null;
-            return $"{values[0]*values[1]/(double)values[2]:0.##} EV";
+            return $"{(sbyte)values[0]*(sbyte)values[1]/(double)(sbyte)values[2]:0.##} EV";
         }
 
         [CanBeNull]


### PR DESCRIPTION
This commit corrects Issue #18. Other GetEvDescription calls were tested, but should be verified. The double cast on values[2] may not be necessary but left it just in case.