### PR TITLE
Add and display 13 new Canon tags

### DIFF
--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -30,6 +30,44 @@ namespace MetadataExtractor
 {
     public static class DirectoryExtensions
     {
+        #region Int16
+
+        /// <summary>Returns a tag's value as a <see cref="short"/>, or throws if conversion is not possible.</summary>
+        /// <remarks>
+        /// If the value is <see cref="IConvertible"/>, then that interface is used for conversion of the value.
+        /// If the value is an array of <see cref="IConvertible"/> having length one, then the single item is converted.
+        /// </remarks>
+        /// <exception cref="MetadataException">No value exists for <paramref name="tagType"/>, or the value is not convertible to the requested type.</exception>
+        public static short GetInt16(this Directory directory, int tagType)
+        {
+            short value;
+            if (directory.TryGetInt16(tagType, out value))
+                return value;
+
+            return ThrowValueNotPossible<short>(directory, tagType);
+        }
+
+        public static bool TryGetInt16(this Directory directory, int tagType, out short value)
+        {
+            var convertible = GetConvertibleObject(directory, tagType);
+
+            if (convertible != null)
+            {
+                try
+                {
+                    value = convertible.ToInt16(null);
+                    return true;
+                }
+                catch
+                { }
+            }
+
+            value = default(short);
+            return false;
+        }
+
+        #endregion
+
         #region Int32
 
         /// <summary>Returns a tag's value as an <see cref="int"/>, or throws if conversion is not possible.</summary>

--- a/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
@@ -726,7 +726,7 @@ namespace MetadataExtractor.Formats.Exif
             if (!Directory.TryGetRational(ExifDirectoryBase.TagFocalPlaneXResolution, out value))
                 return null;
             var unit = GetFocalPlaneResolutionUnitDescription();
-            return value.Reciprocal.ToSimpleString() + (unit == null ? string.Empty : " " + unit.ToLower());
+            return value.ToDecimal().ToString("0.000000");
         }
 
         [CanBeNull]
@@ -736,7 +736,7 @@ namespace MetadataExtractor.Formats.Exif
             if (!Directory.TryGetRational(ExifDirectoryBase.TagFocalPlaneYResolution, out value))
                 return null;
             var unit = GetFocalPlaneResolutionUnitDescription();
-            return value.Reciprocal.ToSimpleString() + (unit == null ? string.Empty : " " + unit.ToLower());
+            return value.ToDecimal().ToString("0.000000");
         }
 
         [CanBeNull]

--- a/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDescriptor.cs
@@ -51,6 +51,8 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     return GetLensTypeDescription();
                 case CanonMakernoteDirectory.CameraSettings.TagDigitalZoom:
                     return GetDigitalZoomDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagRecordMode:
+                    return GetRecordModeDescription();
                 case CanonMakernoteDirectory.CameraSettings.TagQuality:
                     return GetQualityDescription();
                 case CanonMakernoteDirectory.CameraSettings.TagMacroMode:
@@ -97,34 +99,56 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     return GetAfPointUsedDescription();
                 case CanonMakernoteDirectory.FocalLength.TagFlashBias:
                     return GetFlashBiasDescription();
+                case CanonMakernoteDirectory.AfInfo.TagAfPointsInFocus:
+                    return GetTagAfPointsInFocus();
+                case CanonMakernoteDirectory.CameraSettings.TagMaxAperture:
+                    return GetMaxApertureDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagMinAperture:
+                    return GetMinApertureDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagFocusContinuous:
+                    return GetFocusContinuousDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagAESetting:
+                    return GetAESettingDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagDisplayAperture:
+                    return GetDisplayApertureDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagSpotMeteringMode:
+                    return GetSpotMeteringModeDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagPhotoEffect:
+                    return GetPhotoEffectDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagManualFlashOutput:
+                    return GetManualFlashOutputDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagColorTone:
+                    return GetColorToneDescription();
+                case CanonMakernoteDirectory.CameraSettings.TagSRAWQuality:
+                    return GetSRAWQualityDescription();
                 // It turns out that these values are dependent upon the camera model and therefore the below code was
                 // incorrect for some Canon models.  This needs to be revisited.
