### PR TITLE
Olympus Focus Info subifd (0x2050) directory

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -121,6 +121,16 @@ namespace MetadataExtractor.Formats.Exif
                     PushDirectory(typeof(OlympusImageProcessingMakernoteDirectory));
                     return true;
                 }
+                if (tagId == OlympusMakernoteDirectory.TagFocusInfo)
+                {
+                    PushDirectory(typeof(OlympusFocusInfoMakernoteDirectory));
+                    return true;
+                }
+                if(tagId == OlympusMakernoteDirectory.TagMainInfo)
+                {
+                    PushDirectory(typeof(OlympusMakernoteDirectory));
+                    return true;
+                }
             }
 
             return false;

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
@@ -1,0 +1,239 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System;
+using System.Text;
+using JetBrains.Annotations;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>
+    /// Provides human-readable string representations of tag values stored in a <see cref="OlympusFocusInfoMakernoteDirectory"/>.
+    /// </summary>
+    /// <remarks>
+    /// Some Description functions converted from Exiftool version 10.10 created by Phil Harvey
+    /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+    /// lib\Image\ExifTool\Olympus.pm
+    /// </remarks>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class OlympusFocusInfoMakernoteDescriptor : TagDescriptor<OlympusFocusInfoMakernoteDirectory>
+    {
+        public OlympusFocusInfoMakernoteDescriptor([NotNull] OlympusFocusInfoMakernoteDirectory directory)
+            : base(directory)
+        {
+        }
+
+        public override string GetDescription(int tagType)
+        {
+            switch (tagType)
+            {
+                case OlympusFocusInfoMakernoteDirectory.TagFocusInfoVersion:
+                    return GetFocusInfoVersionDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagAutoFocus:
+                    return GetAutoFocusDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagFocusDistance:
+                    return GetFocusDistanceDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagAfPoint:
+                    return GetAfPointDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagExternalFlash:
+                    return GetExternalFlashDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagExternalFlashBounce:
+                    return GetExternalFlashBounceDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagExternalFlashZoom:
+                    return GetExternalFlashZoomDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagManualFlash:
+                    return GetManualFlashDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagMacroLed:
+                    return GetMacroLedDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagSensorTemperature:
+                    return GetSensorTemperatureDescription();
+                case OlympusFocusInfoMakernoteDirectory.TagImageStabilization:
+                    return GetImageStabilizationDescription();
+                default:
+                    return base.GetDescription(tagType);
+            }
+        }
+
+        [CanBeNull]
+        public string GetFocusInfoVersionDescription()
+        {
+            return GetVersionBytesDescription(OlympusFocusInfoMakernoteDirectory.TagFocusInfoVersion, 4);
+        }
+
+        [CanBeNull]
+        public string GetAutoFocusDescription()
+        {
+            return GetIndexedDescription(OlympusFocusInfoMakernoteDirectory.TagAutoFocus,
+                "Off", "On");
+        }
+
+        [CanBeNull]
+        /// <remarks>
+        /// this rational value looks like it is in mm when the denominator is
+        /// 1 (E-1), and cm when denominator is 10 (E-300), so if we ignore the
+        /// denominator we are consistently in mm - PH
+        /// </remarks>
+        public string GetFocusDistanceDescription()
+        {
+            Rational value;
+            if (!Directory.TryGetRational(OlympusFocusInfoMakernoteDirectory.TagFocusDistance, out value))
+                return "inf";
+            if (value.Numerator == 0xFFFFFFFF)
+                return "inf";
+
+            return value.Numerator / 1000.0 + " m";
+        }
+
+        [CanBeNull]
+        /// <remarks>
+        /// <para>TODO: Complete when Camera Model is available.</para>
+        /// <para>There are differences in how to interpret this tag that can only be reconciled by knowing the model.</para>
+        /// </remarks>
+        public string GetAfPointDescription()
+        {
+            short value;
+            if (!Directory.TryGetInt16(OlympusFocusInfoMakernoteDirectory.TagAfPoint, out value))
+                return null;
+
+            return value.ToString();
+        }
+
+        [CanBeNull]
+        public string GetExternalFlashDescription()
+        {
+            var values = Directory.GetObject(OlympusFocusInfoMakernoteDirectory.TagExternalFlash) as ushort[];
+            if (values == null || values.Length < 2)
+                return null;
+
+            var join = $"{values[0]} {values[1]}";
+            
+            switch (join)
+            {
+                case "0 0":
+                    return "Off";
+                case "1 0":
+                    return "On";
+                default:
+                    return "Unknown (" + join + ")";
+            }
+        }
+
+        [CanBeNull]
+        public string GetExternalFlashBounceDescription()
+        {
+            return GetIndexedDescription(OlympusFocusInfoMakernoteDirectory.TagExternalFlashBounce,
+                "Bounce or Off", "Direct");
+        }
+
+        [CanBeNull]
+        public string GetExternalFlashZoomDescription()
+        {
+            var values = Directory.GetObject(OlympusFocusInfoMakernoteDirectory.TagExternalFlashZoom) as ushort[];
+            if (values == null)
+            {
+                // check if it's only one value long also
+                short value;
+                if (!Directory.TryGetInt16(OlympusFocusInfoMakernoteDirectory.TagExternalFlashZoom, out value))
+                    return null;
+
+                values = new ushort[1];
+                values[0] = (ushort)value;
+            }
+
+            if (values.Length == 0)
+                return null;
+
+            var join = $"{values[0]}" + ((values.Length > 1) ? $"{ values[1]}" : "");
+
+            switch (join)
+            {
+                case "0":
+                    return "Off";
+                case "1":
+                    return "On";
+                case "0 0":
+                    return "Off";
+                case "1 0":
+                    return "On";
+                default:
+                    return "Unknown (" + join + ")";
+            }
+        }
+
+        [CanBeNull]
+        public string GetManualFlashDescription()
+        {
+            var values = Directory.GetObject(OlympusFocusInfoMakernoteDirectory.TagManualFlash) as short[];
+            if (values == null)
+                return null;
+
+            if (values[0] == 0)
+                return "Off";
+
+            if (values[1] == 1)
+                return "Full";
+            else
+                return "On " + 1.0 / values[1] + " strength)";
+        }
+
+        [CanBeNull]
+        public string GetMacroLedDescription()
+        {
+            return GetIndexedDescription(OlympusFocusInfoMakernoteDirectory.TagMacroLed,
+                "Off", "On");
+        }
+
+        [CanBeNull]
+        /// <remarks>
+        /// <para>TODO: Complete when Camera Model is available.</para>
+        /// <para>There are differences in how to interpret this tag that can only be reconciled by knowing the model.</para>
+        /// </remarks>
+        public string GetSensorTemperatureDescription()
+        {
+            return Directory.GetString(OlympusFocusInfoMakernoteDirectory.TagSensorTemperature);
+        }
+
+        [CanBeNull]
+        /// <remarks>
+        /// ref http://fourthirdsphoto.com/vbb/showpost.php?p=107607&postcount=15
+        /// <para> if the first 4 bytes are non-zero, then bit 0x01 of byte 44 gives the stabilization mode</para>
+        /// <notes>(the other value is more reliable, so ignore this totally if the other exists)</notes>
+        /// </remarks>
+        public string GetImageStabilizationDescription()
+        {
+            var values = Directory.GetByteArray(OlympusFocusInfoMakernoteDirectory.TagImageStabilization);
+            if (values == null)
+                return null;
+            
+            if((values[0] | values[1] | values[2] | values[3]) == 0x0)
+                return "Off";
+            else
+                return "On, " + ((values[43] & 1) > 0 ? "Mode 1" : "Mode 2");
+
+        }
+
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDirectory.cs
@@ -1,0 +1,108 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>
+    /// The Olympus focus info makernote is used by many manufacturers (Epson, Konica, Minolta and Agfa...), and as such contains some tags
+    /// that appear specific to those manufacturers.
+    /// </summary>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class OlympusFocusInfoMakernoteDirectory : Directory
+    {
+        public const int TagFocusInfoVersion = 0x0000;
+        public const int TagAutoFocus = 0x0209;
+        public const int TagSceneDetect = 0x0210;
+        public const int TagSceneArea = 0x0211;
+        public const int TagSceneDetectData = 0x0212;
+
+        public const int TagZoomStepCount = 0x0300;
+        public const int TagFocusStepCount = 0x0301;
+        public const int TagFocusStepInfinity = 0x0303;
+        public const int TagFocusStepNear = 0x0304;
+        public const int TagFocusDistance = 0x0305;
+        public const int TagAfPoint = 0x0308;
+        // 0x031a Continuous AF parameters?
+        public const int TagAfInfo = 0x0328;    // ifd
+
+        public const int TagExternalFlash = 0x1201;
+        public const int TagExternalFlashGuideNumber = 0x1203;
+        public const int TagExternalFlashBounce = 0x1204;
+        public const int TagExternalFlashZoom = 0x1205;
+        public const int TagInternalFlash = 0x1208;
+        public const int TagManualFlash = 0x1209;
+        public const int TagMacroLed = 0x120A;
+        
+        public const int TagSensorTemperature = 0x1500;
+
+        public const int TagImageStabilization = 0x1600;
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        {
+            { TagFocusInfoVersion, "Focus Info Version" },
+            { TagAutoFocus, "Auto Focus" },
+            { TagSceneDetect, "Scene Detect" },
+            { TagSceneArea, "Scene Area" },
+            { TagSceneDetectData, "Scene Detect Data" },
+            { TagZoomStepCount, "Zoom Step Count" },
+            { TagFocusStepCount, "Focus Step Count" },
+            { TagFocusStepInfinity, "Focus Step Infinity" },
+            { TagFocusStepNear, "Focus Step Near" },
+            { TagFocusDistance, "Focus Distance" },
+            { TagAfPoint, "AF Point" },
+            { TagAfInfo, "AF Info" },
+            { TagExternalFlash, "External Flash" },
+            { TagExternalFlashGuideNumber, "External Flash Guide Number" },
+            { TagExternalFlashBounce, "External Flash Bounce" },
+            { TagExternalFlashZoom, "External Flash Zoom" },
+            { TagInternalFlash, "Internal Flash" },
+            { TagManualFlash, "Manual Flash" },
+            { TagMacroLed, "Macro LED" },
+            { TagSensorTemperature, "Sensor Temperature" },
+            { TagImageStabilization, "Image Stabilization" }
+    };
+
+        public OlympusFocusInfoMakernoteDirectory()
+        {
+            SetDescriptor(new OlympusFocusInfoMakernoteDescriptor(this));
+        }
+
+        public override string Name => "Olympus Focus Info";
+
+        public override void Set(int tagType, object value)
+        {
+            var bytes = value as byte[];
+            base.Set(tagType, value);
+        }
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
@@ -160,7 +160,8 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagWhiteBalanceBracket = 0x0303;
         public const int TagWhiteBalanceBias = 0x0304;
         public const int TagSceneMode = 0x0403;
-        public const int TagFirmware = 0x0404;
+        public const int TagSerialNumber1 = 0x0404;
+        public const int TagFirmware = 0x0405;
 
         /// <summary>
         /// See the PIM specification here:
@@ -193,7 +194,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagRedBias = 0x1017;
         public const int TagBlueBias = 0x1018;
         public const int TagColorMatrixNumber = 0x1019;
-        public const int TagSerialNumber = 0x101A;
+        public const int TagSerialNumber2 = 0x101A;
         public const int TagFlashBias = 0x1023;
         public const int TagExternalFlashBounce = 0x1026;
         public const int TagExternalFlashZoom = 0x1027;
@@ -220,6 +221,8 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagImageProcessing = 0x2040;
         public const int TagFocusInfo = 0x2050;
         public const int TagRawInfo = 0x3000;
+
+        public const int TagMainInfo = 0x4000;
 
         // These 'sub'-tag values have been created for consistency -- they don't exist within the Makernote IFD
         public static class CameraSettings
@@ -311,6 +314,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagWhiteBalanceBracket, "White Balance Bracket" },
             { TagWhiteBalanceBias, "White Balance Bias" },
             { TagSceneMode, "Scene Mode" },
+            { TagSerialNumber1, "Serial Number" },
             { TagFirmware, "Firmware" },
             { TagPrintImageMatchingInfo, "Print Image Matching (PIM) Info" },
             { TagDataDump1, "Data Dump" },
@@ -338,7 +342,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagRedBias, "Red Bias" },
             { TagBlueBias, "Blue Bias" },
             { TagColorMatrixNumber, "Color Matrix Number" },
