### PR TITLE
Parse with DateTimeOffset instead of DateTime

### DIFF
--- a/MetadataExtractor.Tests/DirectoryTest.cs
+++ b/MetadataExtractor.Tests/DirectoryTest.cs
@@ -114,27 +114,25 @@ namespace MetadataExtractor.Tests
         [Fact]
         public void TestSetStringAndGetDate()
         {
-            Action<string, DateTime> test = (str, expected) =>
+            Action<string, DateTimeOffset> test = (str, expected) =>
             {
                 _directory.Set(1, str);
-                Assert.Equal(expected, _directory.GetDateTime(1));
+                Assert.Equal(expected, _directory.GetDateTimeOffset(1));
             };
 
-            // TODO revisit these commented cases and introduce GetDateTimeOffset impl/test
-
-            test("2002:01:30 23:59:59",           new DateTime(2002, 1, 30, 23, 59, 59,     DateTimeKind.Unspecified));
-            test("2002:01:30 23:59",              new DateTime(2002, 1, 30, 23, 59,  0,     DateTimeKind.Unspecified));
-            test("2002-01-30 23:59:59",           new DateTime(2002, 1, 30, 23, 59, 59,     DateTimeKind.Unspecified));
-            test("2002-01-30 23:59",              new DateTime(2002, 1, 30, 23, 59,  0,     DateTimeKind.Unspecified));
-//          test("2002-01-30T23:59:59.099-08:00", new DateTime(2002, 1, 30, 23, 59, 59, 99, DateTimeKind.Unspecified));
-            test("2002-01-30T23:59:59.099",       new DateTime(2002, 1, 30, 23, 59, 59, 99, DateTimeKind.Unspecified));
-//          test("2002-01-30T23:59:59-08:00",     new DateTime(2002, 1, 30, 23, 59, 59,     DateTimeKind.Unspecified));
-            test("2002-01-30T23:59:59",           new DateTime(2002, 1, 30, 23, 59, 59,     DateTimeKind.Unspecified));
-//          test("2002-01-30T23:59-08:00",        new DateTime(2002, 1, 30, 23, 59,  0,     DateTimeKind.Unspecified));
-            test("2002-01-30T23:59",              new DateTime(2002, 1, 30, 23, 59,  0,     DateTimeKind.Unspecified));
-            test("2002-01-30",                    new DateTime(2002, 1, 30,  0,  0,  0,     DateTimeKind.Unspecified));
-            test("2002-01",                       new DateTime(2002, 1,  1,  0,  0,  0,     DateTimeKind.Unspecified));
-            test("2002",                          new DateTime(2002, 1,  1,  0,  0,  0,     DateTimeKind.Unspecified));
+            test("2002:01:30 23:59:59",           new DateTimeOffset(2002, 1, 30, 23, 59, 59,     new TimeSpan(0)));
+            test("2002:01:30 23:59",              new DateTimeOffset(2002, 1, 30, 23, 59,  0,     new TimeSpan(0)));
+            test("2002-01-30 23:59:59",           new DateTimeOffset(2002, 1, 30, 23, 59, 59,     new TimeSpan(0)));
+            test("2002-01-30 23:59",              new DateTimeOffset(2002, 1, 30, 23, 59,  0,     new TimeSpan(0)));
+            test("2002-01-30T23:59:59.099-08:00", new DateTimeOffset(2002, 1, 30, 23, 59, 59, 99, new TimeSpan(-8, 0, 0)));
+            test("2002-01-30T23:59:59.099",       new DateTimeOffset(2002, 1, 30, 23, 59, 59, 99, new TimeSpan(0)));
+            test("2002-01-30T23:59:59-08:00",     new DateTimeOffset(2002, 1, 30, 23, 59, 59,     new TimeSpan(-8, 0, 0)));
+            test("2002-01-30T23:59:59",           new DateTimeOffset(2002, 1, 30, 23, 59, 59,     new TimeSpan(0)));
+            test("2002-01-30T23:59-08:00",        new DateTimeOffset(2002, 1, 30, 23, 59,  0,     new TimeSpan(-8, 0, 0)));
+            test("2002-01-30T23:59",              new DateTimeOffset(2002, 1, 30, 23, 59,  0,     new TimeSpan(0)));
+            test("2002-01-30",                    new DateTimeOffset(2002, 1, 30,  0,  0,  0,     new TimeSpan(0)));
+            test("2002-01",                       new DateTimeOffset(2002, 1,  1,  0,  0,  0,     new TimeSpan(0)));
+            test("2002",                          new DateTimeOffset(2002, 1,  1,  0,  0,  0,     new TimeSpan(0)));
         }
 
 