-//              case TAG_CANON_CUSTOM_FUNCTION_LONG_EXPOSURE_NOISE_REDUCTION:
-//                  return getLongExposureNoiseReductionDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_SHUTTER_AUTO_EXPOSURE_LOCK_BUTTONS:
-//                  return getShutterAutoExposureLockButtonDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_MIRROR_LOCKUP:
-//                  return getMirrorLockupDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_TV_AV_AND_EXPOSURE_LEVEL:
-//                  return getTvAndAvExposureLevelDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_AF_ASSIST_LIGHT:
-//                  return getAutoFocusAssistLightDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_SHUTTER_SPEED_IN_AV_MODE:
-//                  return getShutterSpeedInAvModeDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_BRACKETING:
-//                  return getAutoExposureBracketingSequenceAndAutoCancellationDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_SHUTTER_CURTAIN_SYNC:
-//                  return getShutterCurtainSyncDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_AF_STOP:
-//                  return getLensAutoFocusStopButtonDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_FILL_FLASH_REDUCTION:
-//                  return getFillFlashReductionDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_MENU_BUTTON_RETURN:
-//                  return getMenuButtonReturnPositionDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_SET_BUTTON_FUNCTION:
-//                  return getSetButtonFunctionWhenShootingDescription();
-//              case TAG_CANON_CUSTOM_FUNCTION_SENSOR_CLEANING:
-//                  return getSensorCleaningDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_LONG_EXPOSURE_NOISE_REDUCTION:
+                //                  return getLongExposureNoiseReductionDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_SHUTTER_AUTO_EXPOSURE_LOCK_BUTTONS:
+                //                  return getShutterAutoExposureLockButtonDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_MIRROR_LOCKUP:
+                //                  return getMirrorLockupDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_TV_AV_AND_EXPOSURE_LEVEL:
+                //                  return getTvAndAvExposureLevelDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_AF_ASSIST_LIGHT:
+                //                  return getAutoFocusAssistLightDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_SHUTTER_SPEED_IN_AV_MODE:
+                //                  return getShutterSpeedInAvModeDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_BRACKETING:
+                //                  return getAutoExposureBracketingSequenceAndAutoCancellationDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_SHUTTER_CURTAIN_SYNC:
+                //                  return getShutterCurtainSyncDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_AF_STOP:
+                //                  return getLensAutoFocusStopButtonDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_FILL_FLASH_REDUCTION:
+                //                  return getFillFlashReductionDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_MENU_BUTTON_RETURN:
+                //                  return getMenuButtonReturnPositionDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_SET_BUTTON_FUNCTION:
+                //                  return getSetButtonFunctionWhenShootingDescription();
+                //              case TAG_CANON_CUSTOM_FUNCTION_SENSOR_CLEANING:
+                //                  return getSensorCleaningDescription();
                 default:
                     return base.GetDescription(tagType);
             }
@@ -356,6 +380,16 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             }
 
             return "Unknown (" + value + ")";
+        }
+
+        [CanBeNull]
+        public string GetTagAfPointsInFocus()
+        {
+            short value;
+            if (!Directory.TryGetInt16(CanonMakernoteDirectory.AfInfo.TagAfPointsInFocus, out value))
+                return null;
+
+            return DecodeBits(value, 16);
         }
 
         [CanBeNull]
@@ -615,6 +649,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         }
 
         [CanBeNull]