-            { TagSerialNumber, "Serial Number" },
+            { TagSerialNumber2, "Serial Number" },
             { TagFlashBias, "Flash Bias" },
             { TagExternalFlashBounce, "External Flash Bounce" },
             { TagExternalFlashZoom, "External Flash Zoom" },
@@ -365,6 +369,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagImageProcessing, "Image Processing" },
             { TagFocusInfo, "Focus Info" },
             { TagRawInfo, "Raw Info" },
+            { TagMainInfo, "Main Info" },
             { CameraSettings.TagExposureMode, "Exposure Mode" },
             { CameraSettings.TagFlashMode, "Flash Mode" },
             { CameraSettings.TagWhiteBalance, "White Balance" },

--- a/MetadataExtractor/MetadataExtractor.Portable.csproj
+++ b/MetadataExtractor/MetadataExtractor.Portable.csproj
@@ -86,6 +86,8 @@
     <Compile Include="Formats\Exif\makernotes\OlympusCameraSettingsMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusEquipmentMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusEquipmentMakernoteDirectory.cs" />
+    <Compile Include="Formats\Exif\makernotes\OlympusFocusInfoMakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\makernotes\OlympusFocusInfoMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusImageProcessingMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusImageProcessingMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\makernotes\OlympusMakernoteDescriptor.cs" />