@@ -182,8 +180,8 @@ namespace MetadataExtractor.Tests
 
             bool b;
             Assert.False(_directory.TryGetBoolean(ExifDirectoryBase.TagAperture, out b));
-            DateTime dt;
-            Assert.False(_directory.TryGetDateTime(ExifDirectoryBase.TagAperture, out dt));
+            DateTimeOffset dt;
+            Assert.False(_directory.TryGetDateTimeOffset(ExifDirectoryBase.TagAperture, out dt));
             double d;
             Assert.False(_directory.TryGetDouble(ExifDirectoryBase.TagAperture, out d));
             int i;

--- a/MetadataExtractor.Tests/Formats/Exif/ExifDirectoryTest.cs
+++ b/MetadataExtractor.Tests/Formats/Exif/ExifDirectoryTest.cs
@@ -127,10 +127,9 @@ namespace MetadataExtractor.Tests.Formats.Exif
             var gpsDirectory = ExifReaderTest.ProcessSegmentBytes<GpsDirectory>("Tests/Data/withPanasonicFaces.jpg.app1");
             Assert.Equal("2010:06:24", gpsDirectory.GetString(GpsDirectory.TagDateStamp));
             Assert.Equal("10/1 17/1 21/1", gpsDirectory.GetString(GpsDirectory.TagTimeStamp));
-            DateTime gpsDate;
+            DateTimeOffset gpsDate;
             Assert.True(gpsDirectory.TryGetGpsDate(out gpsDate));
-            Assert.Equal(DateTimeKind.Utc, gpsDate.Kind);
-            Assert.Equal(new DateTime(2010, 6, 24, 10, 17, 21), gpsDate);
+            Assert.Equal(new DateTimeOffset(2010, 6, 24, 10, 17, 21, new TimeSpan(0)), gpsDate);
         }
     }
 }

--- a/MetadataExtractor.Tests/Formats/Icc/IccReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Icc/IccReaderTest.cs
@@ -75,7 +75,7 @@ namespace MetadataExtractor.Tests.Formats.Icc
 
             Assert.NotNull(directory);
 //            Assert.Equal("1998:02:09 06:49:00", directory.GetString(IccDirectory.TagProfileDateTime));
-            Assert.Equal(new DateTime(1998, 2, 9, 6, 49, 0), directory.GetDateTime(IccDirectory.TagProfileDateTime));
+            Assert.Equal(new DateTimeOffset(1998, 2, 9, 6, 49, 0, new TimeSpan(0)), directory.GetDateTimeOffset(IccDirectory.TagProfileDateTime));
         }
     }
 }

--- a/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
@@ -68,8 +68,8 @@ namespace MetadataExtractor.Tests.Formats.Png
             Assert.Equal(2835, directories[3].GetInt32(PngDirectory.TagPixelsPerUnitY));
             Assert.Equal(PngChunkType.tIME, directories[4].GetPngChunkType());
             //Sharpen.Tests.AreEqual("Tue Jan 01 04:08:30 GMT 2013", Sharpen.Extensions.ConvertToString(dirs[4].GetDateTimeNullable(PngDirectory.TagLastModificationTime)));
-            var testString = CreateTestString(2013, 01, 01, 04, 08, 30);
-            Assert.Equal(testString, directories[4].GetDateTime(PngDirectory.TagLastModificationTime).ToString("ddd MMM dd HH:mm:ss zzz yyyy"));
+            var testString = CreateTestString(2013, 01, 01, 04, 08, 30, new TimeSpan(0));
+            Assert.Equal(testString, directories[4].GetDateTimeOffset(PngDirectory.TagLastModificationTime).ToString("ddd MMM dd HH:mm:ss zzz yyyy"));
             Assert.Equal("Tue Jan 01 04:08:30 2013", directories[4].GetString(PngDirectory.TagLastModificationTime));
             Assert.Equal(PngChunkType.iTXt, directories[5].GetPngChunkType());
             var pairs = (IList<KeyValuePair>)directories[5].GetObject(PngDirectory.TagTextualData);
@@ -79,9 +79,9 @@ namespace MetadataExtractor.Tests.Formats.Png
             Assert.Equal("Created with GIMP", pairs[0].Value);
         }
 
