### PR TITLE
Hold original string byte arrays to allow variable encoding (second try)

### DIFF
--- a/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
@@ -75,7 +75,7 @@ namespace MetadataExtractor.Tests.Formats.Png
             Assert.NotNull(pairs);
             Assert.Equal(1, pairs.Count);
             Assert.Equal("Comment", pairs[0].Key);
-            Assert.Equal("Created with GIMP", pairs[0].Value);
+            Assert.Equal("Created with GIMP", pairs[0].Value.ToString());
         }
 
         private static string CreateTestString(int year, int month, int day, int hourOfDay, int minute, int second)

--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -338,7 +338,7 @@ namespace MetadataExtractor
         }
 
         /// <summary>Gets the specified tag's value as an byte array, if possible.</summary>
-        /// <remarks>Only supported where the tag is set as String, Integer, int[], byte[] or Rational[].</remarks>
+        /// <remarks>Only supported where the tag is set as StringValue, String, Integer, int[], byte[] or Rational[].</remarks>
         /// <returns>the tag's value as a byte array</returns>
         [CanBeNull]
         public static byte[] GetByteArray(this Directory directory, int tagType)
@@ -347,6 +347,10 @@ namespace MetadataExtractor
 
             if (o == null)
                 return null;
+
+            var strvalue = o as StringValue;
+            if (strvalue != null)
+                return strvalue.Bytes;
 
             byte[] bytes;
 

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -46,6 +46,9 @@ namespace MetadataExtractor.Formats.Png
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class PngMetadataReader
     {
+        // by spec, PNG is generally supposed to use this encoding
+        private static string defaultEncodingName = "ISO-8859-1";
+
         private static readonly HashSet<PngChunkType> _desiredChunkTypes = new HashSet<PngChunkType>
         {
             PngChunkType.IHDR,
@@ -120,6 +123,11 @@ namespace MetadataExtractor.Formats.Png
         /// <exception cref="System.IO.IOException"/>
         private static IEnumerable<Directory> ProcessChunk([NotNull] PngChunk chunk)
         {
+            // For more guidance:
+            // http://www.w3.org/TR/PNG-Decoders.html#D.Text-chunk-processing
+            // http://www.libpng.org/pub/png/spec/1.2/PNG-Chunks.html#C.iCCP
+            var defaultEncoding = System.Text.Encoding.GetEncoding(defaultEncodingName);
+
             var chunkType = chunk.ChunkType;
             var bytes = chunk.Bytes;
 
@@ -179,7 +187,7 @@ namespace MetadataExtractor.Formats.Png
             else if (chunkType == PngChunkType.iCCP)
             {
                 var reader = new SequentialByteArrayReader(bytes);
-                var profileName = reader.GetNullTerminatedString(maxLengthBytes: 79);
+                var profileName = reader.GetNullTerminatedStringValue(maxLengthBytes: 79);
                 var directory = new PngDirectory(PngChunkType.iCCP);
                 directory.Set(PngDirectory.TagIccProfileName, profileName);
                 var compressionMethod = reader.GetSByte();
@@ -207,9 +215,11 @@ namespace MetadataExtractor.Formats.Png
             else if (chunkType == PngChunkType.tEXt)
             {
                 var reader = new SequentialByteArrayReader(bytes);
-                var keyword = reader.GetNullTerminatedString(maxLengthBytes: 79);
+                var keyword = reader.GetNullTerminatedStringValue(maxLengthBytes: 79).ToString(defaultEncoding);
                 var bytesLeft = bytes.Length - keyword.Length - 1;
-                var value = reader.GetNullTerminatedString(bytesLeft);
+                var value = reader.GetNullTerminatedStringValue(bytesLeft);
+                value.SetEncodingByName(defaultEncodingName);
+
                 var textPairs = new List<KeyValuePair> { new KeyValuePair(keyword, value) };
                 var directory = new PngDirectory(PngChunkType.iTXt);
                 directory.Set(PngDirectory.TagTextualData, textPairs);
@@ -218,23 +228,44 @@ namespace MetadataExtractor.Formats.Png
             else if (chunkType == PngChunkType.iTXt)
             {
                 var reader = new SequentialByteArrayReader(bytes);
-                var keyword = reader.GetNullTerminatedString(maxLengthBytes: 79);
+                var keyword = reader.GetNullTerminatedStringValue(maxLengthBytes: 79).ToString(defaultEncoding);
                 var compressionFlag = reader.GetSByte();
                 var compressionMethod = reader.GetSByte();
-                var languageTag = reader.GetNullTerminatedString(bytes.Length);
-                var translatedKeyword = reader.GetNullTerminatedString(bytes.Length);
+                var languageTag = reader.GetNullTerminatedStringValue(bytes.Length);
+                languageTag.SetEncodingByName(defaultEncodingName);
+
+                var translatedKeyword = reader.GetNullTerminatedStringValue(bytes.Length);
+                translatedKeyword.SetEncodingByName(defaultEncodingName);
+
                 var bytesLeft = bytes.Length - keyword.Length - 1 - 1 - 1 - languageTag.Length - 1 - translatedKeyword.Length - 1;
-                string text = null;
+                StringValue text = null;
                 if (compressionFlag == 0)
                 {
-                    text = reader.GetNullTerminatedString(bytesLeft);
+                    text = reader.GetNullTerminatedStringValue(bytesLeft);
+                    text.SetEncodingByName(defaultEncodingName);
                 }
                 else if (compressionFlag == 1)
                 {
                     if (compressionMethod == 0)
                     {
                         using (var inflaterStream = new DeflateStream(new MemoryStream(bytes, bytes.Length - bytesLeft, bytesLeft), CompressionMode.Decompress))
-                            text = new StreamReader(inflaterStream).ReadToEnd();
+                            using (MemoryStream decompstream = new MemoryStream())
+                        {
+#if !NET35
+                            inflaterStream.CopyTo(decompstream);
+#else
+                            byte[] buffer = new byte[256];
+                            int count;
+                            int totalBytes = 0;
+                            while ((count = inflaterStream.Read(buffer, 0, 256)) > 0)
+                            {
+                                decompstream.Write(buffer, 0, count);
+                                totalBytes += count;
+                            }
+#endif
+                            text = new StringValue(decompstream.ToArray());
+                            text.SetEncodingByName(defaultEncodingName);
+                        }
                     }
                     else
                     {
@@ -255,7 +286,7 @@ namespace MetadataExtractor.Formats.Png
                     if (keyword == "XML:com.adobe.xmp")
                     {
                         // NOTE in testing images, the XMP has parsed successfully, but we are not extracting tags from it as necessary
-                        yield return new XmpReader().Extract(text);
+                        yield return new XmpReader().Extract(text.Bytes);
                     }
                     else
                     {

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -64,7 +64,7 @@ namespace MetadataExtractor.Formats.Tiff
         public void Error(string message) => CurrentDirectory.AddError(message);
 
         public void SetByteArray(int tagId, byte[] bytes)         => CurrentDirectory.Set(tagId, bytes);
-        public void SetString(int tagId, string str)              => CurrentDirectory.Set(tagId, str);
+        public void SetString(int tagId, StringValue strval)      => CurrentDirectory.Set(tagId, strval);
         public void SetRational(int tagId, Rational rational)     => CurrentDirectory.Set(tagId, rational);
         public void SetRationalArray(int tagId, Rational[] array) => CurrentDirectory.Set(tagId, array);
         public void SetFloat(int tagId, float float32)            => CurrentDirectory.Set(tagId, float32);

--- a/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
@@ -63,7 +63,7 @@ namespace MetadataExtractor.Formats.Tiff
 
         void SetByteArray(int tagId, [NotNull] byte[] bytes);
 
-        void SetString(int tagId, [NotNull] string str);
+        void SetString(int tagId, [NotNull] StringValue str);
 
         void SetRational(int tagId, [NotNull] Rational rational);
 

--- a/MetadataExtractor/Formats/Tiff/TiffReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffReader.cs
@@ -265,7 +265,7 @@ namespace MetadataExtractor.Formats.Tiff
                 }
                 case TiffDataFormatCode.String:
                 {
-                    handler.SetString(tagId, reader.GetNullTerminatedString(tagValueOffset, componentCount));
+                    handler.SetString(tagId, reader.GetNullTerminatedStringValue(tagValueOffset, componentCount));
                     break;
                 }
                 case TiffDataFormatCode.RationalS:

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -130,7 +130,7 @@ namespace MetadataExtractor.Formats.Xmp
         /// <remarks>
         /// The extraction is done with Adobe's XMPCore library.
         /// </remarks>
-        public XmpDirectory Extract([NotNull] string xmpString) => Extract(Encoding.UTF8.GetBytes(xmpString));
+        //public XmpDirectory Extract([NotNull] string xmpString) => Extract(Encoding.UTF8.GetBytes(xmpString));
 
         /// <exception cref="XmpException"/>
         private static void ProcessXmpTags(XmpDirectory directory, IXmpMeta xmpMeta)

--- a/MetadataExtractor/IO/IndexedReader.cs
+++ b/MetadataExtractor/IO/IndexedReader.cs
@@ -318,10 +318,26 @@ namespace MetadataExtractor.IO
         /// The maximum number of bytes to read.  If a zero-byte is not reached within this limit,
         /// reading will stop and the string will be truncated to this length.
         /// </param>
-        /// <returns>The read string.</returns>
+        /// <returns>The read <see cref="string"/></returns>
         /// <exception cref="System.IO.IOException">The buffer does not contain enough bytes to satisfy this request.</exception>
         [NotNull]
         public string GetNullTerminatedString(int index, int maxLengthBytes)
+        {
+            return GetNullTerminatedStringValue(index, maxLengthBytes).ToString();
+        }
+
+        /// <summary>
+        /// Creates a string starting at the specified index, and ending where either <c>byte=='\0'</c> or
+        /// <c>length==maxLength</c>.
+        /// </summary>
+        /// <param name="index">The index within the buffer at which to start reading the string.</param>
+        /// <param name="maxLengthBytes">
+        /// The maximum number of bytes to read.  If a zero-byte is not reached within this limit,
+        /// reading will stop and the string will be truncated to this length.
+        /// </param>
+        /// <returns>The read <see cref="StringValue"/></returns>
+        /// <exception cref="System.IO.IOException">The buffer does not contain enough bytes to satisfy this request.</exception>
+        public StringValue GetNullTerminatedStringValue(int index, int maxLengthBytes)
         {
             // NOTE currently only really suited to single-byte character strings
             var bytes = GetBytes(index, maxLengthBytes);
@@ -329,7 +345,12 @@ namespace MetadataExtractor.IO
             var length = 0;
             while (length < bytes.Length && bytes[length] != 0)
                 length++;
-            return Encoding.UTF8.GetString(bytes, 0, length);
+
+            var _actualBytes = new byte[length];
+            if (length > 0)
+                Array.Copy(bytes, 0, _actualBytes, 0, length);
+
+            return new StringValue(_actualBytes);
         }
     }
 }

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -246,10 +246,22 @@ namespace MetadataExtractor.IO
         /// The maximum number of bytes to read.  If a zero-byte is not reached within this limit,
         /// reading will stop and the string will be truncated to this length.
         /// </param>
-        /// <returns>The read string.</returns>
+        /// <returns>The read <see cref="string"/></returns>
         /// <exception cref="System.IO.IOException">The buffer does not contain enough bytes to satisfy this request.</exception>
         [NotNull]
         public string GetNullTerminatedString(int maxLengthBytes)
+        {
+            return GetNullTerminatedStringValue(maxLengthBytes).ToString();
+        }
+
+        /// <summary>Creates a String from the stream, ending where <c>byte=='\0'</c> or where <c>length==maxLength</c>.</summary>
+        /// <param name="maxLengthBytes">
+        /// The maximum number of bytes to read.  If a zero-byte is not reached within this limit,
+        /// reading will stop and the string will be truncated to this length.
+        /// </param>
+        /// <returns>The read string as a <see cref="StringValue"/></returns>
+        /// <exception cref="System.IO.IOException">The buffer does not contain enough bytes to satisfy this request.</exception>
+        public StringValue GetNullTerminatedStringValue(int maxLengthBytes)
         {
             // NOTE currently only really suited to single-byte character strings
             var bytes = new byte[maxLengthBytes];
@@ -257,7 +269,13 @@ namespace MetadataExtractor.IO
             var length = 0;
             while (length < bytes.Length && (bytes[length] = GetByte()) != 0)
                 length++;
-            return Encoding.UTF8.GetString(bytes, 0, length);
+            if (length != maxLengthBytes)
+            {
+                var bytesCopy = new byte[length];
+                Array.Copy(bytes, bytesCopy, length);
+                bytes = bytesCopy;
+            }
+            return new StringValue(bytes);
         }
     }
 }

--- a/MetadataExtractor/KeyValuePair.cs
+++ b/MetadataExtractor/KeyValuePair.cs
@@ -32,7 +32,7 @@ namespace MetadataExtractor
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class KeyValuePair
     {
-        public KeyValuePair([NotNull] string key, [NotNull] string value)
+        public KeyValuePair([NotNull] string key, [NotNull] StringValue value)
         {
             Key = key;
             Value = value;
@@ -42,6 +42,6 @@ namespace MetadataExtractor
         public string Key { get; }
 
         [NotNull]
-        public string Value { get; }
+        public StringValue Value { get; }
     }
 }

--- a/MetadataExtractor/MetadataExtractor.Portable.csproj
+++ b/MetadataExtractor/MetadataExtractor.Portable.csproj
@@ -196,6 +196,7 @@
     <Compile Include="MetadataException.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Rational.cs" />
+    <Compile Include="StringValue.cs" />
     <Compile Include="Tag.cs" />
     <Compile Include="TagDescriptor.cs" />
     <Compile Include="Util\ByteConvert.cs" />

--- a/MetadataExtractor/MetadataExtractor.net35.csproj
+++ b/MetadataExtractor/MetadataExtractor.net35.csproj
@@ -73,6 +73,7 @@
     <Compile Include="Formats\QuickTime\QuickTimeTrackHeaderDirectory.cs" />
     <Compile Include="Formats\Raf\RafMetadataReader.cs" />
     <Compile Include="Formats\Xmp\Schema.cs" />
+    <Compile Include="StringValue.cs" />
     <Compile Include="Util\ByteConvert.cs" />
     <Compile Include="Util\DateUtil.cs" />
     <Compile Include="Util\FileType.cs" />

--- a/MetadataExtractor/MetadataExtractor.net45.csproj
+++ b/MetadataExtractor/MetadataExtractor.net45.csproj
@@ -72,6 +72,7 @@
     <Compile Include="Formats\QuickTime\QuickTimeTrackHeaderDirectory.cs" />
     <Compile Include="Formats\Raf\RafMetadataReader.cs" />
     <Compile Include="Formats\Xmp\Schema.cs" />
+    <Compile Include="StringValue.cs" />
     <Compile Include="Util\ByteConvert.cs" />
     <Compile Include="Util\DateUtil.cs" />
     <Compile Include="Util\FileType.cs" />

--- a/MetadataExtractor/StringValue.cs
+++ b/MetadataExtractor/StringValue.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Text;
+
+using JetBrains.Annotations;
+
+namespace MetadataExtractor
+{
+    public sealed class StringValue : IConvertible
+    {
+        private readonly byte[] _buffer;
+        private Encoding _encoder = Encoding.UTF8;
+
+        public StringValue([NotNull] byte[] bytes)
+        {
+            _buffer = bytes;
+        }
+
+        public StringValue([NotNull] byte[] bytes, Encoding defaultEncoder)
+        {
+            _buffer = bytes;
+            _encoder = defaultEncoder;
+        }
+
+        public byte[] Bytes
+        {
+            get { return _buffer; }
+        }
+
+        public void SetEncodingByName(string encodingName)
+        {
+            _encoder = Encoding.GetEncoding(encodingName);
+        }
+
+        public Encoding Encoder
+        {
+            get { return _encoder; }
+            set { _encoder = value; }
+        }
+
+        public int Length
+        {
+            get { return (_buffer != null) ? _buffer.Length : 0; }
+        }
+
+        #region Conversion methods
+
+        public double ToDouble()
+        {
+            double output;
+            if (!double.TryParse(ToString(), out output))
+                throw new FormatException();
+
+            return output;
+        }
+
+        public float ToSingle()
+        {
+            return (float)ToDouble();
+        }
+
+        public string ToString(IFormatProvider provider) => ToString();
+
+        #region IConvertible
+        double IConvertible.ToDouble(IFormatProvider provider) => ToDouble();
+
+        decimal IConvertible.ToDecimal(IFormatProvider prodiver) => (decimal)ToDouble();
+
+        float IConvertible.ToSingle(IFormatProvider provider) => ToSingle();
+
+        TypeCode IConvertible.GetTypeCode() => TypeCode.Object;
+
+        bool IConvertible.ToBoolean(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        byte IConvertible.ToByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        char IConvertible.ToChar(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        DateTime IConvertible.ToDateTime(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        short IConvertible.ToInt16(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        long IConvertible.ToInt64(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        sbyte IConvertible.ToSByte(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        ushort IConvertible.ToUInt16(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        uint IConvertible.ToUInt32(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        ulong IConvertible.ToUInt64(IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        object IConvertible.ToType(Type conversionType, IFormatProvider provider)
+        {
+            throw new NotImplementedException();
+        }
+
+        #endregion
+
+        #endregion
+
+        #region Formatting
+
+        public override string ToString()
+        {
+            return ToString(_encoder);
+        }
+        public string ToString(Encoding encoder)
+        {
+            return encoder.GetString(_buffer, 0, Length);
+        }
+
+        #endregion
+
+        // user-defined conversion from StringValue to Double
+        /*public static implicit operator double(StringValue strval)
+        {
+            double value;
+            if (double.TryParse(strval.ToString(), out value))
+                return value;
+
+            throw new MetadataException($"Tag cannot be converted to {typeof(double).Name}.");
+        }*/
+
+        // user-defined conversion from StringValue to string
+        /*public static implicit operator string(StringValue strval)
+        {
+            return strval.ToString();
+        }*/
+
+        // user-defined conversion from string to StringValue
+        /*public static implicit operator StringValue(string str)
+        {
+            return new StringValue(Encoding.UTF8.GetBytes(str));
+        }*/
+
+    }
+}


### PR DESCRIPTION
Replaces part of Issue #31, and some discussion is there. This puts it in another branch for now.

This is a work-in-progress to keep byte arrays available for user-defined encoding, like Issue #19. As a bonus, XMP Extract uses the original byte array directly instead of encoding the whole thing first.