### PR TITLE
Hold original string byte arrays to allow variable encoding

### DIFF
--- a/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
@@ -75,7 +75,7 @@ namespace MetadataExtractor.Tests.Formats.Png
             Assert.NotNull(pairs);
             Assert.Equal(1, pairs.Count);
             Assert.Equal("Comment", pairs[0].Key);
-            Assert.Equal("Created with GIMP", pairs[0].Value);
+            Assert.Equal("Created with GIMP", pairs[0].Value.ToString());
         }
 
         private static string CreateTestString(int year, int month, int day, int hourOfDay, int minute, int second)

--- a/MetadataExtractor/DeferredTagValue.cs
+++ b/MetadataExtractor/DeferredTagValue.cs
@@ -1,0 +1,18 @@
+﻿namespace MetadataExtractor
+{
+    public class DeferredTagValue
+    {
+        public DeferredTagValue(int tagId, int tagValueOffset, int tiffHeaderOffset)
+        {
+            //TagParentDirectory = tagParentDirectory;
+            TagId = tagId;
+            TagValueOffset = tagValueOffset;
+            TiffHeaderOffset = tiffHeaderOffset;
+        }
+
+        //public Directory TagParentDirectory { get; set; }
+        public int TagId { get; set; }
+        public int TagValueOffset { get; set; }
+        public int TiffHeaderOffset { get; set; }
+    }
+}

--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -338,7 +338,7 @@ namespace MetadataExtractor
         }
 
         /// <summary>Gets the specified tag's value as an byte array, if possible.</summary>
-        /// <remarks>Only supported where the tag is set as String, Integer, int[], byte[] or Rational[].</remarks>
+        /// <remarks>Only supported where the tag is set as StringValue, String, Integer, int[], byte[] or Rational[].</remarks>
         /// <returns>the tag's value as a byte array</returns>
         [CanBeNull]
         public static byte[] GetByteArray(this Directory directory, int tagType)
@@ -347,6 +347,10 @@ namespace MetadataExtractor
 
             if (o == null)
                 return null;
+
+            var strvalue = o as StringValue;
+            if (strvalue != null)
+                return strvalue.Bytes;
 
             byte[] bytes;
 

--- a/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
@@ -706,6 +706,8 @@ namespace MetadataExtractor.Formats.Exif
 
         public const int TagLens = 0xFDEA;
 
+        public const int TagOffsetSchema = 0xEA1D;
+
         protected static void AddExifTagNames(Dictionary<int, string> map)
         {
             map[TagInteropIndex] = "Interoperability Index";
@@ -857,6 +859,8 @@ namespace MetadataExtractor.Formats.Exif
             map[TagPanasonicTitle2] = "Panasonic Title (2)";
             map[TagPadding] = "Padding";
             map[TagLens] = "Lens";
+
+            map[TagOffsetSchema] = "Offset Schema";
         }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDescriptor.cs
@@ -41,6 +41,9 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         {
             switch (tagType)
             {
+                case CanonMakernoteDirectory.TagCanonOwnerName:
+                    return GetOwnerNameDescription();
+
                 case CanonMakernoteDirectory.TagCanonSerialNumber:
                     return GetSerialNumberDescription();
                 case CanonMakernoteDirectory.CameraSettings.TagFlashActivity:
@@ -128,6 +131,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 default:
                     return base.GetDescription(tagType);
             }
+        }
+
+        [CanBeNull]
+        public string GetOwnerNameDescription()
+        {
+            return Directory.GetString(CanonMakernoteDirectory.TagCanonOwnerName, System.Text.Encoding.GetEncoding("windows-1252"));
         }
 
         [CanBeNull]

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -64,7 +64,7 @@ namespace MetadataExtractor.Formats.Tiff
         public void Error(string message) => CurrentDirectory.AddError(message);
 
         public void SetByteArray(int tagId, byte[] bytes)         => CurrentDirectory.Set(tagId, bytes);
