### PR TITLE
added XDocument property Root to provide access to underlying XML

### DIFF
--- a/MetadataExtractor/Formats/Jpeg/JpegMetadataWriter.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegMetadataWriter.cs
@@ -1,0 +1,218 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using JetBrains.Annotations;
+using MetadataExtractor.Formats.Adobe;
+using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.Icc;
+using MetadataExtractor.Formats.Iptc;
+using MetadataExtractor.Formats.Jfif;
+using MetadataExtractor.Formats.Jfxx;
+using MetadataExtractor.Formats.Photoshop;
+#if !PORTABLE
+using MetadataExtractor.Formats.FileSystem;
+#endif
+using MetadataExtractor.Formats.Xmp;
+using MetadataExtractor.IO;
+using System.Xml.Linq;
+using System.Text;
+using System;
+using System.Xml;
+using System.Diagnostics;
+
+namespace MetadataExtractor.Formats.Jpeg
+{
+    /// <summary>Writes metadata to JPEG formatted files.</summary>
+    /// <author>Michael Osthege</author>
+    public static class JpegMetadataSubstitutor
+    {
+
+        /// <summary>
+        /// Writes a Xmp XDocument to a MemoryStream, starting with the buffer of an existing file.
+        /// If no App1 segment is found, a new App1 segment will be inserted.
+        /// </summary>
+        /// <param name="original">Buffer of a file</param>
+        /// <param name="xmp">XDocument to be written</param>
+        /// <exception cref="JpegProcessingException"/>
+        /// <exception cref="System.IO.IOException"/>
+        [NotNull]
+        public static MemoryStream SubstituteXmp([NotNull] byte[] original, [NotNull] XDocument xmp)
+        {
+            SequentialByteArrayReader reader = new SequentialByteArrayReader(original);
+            MemoryStream ms = new MemoryStream();
+
+            try
+            {
+                bool wroteXmp = false;
+                while (true)
+                {
+                    // Find the segment marker. Markers are zero or more 0xFF bytes, followed
+                    // by a 0xFF and then a byte not equal to 0x00 or 0xFF.
+                    var segmentIdentifier = reader.GetByte();
+                    var segmentTypeByte = reader.GetByte();
+                    ms.WriteByte(segmentIdentifier);
+                    ms.WriteByte(segmentTypeByte);
+
+                    // Read until we have a 0xFF byte followed by a byte that is not 0xFF or 0x00
+                    while (segmentIdentifier != 0xFF || segmentTypeByte == 0xFF || segmentTypeByte == 0)
+                    {
+                        segmentIdentifier = segmentTypeByte;
+                        segmentTypeByte = reader.GetByte();
+                        ms.WriteByte(segmentTypeByte);
+                    }
+
+                    var segmentType = (JpegSegmentType)segmentTypeByte;
+
+                    // is this App1?
+                    // save the index of the first byte of this segment
+                    // read the whole segment into a new byte[]
+                    // evaluate if the segment contains the XMP metadata
+                    // yes: write new xmp metadata to the output (discard the segment that was just read)
+                    // no : write the whole segment to the output
+                    // continue looping
+
+                    if (!wroteXmp && segmentType == JpegSegmentType.App1)
+                    {
+                        // next 2-bytes are <segment-size>: [high-byte] [low-byte]
+                        byte highByte = reader.GetByte();
+                        byte lowByte = reader.GetByte();
+
+                        //int segmentLength = -2 + ((reader.IsMotorolaByteOrder) ? (highByte << 8 | lowByte) : (highByte | lowByte << 8));// (includes size bytes, so subtract two)
+                        int segmentLength = SegmentLengthFromBytes(highByte, lowByte, reader.IsMotorolaByteOrder) - 2;
+                        
+                        // the rest of the segment is only read - at first
+                        byte[] segmentBytes = reader.GetBytes(segmentLength);
+
+                        // if this is the XMP segment, overwrite the byte[] with the new segment
+                        int preambleLength = XmpReader.XmpJpegPreamble.Length;
+                        if (segmentBytes.Length >= preambleLength && XmpReader.XmpJpegPreamble.Equals(Encoding.UTF8.GetString(segmentBytes, 0, preambleLength), StringComparison.OrdinalIgnoreCase))
+                        {
+                            segmentBytes = ByteArrayFromXmpXDocument(xmp);
+                            // also update the segment length!!
+                            byte[] lengthMark = BytesFromSegmentLength(segmentBytes.Length + 2, reader.IsMotorolaByteOrder);
+                            highByte = lengthMark[0];
+                            lowByte = lengthMark[1];
+                            // no one will ever know this was not the original segment
+                            wroteXmp = true;
+                        }
+                        // write the segment
+                        ms.WriteByte(highByte);
+                        ms.WriteByte(lowByte);
+                        ms.Write(segmentBytes, 0, segmentBytes.Length);
+                    }
+                    else if (!wroteXmp && segmentType != JpegSegmentType.Soi && segmentType != JpegSegmentType.App0) // file begins with Soi (App0) App1 ...
+                    {
+                        // we have encountered a segment that should not be earlier than App1. Therfore we must insert a new App1 with the Xmp right now. (The file does not contain an App1 segement yet.)
+                        // go back and overwrite the recently encountered marker (cache what it was!)
+                        // create a new marker App1 http://dev.exiv2.org/projects/exiv2/wiki/The_Metadata_in_JPEG_files
+                        // build Xmp byte[]
+                        // ...
+                        // end by writing the marker that was substituted before
+
+                        // remember the segment that comes after
+                        byte[] nextSegmentMarker = new byte[] { segmentIdentifier, segmentTypeByte };
+                        ms.Seek(-2, SeekOrigin.Current);
+                        // open a new App1 segment
+                        byte[] app1marker = new byte[] { 0xFF, 0xE1 };
+                        ms.Write(app1marker, 0, app1marker.Length);
+                        // build Xmp segment
+                        byte[] segmentBytes = ByteArrayFromXmpXDocument(xmp);
+                        // calculate a length marker
+                        byte[] lengthMark = BytesFromSegmentLength(segmentBytes.Length + 2, reader.IsMotorolaByteOrder);
+                        byte highByte = lengthMark[0];
+                        byte lowByte = lengthMark[1];
+                        // write the segment to the output
+                        ms.WriteByte(highByte);
+                        ms.WriteByte(lowByte);
+                        ms.Write(segmentBytes, 0, segmentBytes.Length);
+                        // remember that we're done
+                        wroteXmp = true;
+                        // write the segment marker that we replaced
+                        ms.Write(nextSegmentMarker, 0, nextSegmentMarker.Length);
+                        // in the next loop it will just proceed
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                throw new JpegProcessingException("An error occured while trying to write Xml to the buffer.", ex);
+            }
+            
+            return ms;
+        }
+        private static byte[] ByteArrayFromXmpXDocument(XDocument xmp)
+        {
+            // we found the XMP segment. Now write the new XMP to the output
+            MemoryStream xmpMS = new MemoryStream();
+            // first the preamble "http://ns.adobe.com/xap/1.0/\x0"
+            byte[] preamble = UTF8Encoding.UTF8.GetBytes(XmpReader.XmpJpegPreamble);
+            xmpMS.Write(preamble, 0, preamble.Length);
+            // now the XDocument WITHOUT Xml Declaration
+            XmlWriterSettings settings = new XmlWriterSettings() { OmitXmlDeclaration = true };
+            using (XmlWriter xw = XmlWriter.Create(xmpMS, settings))
+            {
+                xmp.WriteTo(xw);
+            }
+            // make it into a byte array
+            return xmpMS.ToArray();
+        }
+        private static int SegmentLengthFromBytes(byte highByte, byte lowByte, bool motorolaBigEndian)
+        {
+            return ((motorolaBigEndian) ? (highByte << 8 | lowByte) : (highByte | lowByte << 8));
+        }
+        private static byte[] BytesFromSegmentLength(int length, bool motorolaBigEndian)
+        {
+            byte[] bytes = BitConverter.GetBytes(length);
+            if (motorolaBigEndian)
+                return new byte[] { bytes[1], bytes[0] };
+            else
+                return new byte[] { bytes[0], bytes[1] };
+        }
+
+        ///// <exception cref="JpegProcessingException"/>
+        ///// <exception cref="System.IO.IOException"/>
+        //public static void Process([NotNull] Stream stream, [CanBeNull] IEnumerable<IJpegSegmentMetadataReader> readers = null)
+        //{
+        //    if (readers == null)
+        //        readers = _allReaders;
+
+        //    var segmentTypes = new HashSet<JpegSegmentType>(readers.SelectMany(reader => reader.GetSegmentTypes()));
+        //    var segmentData = JpegSegmentReader.ReadSegments(new SequentialStreamReader(stream), segmentTypes);
+        //    return ProcessJpegSegmentData(readers, segmentData);
+        //}
+
+        //public static void ProcessJpegSegmentData(IEnumerable<IJpegSegmentMetadataReader> readers, JpegSegmentData segmentData)
+        //{
+        //    // Pass the appropriate byte arrays to each reader.
+        //    return (from reader in readers
+        //            from segmentType in reader.GetSegmentTypes()
+        //            from directory in reader.ReadJpegSegments(segmentData.GetSegments(segmentType), segmentType)
+        //            select directory)
+        //            .ToList();
+        //}
+    }
+}

--- a/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
@@ -27,6 +27,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using JetBrains.Annotations;
 using XmpCore;
+using System.Xml.Linq;
 
 namespace MetadataExtractor.Formats.Xmp
 {
@@ -245,6 +246,10 @@ namespace MetadataExtractor.Formats.Xmp
 
         [CanBeNull]
         private IXmpMeta _xmpMeta;
+        
+        [CanBeNull]
+        private XDocument _Root;
+
 
         public XmpDirectory()
         {
@@ -284,9 +289,20 @@ namespace MetadataExtractor.Formats.Xmp
             }
         }
 
+        public void SetRootDocument([NotNull] XDocument root)
+        {
+            _Root = root;
+        }
+
         /// <summary>Gets the <see cref="IXmpMeta"/> object within this directory.</summary>
         /// <remarks>This object provides a rich API for working with XMP data.</remarks>
         [CanBeNull]
         public IXmpMeta XmpMeta => _xmpMeta;
+
+        /// <summary>
+        /// Root XMP <see cref="XDocument"/> as read from the file.
+        /// </summary>
+        [CanBeNull]
+        public XDocument Root => _Root;
     }
 }

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -112,7 +112,10 @@ namespace MetadataExtractor.Formats.Xmp
             var directory = new XmpDirectory();
             try
             {
-                var xmpMeta = XmpMetaFactory.ParseFromBuffer(xmpBytes);
+                // first extract the XML
+                directory.SetRootDocument(XmpMetaFactory.ExtractXDocumentFromBuffer(xmpBytes));
+                // now try to parse it
+                var xmpMeta = XmpMetaFactory.ParseFromXDocument(directory.Root);
                 ProcessXmpTags(directory, xmpMeta);
             }
             catch (XmpException e)