+        public string GetRecordModeDescription()
+        {
+            return GetIndexedDescription(CanonMakernoteDirectory.CameraSettings.TagRecordMode, 1, "JPEG", "CRW+THM", "AVI+THM", "TIF", "TIF+JPEG", "CR2", "CR2+JPEG", null, "MOV", "MP4");
+        }
+
+        [CanBeNull]
         public string GetFocusTypeDescription()
         {
             int value;
@@ -642,13 +682,172 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             int value;
             return !Directory.TryGetInt32(CanonMakernoteDirectory.CameraSettings.TagLensType, out value)
                 ? null
-                : "Lens type: " + value;
+                : value.ToString();
+        }
+
+        [CanBeNull]
+        public string GetMaxApertureDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(CanonMakernoteDirectory.CameraSettings.TagMaxAperture, out value))
+                return null;
+
+            return System.Math.Exp(CanonEv(value) * System.Math.Log(2.0) / 2.0).ToString("0.#");
+        }
+
+        [CanBeNull]
+        public string GetMinApertureDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(CanonMakernoteDirectory.CameraSettings.TagMinAperture, out value))
+                return null;
+
+            return System.Math.Exp(CanonEv(value) * System.Math.Log(2.0) / 2.0).ToString("0.#");
         }
 
         [CanBeNull]
         public string GetFlashActivityDescription()
         {
             return GetIndexedDescription(CanonMakernoteDirectory.CameraSettings.TagFlashActivity, "Flash did not fire", "Flash fired");
+        }
+
+        [CanBeNull]
+        public string GetFocusContinuousDescription()
+        {
+            return GetIndexedDescription(CanonMakernoteDirectory.CameraSettings.TagFocusContinuous, 0, "Single", "Continous",
+                                            null, null, null, null, null, null, "Manual");
+        }
+
+        [CanBeNull]
+        public string GetAESettingDescription()
+        {
+            return GetIndexedDescription(CanonMakernoteDirectory.CameraSettings.TagAESetting, 0, "Normal AE", "Exposure Compensation",
+                                            "AE Lock", "AE Lock + Exposure Comp.", "No AE");
+        }
+
+        [CanBeNull]
+        public string GetDisplayApertureDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(CanonMakernoteDirectory.CameraSettings.TagDisplayAperture, out value))
+                return null;
+
+            return (value / 10).ToString();
+        }
+
+        [CanBeNull]
+        public string GetSpotMeteringModeDescription()
+        {
+            return GetIndexedDescription(CanonMakernoteDirectory.CameraSettings.TagSpotMeteringMode, 0, "Center", "AF Point");
+        }
+
+        [CanBeNull]
+        public string GetPhotoEffectDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(CanonMakernoteDirectory.CameraSettings.TagPhotoEffect, out value))
+                return null;
+
+            switch (value)
+            {
+                case 0:
+                    return "Off";
+                case 1:
+                    return "Vivid";
+                case 2:
+                    return "Neutral";
+                case 3:
+                    return "Smooth";
+                case 4:
+                    return "Sepia";
+                case 5:
+                    return "B&W";
+                case 6:
+                    return "Custom";
+                case 100:
+                    return "My Color Data";
+                default:
+                    return "Unknown (" + value + ")";
+            }
+        }
+
+        [CanBeNull]
+        public string GetManualFlashOutputDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(CanonMakernoteDirectory.CameraSettings.TagManualFlashOutput, out value))
+                return null;
+
+            switch (value)
+            {
+                case 0:
+                    return "n/a";
+                case 0x500:
+                    return "Full";
+                case 0x502:
+                    return "Medium";
+                case 0x504:
+                    return "Low";
+                case 0x7fff:
+                    return "n/a";   // (EOS models)
+                default:
+                    return "Unknown (" + value + ")";
+            }
+        }
+
+        [CanBeNull]
+        public string GetColorToneDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(CanonMakernoteDirectory.CameraSettings.TagColorTone, out value))
+                return null;
+
+            if (value == 0x7fff)
+                return "n/a";
+            else
+                return value.ToString();
+        }
+
+        [CanBeNull]
+        public string GetSRAWQualityDescription()
+        {
+            return GetIndexedDescription(CanonMakernoteDirectory.CameraSettings.TagSRAWQuality, 0, "n/a", "sRAW1 (mRAW)", "sRAW2 (sRAW)");
+        }
+
+        /// <summary>
+        /// Canon hex-based EV (modulo 0x20) to real number
+        /// </summary>
+        ///<remarks>
+        /// Converted from Exiftool version 10.10 created by Phil Harvey
+        /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+        /// lib\Image\ExifTool\Canon.pm
+        ///</remarks>
+        /// <param name="val">value to convert
+        ///         eg) 0x00 -> 0
+        ///             0x0c -> 0.33333
+        ///             0x10 -> 0.5
+        ///             0x14 -> 0.66666
+        ///             0x20 -> 1   ... etc
+        ///</param>
+        ///<returns>double</returns>
+        private double CanonEv(int val)
+        {
+            int sign = 1;
+            if (val < 0)
+            {
+                val = -val;
+                sign = -1;
+            }
+
+            int frac = val & 0x1f;
+            val -= frac;
+
+            if (frac == 0x0c)
+                frac = 0x20 / 3;
+            else if (frac == 0x14)
+                frac = 0x40 / 3;
+
+            return sign * (val + frac) / (double)0x20;
         }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDirectory.cs
@@ -161,7 +161,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             public const int TagFocusMode1 = Offset + 0x07;
 
             public const int TagUnknown3 = Offset + 0x08;
-            public const int TagUnknown4 = Offset + 0x09;
+            public const int TagRecordMode = Offset + 0x09;
 
             /// <summary>
             /// 0 = Large
@@ -263,8 +263,8 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             public const int TagLongFocalLength = Offset + 0x17;
             public const int TagShortFocalLength = Offset + 0x18;
             public const int TagFocalUnitsPerMm = Offset + 0x19;
-            public const int TagUnknown9 = Offset + 0x1A;
-            public const int TagUnknown10 = Offset + 0x1B;
+            public const int TagMaxAperture = Offset + 0x1A;
+            public const int TagMinAperture = Offset + 0x1B;
 
             /// <summary>
             /// 0 = Flash Did Not Fire
