### PR TITLE
Olympusrawdev2

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -111,6 +111,11 @@ namespace MetadataExtractor.Formats.Exif
                     PushDirectory(typeof(OlympusRawDevelopmentMakernoteDirectory));
                     return true;
                 }
+                if (tagId == OlympusMakernoteDirectory.TagRawDevelopment2)
+                {
+                    PushDirectory(typeof(OlympusRawDevelopment2MakernoteDirectory));
+                    return true;
+                }
             }
 
             return false;

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.cs
@@ -1,0 +1,228 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System;
+using JetBrains.Annotations;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>
+    /// Provides human-readable string representations of tag values stored in a <see cref="OlympusRawDevelopment2MakernoteDirectory"/>.
+    /// </summary>
+    /// <remarks>
+    /// Some Description functions and the Filter type list converted from Exiftool version 10.10 created by Phil Harvey
+    /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+    /// lib\Image\ExifTool\Olympus.pm
+    /// </remarks>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class OlympusRawDevelopment2MakernoteDescriptor : TagDescriptor<OlympusRawDevelopment2MakernoteDirectory>
+    {
+        public OlympusRawDevelopment2MakernoteDescriptor([NotNull] OlympusRawDevelopment2MakernoteDirectory directory)
+            : base(directory)
+        {
+        }
+
+        public override string GetDescription(int tagType)
+        {
+            switch (tagType)
+            {
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevVersion:
+                    return GetRawDevVersionDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevExposureBiasValue:
+                    return GetRawDevExposureBiasValueDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevColorSpace:
+                    return GetRawDevColorSpaceDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevNoiseReduction:
+                    return GetRawDevNoiseReductionDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevEngine:
+                    return GetRawDevEngineDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevPictureMode:
+                    return GetRawDevPictureModeDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevPmBwFilter:
+                    return GetRawDevPmBwFilterDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevPmPictureTone:
+                    return GetRawDevPmPictureToneDescription();
+                case OlympusRawDevelopment2MakernoteDirectory.TagRawDevArtFilter:
+                    return GetRawDevArtFilterDescription();
+                default:
+                    return base.GetDescription(tagType);
+            }
+        }
+
+        [CanBeNull]
+        public string GetRawDevVersionDescription()
+        {
+            return GetVersionBytesDescription(OlympusRawDevelopment2MakernoteDirectory.TagRawDevVersion, 4);
+        }
+
+        [CanBeNull]
+        public string GetRawDevExposureBiasValueDescription()
+        {
+            return GetIndexedDescription(OlympusRawDevelopment2MakernoteDirectory.TagRawDevExposureBiasValue, 1,
+                "Color Temperature", "Gray Point");
+        }
+
+        [CanBeNull]
+        public string GetRawDevColorSpaceDescription()
+        {
+            return GetIndexedDescription(OlympusRawDevelopment2MakernoteDirectory.TagRawDevColorSpace,
+                "sRGB", "Adobe RGB", "Pro Photo RGB");
+        }
+
+        [CanBeNull]
+        public string GetRawDevNoiseReductionDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(OlympusRawDevelopment2MakernoteDirectory.TagRawDevNoiseReduction, out value))
+                return null;
+
+            if (value == 0)
+                return "(none)";
+
+            var sb = new StringBuilder();
+            var v = (ushort)value;
+
+            if ((v        & 1) != 0) sb.Append("Noise Reduction, ");
+            if (((v >> 1) & 1) != 0) sb.Append("Noise Filter, ");
+            if (((v >> 2) & 1) != 0) sb.Append("Noise Filter (ISO Boost), ");
+
+            return sb.ToString(0, sb.Length - 2);
+        }
+
+        [CanBeNull]
+        public string GetRawDevEngineDescription()
+        {
+            return GetIndexedDescription(OlympusRawDevelopment2MakernoteDirectory.TagRawDevEngine,
+                "High Speed", "High Function", "Advanced High Speed", "Advanced High Function");
+        }
+
+        [CanBeNull]
+        public string GetRawDevPictureModeDescription()
+        {
+            int value;
+            if (!Directory.TryGetInt32(OlympusRawDevelopment2MakernoteDirectory.TagRawDevPictureMode, out value))
+                return null;
+
+            switch (value)
+            {
+                case 1:
+                    return "Vivid";
+                case 2:
+                    return "Natural";
+                case 3:
+                    return "Muted";
+                case 256:
+                    return "Monotone";
+                case 512:
+                    return "Sepia";
+                default:
+                    return "Unknown (" + value + ")";
+            }
+        }
+
+        [CanBeNull]
+        public string GetRawDevPmBwFilterDescription()
+        {
+            return GetIndexedDescription(OlympusRawDevelopment2MakernoteDirectory.TagRawDevPmBwFilter, 1,
+                "Neutral", "Yellow", "Orange", "Red", "Green");
+        }
+
+        [CanBeNull]
+        public string GetRawDevPmPictureToneDescription()
+        {
+            return GetIndexedDescription(OlympusRawDevelopment2MakernoteDirectory.TagRawDevPmPictureTone, 1,
+                "Neutral", "Sepia", "Blue", "Purple", "Green");
+        }
+
+        [CanBeNull]
+        public string GetRawDevArtFilterDescription() => GetFilterDescription(OlympusRawDevelopment2MakernoteDirectory.TagRawDevArtFilter);
+
+        [CanBeNull]
+        private string GetFilterDescription(int tagId)
+        {
+            var values = Directory.GetObject(tagId) as short[];
+            if (values == null || values.Length == 0)
+                return null;
+
+            var sb = new StringBuilder();
+            for (var i = 0; i < values.Length; i++)
+            {
+                if (i == 0)
+                    sb.Append(_filters.ContainsKey(values[i]) ? _filters[values[i]] : "[unknown]");
+                else
+                    sb.Append(values[i]);
+                sb.Append("; ");
+            }
+
+            return sb.ToString(0, sb.Length - 2);
+        }
+
+        // RawDevArtFilter values
+        private static readonly Dictionary<int, string> _filters = new Dictionary<int, string>
+        {
+            { 0, "Off" },
+            { 1, "Soft Focus" },
+            { 2, "Pop Art" },
+            { 3, "Pale & Light Color" },
+            { 4, "Light Tone" },
+            { 5, "Pin Hole" },
+            { 6, "Grainy Film" },
+            { 9, "Diorama" },
+            { 10, "Cross Process" },
+            { 12, "Fish Eye" },
+            { 13, "Drawing" },
+            { 14, "Gentle Sepia" },
+            { 15, "Pale & Light Color II" },
+            { 16, "Pop Art II" },
+            { 17, "Pin Hole II" },
+            { 18, "Pin Hole III" },
+            { 19, "Grainy Film II" },
+            { 20, "Dramatic Tone" },
+            { 21, "Punk" },
+            { 22, "Soft Focus 2" },
+            { 23, "Sparkle" },
+            { 24, "Watercolor" },
+            { 25, "Key Line" },
+            { 26, "Key Line II" },
+            { 27, "Miniature" },
+            { 28, "Reflection" },
+            { 29, "Fragmented" },
+            { 31, "Cross Process II" },
+            { 32, "Dramatic Tone II" },
+            { 33, "Watercolor I" },
+            { 34, "Watercolor II" },
+            { 35, "Diorama II" },
+            { 36, "Vintage" },
+            { 37, "Vintage II" },
+            { 38, "Vintage III" },
+            { 39, "Partial Color" },
+            { 40, "Partial Color II" },
+            { 41, "Partial Color III" }
+        };
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.cs
@@ -1,0 +1,110 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>
+    /// The Olympus raw development 2 makernote is used by many manufacturers (Epson, Konica, Minolta and Agfa...), and as such contains some tags
+    /// that appear specific to those manufacturers.
+    /// </summary>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class OlympusRawDevelopment2MakernoteDirectory : Directory
+    {
+        public const int TagRawDevVersion = 0x0000;
+        public const int TagRawDevExposureBiasValue = 0x0100;
+        public const int TagRawDevWhiteBalance = 0x0101;
+        public const int TagRawDevWhiteBalanceValue = 0x0102;
+        public const int TagRawDevWbFineAdjustment = 0x0103;
+        public const int TagRawDevGrayPoint = 0x0104;
+        public const int TagRawDevContrastValue = 0x0105;
+        public const int TagRawDevSharpnessValue = 0x0106;
+        public const int TagRawDevSaturationEmphasis = 0x0107;
+        public const int TagRawDevMemoryColorEmphasis = 0x0108;
+        public const int TagRawDevColorSpace = 0x0109;
+        public const int TagRawDevNoiseReduction = 0x010a;
+        public const int TagRawDevEngine = 0x010b;
+        public const int TagRawDevPictureMode = 0x010c;
+        public const int TagRawDevPmSaturation = 0x010d;
+        public const int TagRawDevPmContrast = 0x010e;
+        public const int TagRawDevPmSharpness = 0x010f;
+        public const int TagRawDevPmBwFilter = 0x0110;
+        public const int TagRawDevPmPictureTone = 0x0111;
+        public const int TagRawDevGradation = 0x0112;
+        public const int TagRawDevSaturation3 = 0x0113;
+        public const int TagRawDevAutoGradation = 0x0119;
+        public const int TagRawDevPmNoiseFilter = 0x0120;
+        public const int TagRawDevArtFilter = 0x0121;
+
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        {
+            { TagRawDevVersion, "Raw Dev Version" },
+            { TagRawDevExposureBiasValue, "Raw Dev Exposure Bias Value" },
+            { TagRawDevWhiteBalance, "Raw Dev White Balance" },
+            { TagRawDevWhiteBalanceValue, "Raw Dev White Balance Value" },
+            { TagRawDevWbFineAdjustment, "Raw Dev WB Fine Adjustment" },
+            { TagRawDevGrayPoint, "Raw Dev Gray Point" },
+            { TagRawDevContrastValue, "Raw Dev Contrast Value" },
+            { TagRawDevSharpnessValue, "Raw Dev Sharpness Value" },
+            { TagRawDevSaturationEmphasis, "Raw Dev Saturation Emphasis" },
+            { TagRawDevMemoryColorEmphasis, "Raw Dev Memory Color Emphasis" },
+            { TagRawDevColorSpace, "Raw Dev Color Space" },
+            { TagRawDevNoiseReduction, "Raw Dev Noise Reduction" },
+            { TagRawDevEngine, "Raw Dev Engine" },
+            { TagRawDevPictureMode, "Raw Dev Picture Mode" },
+            { TagRawDevPmSaturation, "Raw Dev PM Saturation" },
+            { TagRawDevPmContrast, "Raw Dev PM Contrast" },
+            { TagRawDevPmSharpness, "Raw Dev PM Sharpness" },
+            { TagRawDevPmBwFilter, "Raw Dev PM BW Filter" },
+            { TagRawDevPmPictureTone, "Raw Dev PM Picture Tone" },
+            { TagRawDevGradation, "Raw Dev Gradation" },
+            { TagRawDevSaturation3, "Raw Dev Saturation 3" },
+            { TagRawDevAutoGradation, "Raw Dev Auto Gradation" },
+            { TagRawDevPmNoiseFilter, "Raw Dev PM Noise Filter" },
+            { TagRawDevArtFilter, "Raw Dev Art Filter" }
+    };
+
+        public OlympusRawDevelopment2MakernoteDirectory()
+        {
+            SetDescriptor(new OlympusRawDevelopment2MakernoteDescriptor(this));
+        }
+
+        public override string Name => "Olympus Raw Development 2";
+
+        public override void Set(int tagType, object value)
+        {
+            var bytes = value as byte[];
+            base.Set(tagType, value);
+        }
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/MetadataExtractor.Portable.csproj
+++ b/MetadataExtractor/MetadataExtractor.Portable.csproj
@@ -88,6 +88,8 @@
     <Compile Include="Formats\Exif\makernotes\OlympusEquipmentMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusMakernoteDirectory.cs" />
+    <Compile Include="Formats\Exif\makernotes\OlympusRawDevelopment2MakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\makernotes\OlympusRawDevelopment2MakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusRawDevelopmentMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusRawDevelopmentMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\makernotes\PanasonicMakernoteDescriptor.cs" />

--- a/MetadataExtractor/MetadataExtractor.net35.csproj
+++ b/MetadataExtractor/MetadataExtractor.net35.csproj
@@ -58,6 +58,8 @@
     <Compile Include="Formats\Exif\Makernotes\OlympusCameraSettingsMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusEquipmentMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusEquipmentMakernoteDirectory.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopment2MakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopment2MakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopmentMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopmentMakernoteDirectory.cs" />
     <Compile Include="Formats\Jfxx\JfxxDescriptor.cs" />

--- a/MetadataExtractor/MetadataExtractor.net45.csproj
+++ b/MetadataExtractor/MetadataExtractor.net45.csproj
@@ -54,6 +54,8 @@
     </Compile>
     <Compile Include="DirectoryExtensions.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusCameraSettingsMakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopment2MakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopment2MakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopmentMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusEquipmentMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusCameraSettingsMakernoteDirectory.cs" />


### PR DESCRIPTION
Implements another Olympus subifd (Raw Development 2, 0x2031) as a directory. However, there are no images in the current images repository to test. It's a short directory so not a huge deal.

This used a copy/paste of GetFilterDescription AND _filters from OlympusCameraSettingsMakernoteDescriptor. You might decide how best to share these in the "Olympus" set, as there could be other directories that use them.