--- a/MetadataExtractor/ImageMetadataWriter.cs
+++ b/MetadataExtractor/ImageMetadataWriter.cs
@@ -1,0 +1,120 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.IO;
+using JetBrains.Annotations;
+using MetadataExtractor.Formats.Bmp;
+#if !PORTABLE
+using MetadataExtractor.Formats.FileSystem;
+#endif
+using MetadataExtractor.Formats.Gif;
+using MetadataExtractor.Formats.Ico;
+using MetadataExtractor.Formats.Jpeg;
+using MetadataExtractor.Formats.Pcx;
+using MetadataExtractor.Formats.Photoshop;
+using MetadataExtractor.Formats.Png;
+using MetadataExtractor.Formats.QuickTime;
+using MetadataExtractor.Formats.Raf;
+using MetadataExtractor.Formats.Tiff;
+using MetadataExtractor.Formats.WebP;
+using MetadataExtractor.Util;
+using System.Xml.Linq;
+using System.Threading.Tasks;
+
+namespace MetadataExtractor
+{
+    /// <summary>Writes metadata to any supported file format.</summary>
+    /// <remarks>
+    /// This class a lightweight wrapper around other, specific metadata processors.
+    /// During saving, the file type is determined from the first few bytes of the existing file.
+    /// Writing is then delegated to one of:
+    ///
+    /// <list type="bullet">
+    ///   <item><see cref="JpegMetadataSubstitutor"/> for JPEG files</item>
+    /////   <item><see cref="TiffMetadataReader"/> for TIFF and (most) RAW files</item>
+    /////   <item><see cref="PsdMetadataReader"/> for Photoshop files</item>
+    /////   <item><see cref="PngMetadataReader"/> for PNG files</item>
+    /////   <item><see cref="BmpMetadataReader"/> for BMP files</item>
+    /////   <item><see cref="GifMetadataReader"/> for GIF files</item>
+    /////   <item><see cref="IcoMetadataReader"/> for ICO files</item>
+    /////   <item><see cref="PcxMetadataReader"/> for PCX files</item>
+    /////   <item><see cref="WebPMetadataReader"/> for WebP files</item>
+    /////   <item><see cref="RafMetadataReader"/> for RAF files</item>
+    /// </list>
+    ///
+    /// If you know the file type you're working with, you may use one of the above processors directly.
+    /// For most scenarios it is simpler, more convenient and more robust to use this class.
+    /// <para />
+    /// <see cref="FileTypeDetector"/> is used to determine the provided image's file type, and therefore
+    /// the appropriate metadata reader to use.
+    /// </remarks>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public static class ImageMetadataWriter
+    {
+        /// <summary>Writes metadata to a <see cref="Stream"/>.</summary>
+        /// <param name="original">A stream to which the file data may be written.  The stream must be positioned at the beginning of the file's data.</param>
+        /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
+        /// <exception cref="System.IO.IOException"/>
+        [NotNull]
+        public static MemoryStream SubstituteXmp([NotNull] Stream stream, XDocument xmp)
+        {
+            var fileType = FileTypeDetector.DetectFileType(stream);
+            stream.Seek(0, SeekOrigin.Begin);
+            byte[] original = new byte[stream.Length];
+            stream.Read(original, 0, (int)stream.Length);
+            switch (fileType)
+            {
+                case FileType.Jpeg: return JpegMetadataSubstitutor.SubstituteXmp(original, xmp);
+                //case FileType.Tiff:
+                //case FileType.Arw:
+                //case FileType.Cr2:
+                //case FileType.Nef:
+                //case FileType.Orf:
+                //case FileType.Rw2:
+                //    return TiffMetadataReader.ReadMetadata(stream);
+                //case FileType.Psd:
+                //    return PsdMetadataReader.ReadMetadata(stream);
+                //case FileType.Png:
+                //    return PngMetadataReader.ReadMetadata(stream);
+                //case FileType.Bmp:
+                //    return new[] { BmpMetadataReader.ReadMetadata(stream) };
+                //case FileType.Gif:
+                //    return new[] { GifMetadataReader.ReadMetadata(stream) };
+                //case FileType.Ico:
+                //    return IcoMetadataReader.ReadMetadata(stream);
+                //case FileType.Pcx:
+                //    return new[] { PcxMetadataReader.ReadMetadata(stream) };
+                //case FileType.Riff:
+                //    return WebPMetadataReader.ReadMetadata(stream);
+                //case FileType.Raf:
+                //    return RafMetadataReader.ReadMetadata(stream);
+                //case FileType.QuickTime:
+                //    return QuicktimeMetadataReader.ReadMetadata(stream);
+            }
+
+            throw new ImageProcessingException("File format is not supported");
+        }
+    }
+}