--- a/MetadataExtractor/MetadataExtractor.net35.csproj
+++ b/MetadataExtractor/MetadataExtractor.net35.csproj
@@ -58,6 +58,8 @@
     <Compile Include="Formats\Exif\Makernotes\OlympusCameraSettingsMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusEquipmentMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusEquipmentMakernoteDirectory.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusFocusInfoMakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusFocusInfoMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusImageProcessingMakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusImageProcessingMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopment2MakernoteDescriptor.cs" />

--- a/MetadataExtractor/MetadataExtractor.net45.csproj
+++ b/MetadataExtractor/MetadataExtractor.net45.csproj
@@ -54,6 +54,8 @@
     </Compile>
     <Compile Include="DirectoryExtensions.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusCameraSettingsMakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusFocusInfoMakernoteDescriptor.cs" />
+    <Compile Include="Formats\Exif\Makernotes\OlympusFocusInfoMakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopment2MakernoteDescriptor.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusRawDevelopment2MakernoteDirectory.cs" />
     <Compile Include="Formats\Exif\Makernotes\OlympusImageProcessingMakernoteDescriptor.cs" />


### PR DESCRIPTION
Implements an Olympus subifd (Focus Info, 0x2050) as a directory. Cleans-up the remaining format 13 errors from the images project. Other notes:

- There are two "Serial Number" tags in the main Olympus Makernote. This corrects the list and reassigns TagFirmware to value 0x0405

- FocusInfo tag 0x4000 is a subifd pointing to a second OlympusMakernoteDirectory. Added that to ExifTiffHandler.TryEnterSubIfd. That corrects a few other format 13 errors as well.