### PR TITLE
support reading up to two subifd's for tag 0x14a

### DIFF
--- a/MetadataExtractor/Formats/Exif/SubIFD1Descriptor.cs
+++ b/MetadataExtractor/Formats/Exif/SubIFD1Descriptor.cs
@@ -1,0 +1,40 @@
+#region License
+//
+// Copyright 2002-2015 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using JetBrains.Annotations;
+
+namespace MetadataExtractor.Formats.Exif
+{
+    /// <summary>
+    /// Provides human-readable string representations of tag values stored in a <see cref="SubIfd1Directory"/>.
+    /// </summary>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public class SubIfd1Descriptor : ExifDescriptorBase<SubIfd1Directory>
+    {
+        public SubIfd1Descriptor([NotNull] SubIfd1Directory directory)
+            : base(directory)
+        {
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/SubIFD1Directory.cs
+++ b/MetadataExtractor/Formats/Exif/SubIFD1Directory.cs
@@ -1,0 +1,52 @@
+#region License
+//
+// Copyright 2002-2015 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+
+namespace MetadataExtractor.Formats.Exif
+{
+    /// <summary>Describes Exif tags from the SubIFD1 directory.</summary>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public class SubIfd1Directory : ExifDirectoryBase
+    {
+        public SubIfd1Directory()
+        {
+            SetDescriptor(new SubIfd1Descriptor(this));
+        }
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>();
+
+        static SubIfd1Directory()
+        {
+            AddExifTagNames(_tagNameMap);
+        }
+
+        public override string Name => "SubIFD1";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/SubIFD2Descriptor.cs
+++ b/MetadataExtractor/Formats/Exif/SubIFD2Descriptor.cs
@@ -1,0 +1,40 @@
+#region License
+//
+// Copyright 2002-2015 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using JetBrains.Annotations;
+
+namespace MetadataExtractor.Formats.Exif
+{
+    /// <summary>
+    /// Provides human-readable string representations of tag values stored in a <see cref="SubIfd2Directory"/>.
+    /// </summary>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public class SubIfd2Descriptor : ExifDescriptorBase<SubIfd2Directory>
+    {
+        public SubIfd2Descriptor([NotNull] SubIfd2Directory directory)
+            : base(directory)
+        {
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/SubIFD2Directory.cs
+++ b/MetadataExtractor/Formats/Exif/SubIFD2Directory.cs
@@ -1,0 +1,52 @@
+#region License
+//
+// Copyright 2002-2015 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+
+namespace MetadataExtractor.Formats.Exif
+{
+    /// <summary>Describes Exif tags from the SubIFD2 directory.</summary>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public class SubIfd2Directory : ExifDirectoryBase
+    {
+        public SubIfd2Directory()
+        {
+            SetDescriptor(new SubIfd2Descriptor(this));
+        }
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>();
+
+        static SubIfd2Directory()
+        {
+            AddExifTagNames(_tagNameMap);
+        }
+
+        public override string Name => "SubIFD2";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/MetadataExtractor.Portable.csproj
+++ b/MetadataExtractor/MetadataExtractor.Portable.csproj
@@ -98,6 +98,10 @@
     <Compile Include="Formats\Exif\makernotes\SonyType1MakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\makernotes\SonyType6MakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\makernotes\SonyType6MakernoteDirectory.cs" />
+    <Compile Include="Formats\Exif\SubIFD1Descriptor.cs" />
+    <Compile Include="Formats\Exif\SubIFD1Directory.cs" />
+    <Compile Include="Formats\Exif\SubIFD2Descriptor.cs" />
+    <Compile Include="Formats\Exif\SubIFD2Directory.cs" />
     <Compile Include="Formats\Gif\GifHeaderDescriptor.cs" />
     <Compile Include="Formats\Gif\GifHeaderDirectory.cs" />
     <Compile Include="Formats\Gif\GifMetadataReader.cs" />

--- a/MetadataExtractor/MetadataExtractor.net35.csproj
+++ b/MetadataExtractor/MetadataExtractor.net35.csproj
@@ -54,6 +54,10 @@
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DirectoryExtensions.cs" />
+    <Compile Include="Formats\Exif\SubIFD1Descriptor.cs" />
+    <Compile Include="Formats\Exif\SubIFD1Directory.cs" />
+    <Compile Include="Formats\Exif\SubIFD2Descriptor.cs" />
+    <Compile Include="Formats\Exif\SubIFD2Directory.cs" />
     <Compile Include="Formats\Jfxx\JfxxDescriptor.cs" />
     <Compile Include="Formats\Jfxx\JfxxDirectory.cs" />
     <Compile Include="Formats\Jfxx\JfxxReader.cs" />

--- a/MetadataExtractor/MetadataExtractor.net45.csproj
+++ b/MetadataExtractor/MetadataExtractor.net45.csproj
@@ -53,6 +53,10 @@
       <Link>SharedAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="DirectoryExtensions.cs" />
+    <Compile Include="Formats\Exif\SubIFD2Descriptor.cs" />
+    <Compile Include="Formats\Exif\SubIFD1Descriptor.cs" />
+    <Compile Include="Formats\Exif\SubIFD2Directory.cs" />
+    <Compile Include="Formats\Exif\SubIFD1Directory.cs" />
     <Compile Include="Formats\Jfxx\JfxxDescriptor.cs" />
     <Compile Include="Formats\Jfxx\JfxxDirectory.cs" />
     <Compile Include="Formats\Jfxx\JfxxReader.cs" />


### PR DESCRIPTION
One way to fix drewnoakes/metadata-extractor#103 reported on the Java version.

NEF puts one or more (usually one or two) subifd's in tag 0x014a as either an IFD or one or more longs. This push supports reading them as longs, and only the first two. I don't consider this a complete solution, but it gets it started and will only run when that tag exists.

Two new Directory classes were added to support this. Review that decision, although class explosion is a well known issue for subifd's anyway.