--- a/MetadataExtractor/MetadataExtractor.Portable.csproj
+++ b/MetadataExtractor/MetadataExtractor.Portable.csproj
@@ -143,6 +143,7 @@
     <Compile Include="Formats\Jpeg\JpegDescriptor.cs" />
     <Compile Include="Formats\Jpeg\JpegDirectory.cs" />
     <Compile Include="Formats\Jpeg\JpegMetadataReader.cs" />
+    <Compile Include="Formats\Jpeg\JpegMetadataWriter.cs" />
     <Compile Include="Formats\Jpeg\JpegProcessingException.cs" />
     <Compile Include="Formats\Jpeg\JpegReader.cs" />
     <Compile Include="Formats\Jpeg\JpegSegment.cs" />
@@ -202,6 +203,7 @@
     <Compile Include="Formats\Xmp\XmpReader.cs" />
     <Compile Include="GeoLocation.cs" />
     <Compile Include="ImageMetadataReader.cs" />
+    <Compile Include="ImageMetadataWriter.cs" />
     <Compile Include="ImageProcessingException.cs" />
     <Compile Include="IO\BufferBoundsException.cs" />
     <Compile Include="IO\ByteArrayReader.cs" />
@@ -235,7 +237,7 @@
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\SL4\SharpZipLib.Silverlight4.dll</HintPath>
     </Reference>
     <Reference Include="XmpCore.Portable, Version=5.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XmpCore.1.2.2\lib\portable-net45+sl50+netcore45+wpa81+wp8\XmpCore.Portable.dll</HintPath>