-        public void SetString(int tagId, string str)              => CurrentDirectory.Set(tagId, str);
+        public void SetString(int tagId, StringValue strval)      => CurrentDirectory.Set(tagId, strval);
         public void SetRational(int tagId, Rational rational)     => CurrentDirectory.Set(tagId, rational);
         public void SetRationalArray(int tagId, Rational[] array) => CurrentDirectory.Set(tagId, array);
         public void SetFloat(int tagId, float float32)            => CurrentDirectory.Set(tagId, float32);

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -86,6 +86,8 @@ namespace MetadataExtractor.Formats.Tiff
 
         public abstract void Completed(IndexedReader reader, int tiffHeaderOffset);
 
+        public abstract bool DeferProcessing(int tagId);
+
         public abstract bool CustomProcessTag(int tagOffset, ICollection<int> processedIfdOffsets, int tiffHeaderOffset, IndexedReader reader, int tagId, int byteCount);
 
         public abstract bool HasFollowerIfd();

--- a/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
@@ -54,6 +54,8 @@ namespace MetadataExtractor.Formats.Tiff
 
         void Completed([NotNull] IndexedReader reader, int tiffHeaderOffset);
 
+        bool DeferProcessing(int tagId);
+
         /// <exception cref="System.IO.IOException"/>
         bool CustomProcessTag(int tagOffset, [NotNull] ICollection<int> processedIfdOffsets, int tiffHeaderOffset, [NotNull] IndexedReader reader, int tagId, int byteCount);
 

--- a/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
@@ -63,7 +63,7 @@ namespace MetadataExtractor.Formats.Tiff
 
         void SetByteArray(int tagId, [NotNull] byte[] bytes);
 
-        void SetString(int tagId, [NotNull] string str);
+        void SetString(int tagId, [NotNull] StringValue strval);
 
         void SetRational(int tagId, [NotNull] Rational rational);
 

--- a/MetadataExtractor/Formats/Tiff/TiffReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffReader.cs
@@ -250,7 +250,7 @@ namespace MetadataExtractor.Formats.Tiff
                 }
                 case TiffDataFormatCode.String:
                 {
-                    handler.SetString(tagId, reader.GetNullTerminatedString(tagValueOffset, componentCount));
+                    handler.SetString(tagId, reader.GetNullTerminatedStringValue(tagValueOffset, componentCount));
                     break;
                 }
                 case TiffDataFormatCode.RationalS:

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -130,7 +130,7 @@ namespace MetadataExtractor.Formats.Xmp
         /// <remarks>
         /// The extraction is done with Adobe's XMPCore library.
         /// </remarks>
-        public XmpDirectory Extract([NotNull] string xmpString) => Extract(Encoding.UTF8.GetBytes(xmpString));
+        //public XmpDirectory Extract([NotNull] string xmpString) => Extract(Encoding.UTF8.GetBytes(xmpString));
 
         /// <exception cref="XmpException"/>
         private static void ProcessXmpTags(XmpDirectory directory, IXmpMeta xmpMeta)