-        private static string CreateTestString(int year, int month, int day, int hourOfDay, int minute, int second)
+        private static string CreateTestString(int year, int month, int day, int hourOfDay, int minute, int second, TimeSpan offset)
         {
-            return new DateTime(year, month, day, hourOfDay, minute, second)
+            return new DateTimeOffset(year, month, day, hourOfDay, minute, second, offset)
                 .ToString("ddd MMM dd HH:mm:ss zzz yyyy");
         }
     }

--- a/MetadataExtractor.Tests/Formats/Xmp/XmpReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Xmp/XmpReaderTest.cs
@@ -167,22 +167,22 @@ namespace MetadataExtractor.Tests.Formats.Xmp
             Assert.Equal(new Rational(6965784, 1000000), _directory.GetRational(XmpDirectory.TagShutterSpeed));
         }
 
-        [Fact(Skip = "TODO fix XMP support for DateTime with offset")]
+        [Fact]
         public void TestExtract_OriginalDateTime()
         {
-            var actual = _directory.GetDateTime(XmpDirectory.TagDateTimeOriginal);
+            var actual = _directory.GetDateTimeOffset(XmpDirectory.TagDateTimeOriginal);
             // Underlying string value (in XMP data) is: 2010-12-12T12:41:35.00+01:00
-            Assert.Equal(DateTime.ParseExact("11:41:35 12 12 2010 +0000", "hh:mm:ss dd MM yyyy zzz", null), actual);
-            Assert.Equal(new DateTime(2010, 12, 12, 11, 41, 35), actual);
+            Assert.Equal(DateTimeOffset.ParseExact("11:41:35 12 12 2010 +0000", "hh:mm:ss dd MM yyyy zzz", null), actual);
+            Assert.Equal(new DateTimeOffset(2010, 12, 12, 11, 41, 35, new TimeSpan(0)), actual);
         }
 
-        [Fact(Skip = "TODO fix XMP support for DateTime with offset")]
+        [Fact]
         public void TestExtract_DigitizedDateTime()
         {
-            var actual = _directory.GetDateTime(XmpDirectory.TagDateTimeDigitized);
+            var actual = _directory.GetDateTimeOffset(XmpDirectory.TagDateTimeDigitized);
             // Underlying string value (in XMP data) is: 2010-12-12T12:41:35.00+01:00
-            Assert.Equal(DateTime.ParseExact("11:41:35 12 12 2010 +0000", "hh:mm:ss dd MM yyyy zzz", null), actual);
-            Assert.Equal(new DateTime(2010, 12, 12, 11, 41, 35), actual);
+            Assert.Equal(DateTimeOffset.ParseExact("11:41:35 12 12 2010 +0000", "hh:mm:ss dd MM yyyy zzz", null), actual);
+            Assert.Equal(new DateTimeOffset(2010, 12, 12, 11, 41, 35, new TimeSpan(0)), actual);
         }
 
         [Fact]

--- a/MetadataExtractor.Tools.FileProcessor/Program.cs
+++ b/MetadataExtractor.Tools.FileProcessor/Program.cs
@@ -72,6 +72,8 @@ namespace MetadataExtractor.Tools.FileProcessor
             var markdownFormat = args.Remove("--markdown");
             var showHex = args.Remove("--hex");
 
