### PR TITLE
Handle IFD0 ApplicationNotes tag (0x02BC)  as XMP

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
@@ -186,6 +186,10 @@ namespace MetadataExtractor.Formats.Exif
 
         public const int TagReferenceBlackWhite = 0x0214;
 
+        public const int TagStripRowCounts = 0x022F;
+
+        public const int TagApplicationNotes = 0x02BC;
+
         public const int TagRelatedImageFileFormat = 0x1000;
 
         public const int TagRelatedImageWidth = 0x1001;
@@ -753,6 +757,8 @@ namespace MetadataExtractor.Formats.Exif
             map[TagYCbCrSubsampling] = "YCbCr Sub-Sampling";
             map[TagYCbCrPositioning] = "YCbCr Positioning";
             map[TagReferenceBlackWhite] = "Reference Black/White";
+            map[TagStripRowCounts] = "Strip Row Counts";
+            map[TagApplicationNotes] = "Application Notes";
             map[TagRelatedImageFileFormat] = "Related Image File Format";
             map[TagRelatedImageWidth] = "Related Image Width";
             map[TagRelatedImageHeight] = "Related Image Height";

--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -30,6 +30,7 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.Exif.Makernotes;
 using MetadataExtractor.Formats.Iptc;
 using MetadataExtractor.Formats.Tiff;
+using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.IO;
 
 namespace MetadataExtractor.Formats.Exif
@@ -123,6 +124,14 @@ namespace MetadataExtractor.Formats.Exif
                 }
                 return false;
             }
+
+            // Custom processing for embedded XMP data
+            if (tagId == ExifDirectoryBase.TagApplicationNotes && CurrentDirectory is ExifIfd0Directory)
+            {
+                Directories.Add(new XmpReader().Extract(reader.GetNullTerminatedString(tagOffset, byteCount)));
+                return true;
+            }
+
             return false;
         }
 


### PR DESCRIPTION
In .NET, addresses the other half of drewnoakes/metadata-extractor#151

IFD0 was missing the ApplicationNotes tag (0x02BC) which can apparently hold XMP data. This assumes it is always XMP in there, but I can't 100% confirm this.