@@ -273,14 +273,25 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             public const int TagFlashActivity = Offset + 0x1C;
 
             public const int TagFlashDetails = Offset + 0x1D;
-            public const int TagUnknown12 = Offset + 0x1E;
-            public const int TagUnknown13 = Offset + 0x1F;
+            public const int TagFocusContinuous = Offset + 0x1E;
+            public const int TagAESetting = Offset + 0x1F;
 
             /// <summary>
             /// 0 = Focus Mode: Single
             /// 1 = Focus Mode: Continuous
             /// </summary>
             public const int TagFocusMode2 = Offset + 0x20;
+
+            public const int TagDisplayAperture = Offset + 0x21;
+            public const int TagZoomSourceWidth = Offset + 0x22;
+            public const int TagZoomTargetWidth = Offset + 0x23;
+
+            public const int TagSpotMeteringMode = Offset + 0x25;
+            public const int TagPhotoEffect = Offset + 0x26;
+            public const int TagManualFlashOutput = Offset + 0x27;
+
+            public const int TagColorTone = Offset + 0x29;
+            public const int TagSRAWQuality = Offset + 0x2D;
         }
 
         // These 'sub'-tag values have been created for consistency -- they don't exist within the exif segment
@@ -531,16 +542,25 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { CameraSettings.TagQuality, "Quality" },
             { CameraSettings.TagUnknown2, "Unknown Camera Setting 2" },
             { CameraSettings.TagUnknown3, "Unknown Camera Setting 3" },
-            { CameraSettings.TagUnknown4, "Unknown Camera Setting 4" },
+            { CameraSettings.TagRecordMode, "Record Mode" },
             { CameraSettings.TagDigitalZoom, "Digital Zoom" },
             { CameraSettings.TagFocusType, "Focus Type" },
             { CameraSettings.TagUnknown7, "Unknown Camera Setting 7" },
             { CameraSettings.TagLensType, "Lens Type" },
-            { CameraSettings.TagUnknown9, "Unknown Camera Setting 9" },
-            { CameraSettings.TagUnknown10, "Unknown Camera Setting 10" },
+            { CameraSettings.TagMaxAperture, "Max Aperture" },
+            { CameraSettings.TagMinAperture, "Min Aperture" },
             { CameraSettings.TagFlashActivity, "Flash Activity" },
-            { CameraSettings.TagUnknown12, "Unknown Camera Setting 12" },
-            { CameraSettings.TagUnknown13, "Unknown Camera Setting 13" },
+            { CameraSettings.TagFocusContinuous, "Focus Continuous" },
+            { CameraSettings.TagAESetting, "AE Setting" },
+            { CameraSettings.TagDisplayAperture, "Display Aperture" },
+            { CameraSettings.TagZoomSourceWidth, "Zoom Source Width" },
+            { CameraSettings.TagZoomTargetWidth, "Zoom Target Width" },
+            { CameraSettings.TagSpotMeteringMode, "Spot Metering Mode" },
+            { CameraSettings.TagPhotoEffect, "Photo Effect" },
+            { CameraSettings.TagManualFlashOutput, "Manual Flash Output" },
+            { CameraSettings.TagColorTone, "Color Tone" },
+            { CameraSettings.TagSRAWQuality, "SRAW Quality" },
+
             { FocalLength.TagWhiteBalance, "White Balance" },
             { FocalLength.TagSequenceNumber, "Sequence Number" },
             { FocalLength.TagAfPointUsed, "AF Point Used" },
@@ -719,23 +739,74 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     break;
                 }
 