--- a/MetadataExtractor/IO/IndexedReader.cs
+++ b/MetadataExtractor/IO/IndexedReader.cs
@@ -323,13 +323,23 @@ namespace MetadataExtractor.IO
         [NotNull]
         public string GetNullTerminatedString(int index, int maxLengthBytes)
         {
+            return GetNullTerminatedStringValue(index, maxLengthBytes).ToString();
+        }
+
+        public StringValue GetNullTerminatedStringValue(int index, int maxLengthBytes)
+        {
             // NOTE currently only really suited to single-byte character strings
             var bytes = GetBytes(index, maxLengthBytes);
             // Count the number of non-null bytes
             var length = 0;
             while (length < bytes.Length && bytes[length] != 0)
                 length++;
-            return Encoding.UTF8.GetString(bytes, 0, length);
+
+            var _actualBytes = new byte[length];
+            if(length > 0)
+                Array.Copy(bytes, 0, _actualBytes, 0, length);
+
+            return new StringValue(_actualBytes);
         }
     }
 }

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -251,13 +251,24 @@ namespace MetadataExtractor.IO
         [NotNull]
         public string GetNullTerminatedString(int maxLengthBytes)
         {
+            return GetNullTerminatedStringValue(maxLengthBytes).ToString();
+        }
+
+        public StringValue GetNullTerminatedStringValue(int maxLengthBytes)
+        {
             // NOTE currently only really suited to single-byte character strings
             var bytes = new byte[maxLengthBytes];
             // Count the number of non-null bytes
             var length = 0;
             while (length < bytes.Length && (bytes[length] = GetByte()) != 0)
                 length++;
-            return Encoding.UTF8.GetString(bytes, 0, length);
+            if(length != maxLengthBytes)
+            {
+                var bytesCopy = new byte[length];
+                Array.Copy(bytes, bytesCopy, length);
+                bytes = bytesCopy;
+            }
+            return new StringValue(bytes);
         }
     }
 }

--- a/MetadataExtractor/KeyValuePair.cs
+++ b/MetadataExtractor/KeyValuePair.cs
@@ -32,7 +32,7 @@ namespace MetadataExtractor
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class KeyValuePair
     {
-        public KeyValuePair([NotNull] string key, [NotNull] string value)
+        public KeyValuePair([NotNull] string key, [NotNull] StringValue value)
         {
             Key = key;
             Value = value;
@@ -42,6 +42,6 @@ namespace MetadataExtractor
         public string Key { get; }
 
         [NotNull]
-        public string Value { get; }
+        public StringValue Value { get; }
     }
 }

--- a/MetadataExtractor/MetadataExtractor.Portable.csproj
+++ b/MetadataExtractor/MetadataExtractor.Portable.csproj
@@ -196,6 +196,7 @@
     <Compile Include="MetadataException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rational.cs" />
+    <Compile Include="StringValue.cs" />
     <Compile Include="Tag.cs" />
     <Compile Include="TagDescriptor.cs" />
     <Compile Include="Util\ByteConvert.cs" />

--- a/MetadataExtractor/MetadataExtractor.Portable.csproj
+++ b/MetadataExtractor/MetadataExtractor.Portable.csproj
@@ -40,6 +40,7 @@
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="Age.cs" />
+    <Compile Include="DeferredTagValue.cs" />
     <Compile Include="Directory.cs" />
     <Compile Include="DirectoryExtensions.cs" />
     <Compile Include="Face.cs" />

--- a/MetadataExtractor/MetadataExtractor.net35.csproj
+++ b/MetadataExtractor/MetadataExtractor.net35.csproj
@@ -53,6 +53,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="DeferredTagValue.cs" />
     <Compile Include="DirectoryExtensions.cs" />
     <Compile Include="Formats\Jfxx\JfxxDescriptor.cs" />
     <Compile Include="Formats\Jfxx\JfxxDirectory.cs" />

--- a/MetadataExtractor/MetadataExtractor.net35.csproj
+++ b/MetadataExtractor/MetadataExtractor.net35.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Formats\QuickTime\QuickTimeTrackHeaderDirectory.cs" />
     <Compile Include="Formats\Raf\RafMetadataReader.cs" />
     <Compile Include="Formats\Xmp\Schema.cs" />
+    <Compile Include="StringValue.cs" />
     <Compile Include="Util\ByteConvert.cs" />
     <Compile Include="Util\DateUtil.cs" />
     <Compile Include="Util\FileType.cs" />

--- a/MetadataExtractor/MetadataExtractor.net45.csproj
+++ b/MetadataExtractor/MetadataExtractor.net45.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Formats\QuickTime\QuickTimeTrackHeaderDirectory.cs" />
     <Compile Include="Formats\Raf\RafMetadataReader.cs" />
     <Compile Include="Formats\Xmp\Schema.cs" />