+            Console.Out.NewLine = "\r";
+
             if (args.Count < 1)
             {
                 Console.Out.WriteLine("MetadataExtractor {0}", Assembly.GetExecutingAssembly().GetName().Version);

--- a/MetadataExtractor/Formats/Exif/GpsDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/GpsDirectory.cs
@@ -211,11 +211,11 @@ namespace MetadataExtractor.Formats.Exif
 
         /// <summary>
         /// Parses values for <see cref="TagDateStamp"/> and <see cref="TagTimeStamp"/> to produce a single
-        /// <see cref="DateTime"/> value representing when this image was captured according to the GPS unit.
+        /// <see cref="DateTimeOffset"/> value representing when this image was captured according to the GPS unit.
         /// </summary>
-        public bool TryGetGpsDate(out DateTime date)
+        public bool TryGetGpsDate(out DateTimeOffset date)
         {
-            if (!this.TryGetDateTime(TagDateStamp, out date))
+            if (!this.TryGetDateTimeOffset(TagDateStamp, out date))
                 return false;
 
             var timeComponents = this.GetRationalArray(TagTimeStamp);
@@ -227,8 +227,6 @@ namespace MetadataExtractor.Formats.Exif
                 .AddHours(timeComponents[0].ToDouble())
                 .AddMinutes(timeComponents[1].ToDouble())
                 .AddSeconds(timeComponents[2].ToDouble());
-
-            date = DateTime.SpecifyKind(date, DateTimeKind.Utc);
 
             return true;
         }

--- a/MetadataExtractor/Formats/Icc/IccDescriptor.cs
+++ b/MetadataExtractor/Formats/Icc/IccDescriptor.cs
@@ -368,8 +368,8 @@ namespace MetadataExtractor.Formats.Icc
         [CanBeNull]
         private string GetProfileDateTimeDescription()
         {
-            DateTime value;
-            if (!Directory.TryGetDateTime(IccDirectory.TagProfileDateTime, out value))
+            DateTimeOffset value;
+            if (!Directory.TryGetDateTimeOffset(IccDirectory.TagProfileDateTime, out value))
                 return null;
 
             return value.ToString("yyyy:MM:dd HH:mm:ss");

--- a/MetadataExtractor/Formats/Icc/IccReader.cs
+++ b/MetadataExtractor/Formats/Icc/IccReader.cs
@@ -184,7 +184,7 @@ namespace MetadataExtractor.Formats.Icc
 
             if (DateUtil.IsValidDate(year, month, day) &&
                 DateUtil.IsValidTime(hours, minutes, seconds))
-                directory.Set(tagType, new DateTime(year, month, day, hours, minutes, seconds, kind: DateTimeKind.Utc));
+                directory.Set(tagType, new DateTimeOffset(year, month, day, hours, minutes, seconds, new TimeSpan(0)));
             else
                 directory.AddError($"ICC data describes an invalid date/time: year={year} month={month} day={day} hour={hours} minute={minutes} second={seconds}");
         }

--- a/MetadataExtractor/Formats/Png/PngDescriptor.cs
+++ b/MetadataExtractor/Formats/Png/PngDescriptor.cs
@@ -118,8 +118,8 @@ namespace MetadataExtractor.Formats.Png
         [CanBeNull]
         public string GetLastModificationTimeDescription()
         {
-            DateTime value;
-            if (!Directory.TryGetDateTime(PngDirectory.TagLastModificationTime, out value))
+            DateTimeOffset value;
+            if (!Directory.TryGetDateTimeOffset(PngDirectory.TagLastModificationTime, out value))
                 return null;
 
             return value.ToString("yyyy:MM:dd HH:mm:ss");

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -282,7 +282,7 @@ namespace MetadataExtractor.Formats.Png
                 var directory = new PngDirectory(PngChunkType.tIME);
                 try
                 {
-                    var time = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Unspecified);
+                    var time = new DateTimeOffset(year, month, day, hour, minute, second, new TimeSpan(0));
                     directory.Set(PngDirectory.TagLastModificationTime, time);
                 }
                 catch (ArgumentOutOfRangeException e)

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -30,7 +30,7 @@ namespace MetadataExtractor.Formats.QuickTime
 {
     public static class QuicktimeMetadataReader
     {
-        private static readonly DateTime _epoch = new DateTime(1904, 1, 1);
+        private static readonly DateTimeOffset _epoch = new DateTimeOffset(1904, 1, 1, 0, 0, 0, new TimeSpan(0));
 
         public static
 #if NET35 || PORTABLE

--- a/MetadataExtractor/Util/DateUtil.cs
+++ b/MetadataExtractor/Util/DateUtil.cs
@@ -44,8 +44,8 @@ namespace MetadataExtractor.Util
                minutes >= 0 && minutes < 60 &&
                seconds >= 0 && seconds < 60;
 
-        private static readonly DateTime _unixEpoch = new DateTime(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTimeOffset _unixEpoch = new DateTimeOffset(1970, 1, 1, 0, 0, 0, new TimeSpan(0));
 
-        public static DateTime FromUnixTime(long unixTime) => _unixEpoch.AddSeconds(unixTime);
+        public static DateTimeOffset FromUnixTime(long unixTime) => _unixEpoch.AddSeconds(unixTime);
     }
 }


### PR DESCRIPTION
Date/Time parsing switched to DateTimeOffset. XMP date fields have always been returned as strings so no changes were necessary to the XMP project (that will come later). If you wanted to return these fields directly as some form of date object, that's a different issue.

The two XMP tests were reinstated to satisfy #30. Two new parsing formats were added to DirectoryExtensions to make those tests work. For now, it has to be that way because the XMP fields are still strings.