+                // Notes from Exiftool 10.10 by Phil Harvey, lib\Image\Exiftool\Canon.pm:
+                // Auto-focus information used by many older Canon models. The values in this
+                // record are sequential, and some have variable sizes based on the value of
+                // numafpoints (which may be 1,5,7,9,15,45, or 53). The AFArea coordinates are
+                // given in a system where the image has dimensions given by AFImageWidth and
+                // AFImageHeight, and 0,0 is the image center. The direction of the Y axis
+                // depends on the camera model, with positive Y upwards for EOS models, but
+                // apparently downwards for PowerShot models.
+
+
+                // AFInfo is another array with 'fake' tags. The first int of the array contains
+                // the number of AF points. Iterate through the array one byte at a time, generally
+                // assuming one byte corresponds to one tag UNLESS certain tag numbers are encountered.
+                // For these, read specific subsequent bytes from the array based on the tag type. The
+                // number of bytes read can vary.
+
                 case TagAfInfoArray:
                 {
                     var values = (ushort[])array;
+                    int numafpoints = values[0];
+                    int tagnumber = 0;
                     for (var i = 0; i < values.Length; i++)
-                        Set(AfInfo.Offset + i, values[i]);
+                    {
+                        // These two tags store 'numafpoints' bytes of data in the array
+                        if (AfInfo.Offset + tagnumber == AfInfo.TagAfAreaXPositions ||
+                            AfInfo.Offset + tagnumber == AfInfo.TagAfAreaYPositions)
+                        {
+                            // There could be incorrect data in the array, so boundary check
+                            if (values.Length - 1 >= (i + numafpoints))
+                            {
+                                var areaPositions = new short[numafpoints];
+                                for (var j = 0; j < areaPositions.Length; j++)
+                                    areaPositions[j] = (short)values[i + j];
+
+                                Set(AfInfo.Offset + tagnumber, areaPositions);
+                            }
+                            i += numafpoints - 1;   // assume these bytes are processed and skip
+                        }
+                        else if (AfInfo.Offset + tagnumber == AfInfo.TagAfPointsInFocus)
+                        {
+                            var pointsInFocus = new short[(int)((numafpoints + 15) / 16)];
+                            
+                            // There could be incorrect data in the array, so boundary check
+                            if (values.Length - 1 >= (i + pointsInFocus.Length))
+                            {
+                                for (var j = 0; j < pointsInFocus.Length; j++)
+                                    pointsInFocus[j] = (short)values[i + j];
+
+                                Set(AfInfo.Offset + tagnumber, pointsInFocus);
+                            }
+                            i += pointsInFocus.Length - 1;  // assume these bytes are processed and skip
+                        }
+                        else
+                            Set(AfInfo.Offset + tagnumber, values[i]);
+                        tagnumber++;
+                    }
                     break;
                 }
 
                 // TODO the interpretation of the custom functions tag depends upon the camera model
-//                case TAG_CANON_CUSTOM_FUNCTIONS_ARRAY:
-//                {
-//                    int subTagTypeBase = 0xC300;
-//                    // we intentionally skip the first array member
-//                    for (int i = 1; i < ints.length; i++)
-//                        setInt(subTagTypeBase + i + 1, ints[i] & 0x0F);
-//                    break;
-//                }
+                //                case TAG_CANON_CUSTOM_FUNCTIONS_ARRAY:
+                //                {
+                //                    int subTagTypeBase = 0xC300;
+                //                    // we intentionally skip the first array member
+                //                    for (int i = 1; i < ints.length; i++)
+                //                        setInt(subTagTypeBase + i + 1, ints[i] & 0x0F);
+                //                    break;
+                //                }
 
                 default:
                 {

--- a/MetadataExtractor/TagDescriptor.cs
+++ b/MetadataExtractor/TagDescriptor.cs
@@ -25,6 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using MetadataExtractor.Util;
@@ -293,5 +294,32 @@ namespace MetadataExtractor
         protected static string GetFStopDescription(double fStop) => $"f/{fStop:0.0}";
 
         protected static string GetFocalLengthDescription(double mm) => $"{mm:0.#} mm";
+
+        /// <summary>
+        /// Decode bit mask
+        /// </summary>
+        ///<remarks>
+        /// Converted from Exiftool version 10.10 created by Phil Harvey
+        /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+        /// lib\Image\ExifTool\ExifTool.pm
+        ///</remarks>
+        ///<param name="val">value to decode</param>
+        ///<param name="bits">optional bits per word (defaults to 32)</param>
+        protected string DecodeBits(short val, int bits = 32)
+        {
+            int num = 0;
+            List<int> bitList = new List<int>();
+
+            for (var i = 0; i < bits; i++)
+            {
+                if ((val & (1 << i)) > 0)
+                {
+                    int n = i + num;
+                    bitList.Add(n);
+                }
+            }
+            num += bits;
+            return (bitList.Count == 0) ? "(none)" : string.Join(",", bitList.Select(x => x.ToString()).ToArray());
+        }
     }
 }


### PR DESCRIPTION
Delved into Exiftool a bit to identify some Canon tags and offer some potential display cleanup for a few existing tags.

New/Revised Canon: TagRecordMode, TagMaxAperture, TagMinAperture, TagFocusContinuous, TagAESetting, TagDisplayAperture, TagZoomSourceWidth, TagZoomTargetWidth, TagSpotMeteringMode, TagPhotoEffect, TagManualFlashOutput, TagColorTone, TagSRAWQuality

A couple of functions were also converted from Exiftool to C# and I tried to attribute those appropriately.