+    <Compile Include="StringValue.cs" />
     <Compile Include="Util\ByteConvert.cs" />
     <Compile Include="Util\DateUtil.cs" />
     <Compile Include="Util\FileType.cs" />

--- a/MetadataExtractor/MetadataExtractor.net45.csproj
+++ b/MetadataExtractor/MetadataExtractor.net45.csproj
@@ -52,6 +52,7 @@
     <Compile Include="..\SharedAssemblyInfo.cs">
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
+    <Compile Include="DeferredTagValue.cs" />
     <Compile Include="DirectoryExtensions.cs" />
     <Compile Include="Formats\Jfxx\JfxxDescriptor.cs" />
     <Compile Include="Formats\Jfxx\JfxxDirectory.cs" />

--- a/MetadataExtractor/StringValue.cs
+++ b/MetadataExtractor/StringValue.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Text;
+
+using JetBrains.Annotations;
+
+namespace MetadataExtractor
+{
+    public sealed class StringValue : IConvertible
+    {
+        private readonly byte[] _buffer;
+        private Encoding _encoder = Encoding.UTF8;
+
+        public StringValue([NotNull] byte[] bytes)
+        {
+            _buffer = bytes;
+        }
+
+        public StringValue([NotNull] byte[] bytes, Encoding defaultEncoder)
+        {
+            _buffer = bytes;
+            _encoder = defaultEncoder;
+        }
+
+        public byte[] Bytes
+        {
+            get { return _buffer; }
+        }
+
+        public void SetEncodingByName(string encodingName)
+        {
+            _encoder = Encoding.GetEncoding(encodingName);
+        }
+
+        public Encoding Encoder
+        {
+            get { return _encoder; }
+            set { _encoder = value; }
+        }
+
+        public int Length
+        {
+            get { return (_buffer != null) ? _buffer.Length : 0; }
+        }
+
+        #region Conversion methods
+
+        public double ToDouble()
+        {
+            double output;
+            if (!double.TryParse(ToString(), out output))
+                throw new FormatException();
+
+            return output;
+        }
+
+        public float ToSingle()
+        {
+            return (float)ToDouble();
+        }
+
+        public string ToString(IFormatProvider provider) => ToString();
+
+        #region IConvertible
+        double IConvertible.ToDouble(IFormatProvider provider) => ToDouble();
+
+        decimal IConvertible.ToDecimal(IFormatProvider prodiver) => (decimal)ToDouble();
+
+        float IConvertible.ToSingle(IFormatProvider provider) => ToSingle();
+
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Object;
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Formatting
+
+        public override string ToString()
+        {
+            return ToString(_encoder);
+        }
+        public string ToString(Encoding encoder)
+        {
+            return encoder.GetString(_buffer, 0, Length);
+        }
+
+        #endregion
+
+        // user-defined conversion from StringValue to Double
+        /*public static implicit operator double(StringValue strval)
+        {
+            double value;
+            if (double.TryParse(strval.ToString(), out value))
+                return value;
+
+            throw new MetadataException($"Tag cannot be converted to {typeof(double).Name}.");
+        }*/
+
+        // user-defined conversion from StringValue to string
+        /*public static implicit operator string(StringValue strval)
+        {
+            return strval.ToString();
+        }*/
+
+        // user-defined conversion from string to StringValue
+        /*public static implicit operator StringValue(string str)
+        {
+            return new StringValue(Encoding.UTF8.GetBytes(str));
+        }*/
+
+    }
+}


### PR DESCRIPTION
This is a work-in-progress to keep byte arrays available to handle encoding issues, like Issue #19. I wanted to get your thoughts before proceeding any further - on the right track, implementation discussion, etc. I threw in CanonMakernoteDescriptor.GetOwnerNameDescription() to possibly demonstrate your suggestion in the Issue.

It does have a happy side effect - XMP Extract now uses the original byte array directly instead of encoding first.