+      <HintPath>..\packages\XmpCore.1.2.3\lib\portable-net45+sl50+netcore45+wpa81+wp8\XmpCore.Portable.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Zlib.Portable, Version=1.11.0.0, Culture=neutral, processorArchitecture=MSIL">

--- a/MetadataExtractor/MetadataExtractor.net45.csproj
+++ b/MetadataExtractor/MetadataExtractor.net45.csproj
@@ -37,14 +37,14 @@
       <HintPath>..\packages\SharpZipLib.0.86.0\lib\20\ICSharpCode.SharpZipLib.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="JetBrains.Annotations, Version=10.1.5.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
-      <HintPath>..\packages\JetBrains.Annotations.10.1.5\lib\net\JetBrains.Annotations.dll</HintPath>
+    <Reference Include="JetBrains.Annotations, Version=10.2.1.0, Culture=neutral, PublicKeyToken=1010a0d8d6380325, processorArchitecture=MSIL">
+      <HintPath>..\packages\JetBrains.Annotations.10.2.1\lib\net\JetBrains.Annotations.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="XmpCore, Version=5.1.2.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\XmpCore.1.2.2\lib\net35\XmpCore.dll</HintPath>
+      <HintPath>..\packages\XmpCore.1.2.3\lib\net35\XmpCore.dll</HintPath>
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/MetadataExtractor/packages.MetadataExtractor.Portable.config
+++ b/MetadataExtractor/packages.MetadataExtractor.Portable.config
@@ -2,6 +2,6 @@
 <packages>
   <package id="JetBrains.Annotations" version="10.1.5" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="sl4" />
-  <package id="XmpCore" version="1.2.2" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
+  <package id="XmpCore" version="1.2.3" targetFramework="portable40-net45+sl5+win8+wp8+wpa81" />
   <package id="Zlib.Portable" version="1.11.0" targetFramework="portable4-net45+sl5+win8+wp8+wpa81" />
 </packages>

--- a/MetadataExtractor/packages.MetadataExtractor.net45.config
+++ b/MetadataExtractor/packages.MetadataExtractor.net45.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="JetBrains.Annotations" version="10.1.5" targetFramework="net45" />
+  <package id="JetBrains.Annotations" version="10.2.1" targetFramework="net45" />
   <package id="SharpZipLib" version="0.86.0" targetFramework="net35" />
-  <package id="XmpCore" version="1.2.2" targetFramework="net35" />
+  <package id="XmpCore" version="1.2.3" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Depends on [XmpCore PR 15](https://github.com/drewnoakes/xmp-core-dotnet/pull/15)

Adds a Root property to XmpDirectory such that the XDocument can be accessed directly.
Load behavior is modified to set the Root property.

This is the basis for my implementation of writing Xmp metadata. See #23 for more information.