### PR TITLE
More Olympus RAW and IFD coverage

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -103,7 +103,8 @@ namespace MetadataExtractor.Formats.Exif
             }
             else if (CurrentDirectory is OlympusMakernoteDirectory)
             {
-                // ReSharper disable once SwitchStatementMissingSomeCases
+                // Note: these also appear in CustomProcessTag because some are IFD pointers while others begin immediately
+                // for the same directories
                 switch (tagId)
                 {
                     case OlympusMakernoteDirectory.TagEquipment:
@@ -207,6 +208,8 @@ namespace MetadataExtractor.Formats.Exif
                 return true;
             }
 
+            // Note: these also appear in TryEnterSubIfd because some are IFD pointers while others begin immediately
+            // for the same directories
             if(CurrentDirectory is OlympusMakernoteDirectory)
             {
                 switch (tagId)

--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -124,6 +124,9 @@ namespace MetadataExtractor.Formats.Exif
                     case OlympusMakernoteDirectory.TagFocusInfo:
                         PushDirectory(new OlympusFocusInfoMakernoteDirectory());
                         return true;
+                    case OlympusMakernoteDirectory.TagRawInfo:
+                        PushDirectory(new OlympusRawInfoMakernoteDirectory());
+                        return true;
                     case OlympusMakernoteDirectory.TagMainInfo:
                         PushDirectory(new OlympusMakernoteDirectory());
                         return true;
@@ -193,6 +196,54 @@ namespace MetadataExtractor.Formats.Exif
                 xmpDirectory.Parent = CurrentDirectory;
                 Directories.Add(xmpDirectory);
                 return true;
+            }
+
+            if(tagId == ExifDirectoryBase.TagPrintIm)
+            {
+                var dirPrintIm = new PrintIMDirectory();
+                dirPrintIm.Parent = CurrentDirectory;
+                Directories.Add(dirPrintIm);
+                ProcessPrintIM(dirPrintIm, tagOffset, reader, byteCount);
+                return true;
+            }
+
+            if(CurrentDirectory is OlympusMakernoteDirectory)
+            {
+                switch (tagId)
+                {
+                    case OlympusMakernoteDirectory.TagEquipment:
+                        PushDirectory(new OlympusEquipmentMakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                    case OlympusMakernoteDirectory.TagCameraSettings:
+                        PushDirectory(new OlympusCameraSettingsMakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                    case OlympusMakernoteDirectory.TagRawDevelopment:
+                        PushDirectory(new OlympusRawDevelopmentMakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                    case OlympusMakernoteDirectory.TagRawDevelopment2:
+                        PushDirectory(new OlympusRawDevelopment2MakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                    case OlympusMakernoteDirectory.TagImageProcessing:
+                        PushDirectory(new OlympusImageProcessingMakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                    case OlympusMakernoteDirectory.TagFocusInfo:
+                        PushDirectory(new OlympusFocusInfoMakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                    case OlympusMakernoteDirectory.TagRawInfo:
+                        PushDirectory(new OlympusRawInfoMakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                    case OlympusMakernoteDirectory.TagMainInfo:
+                        PushDirectory(new OlympusMakernoteDirectory());
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        return true;
+                }
             }
 
             if (CurrentDirectory is PanasonicRawIfd0Directory)
@@ -530,6 +581,61 @@ namespace MetadataExtractor.Formats.Exif
             }
 
             return true;
+        }
+
+        /// <summary>
+        /// Process PrintIM IFD
+        /// </summary>
+        /// <remarks>
+        /// Converted from Exiftool version 10.33 created by Phil Harvey
+        /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+        /// lib\Image\ExifTool\PrintIM.pm
+        /// </remarks>
+        private void ProcessPrintIM([NotNull] Directory directory, int tagValueOffset, [NotNull] IndexedReader reader, int byteCount)
+        {
+            if (byteCount == 0)
+            {
+                Error("Empty PrintIM data");
+                return;
+            }
+            else if(byteCount <= 15)
+            {
+                Error("Bad PrintIM data");
+                return;
+            }
+
+            string header = reader.GetString(tagValueOffset, 12, Encoding.UTF8);
+            if (!string.Equals(header.Substring(0, 7), "PrintIM", StringComparison.Ordinal))
+            {
+                Error("Invalid PrintIM header");
+                return;
+            }
+
+            var localReader = reader;
+            // check size of PrintIM block
+            var num = localReader.GetUInt16(tagValueOffset + 14);
+            if (byteCount < 16 + num * 6)
+            {
+                // size is too big, maybe byte ordering is wrong
+                localReader = reader.WithByteOrder(!reader.IsMotorolaByteOrder);
+                num = localReader.GetUInt16(tagValueOffset + 14);
+                if (byteCount < 16 + num * 6)
+                {
+                    Error("Bad PrintIM size");
+                    return;
+                }
+            }
+
+            directory.Set(PrintIMDirectory.TagPrintImVersion, header.Substring(8, 4));
+
+            for (int n = 0; n < num; n++)
+            {
+                int pos = tagValueOffset + 16 + n * 6;
+                var tag = localReader.GetUInt16(pos);
+                var val = localReader.GetUInt32(pos + 2);
+
+                directory.Set(tag, val);
+            }
         }
 
         private static void ProcessBinary([NotNull] Directory directory, int tagValueOffset, [NotNull] IndexedReader reader, int byteCount, bool issigned = true, int arrayLength = 1)

--- a/MetadataExtractor/Formats/Exif/PrintIMDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/PrintIMDescriptor.cs
@@ -25,24 +25,17 @@
 using System.Diagnostics.CodeAnalysis;
 using JetBrains.Annotations;
 
-namespace MetadataExtractor.Formats.Exif.Makernotes
+namespace MetadataExtractor.Formats.Exif
 {
     /// <summary>
-    /// Provides human-readable string representations of tag values stored in a <see cref="KyoceraMakernoteDirectory"/>.
+    /// Provides human-readable string representations of tag values stored in a <see cref="PrintIMDirectory"/>.
     /// </summary>
-    /// <remarks>
-    /// Some information about this makernote taken from here:
-    /// http://www.ozhiker.com/electronics/pjmt/jpeg_info/kyocera_mn.html
-    /// <para />
-    /// Most manufacturer's Makernote counts the "offset to data" from the first byte
-    /// of TIFF header (same as the other IFD), but Kyocera (along with Fujifilm) counts
-    /// it from the first byte of Makernote itself.
-    /// </remarks>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public sealed class KyoceraMakernoteDescriptor : TagDescriptor<KyoceraMakernoteDirectory>
+    public class PrintIMDescriptor : TagDescriptor<PrintIMDirectory>
     {
-        public KyoceraMakernoteDescriptor([NotNull] KyoceraMakernoteDirectory directory)
+        public PrintIMDescriptor([NotNull] PrintIMDirectory directory)
             : base(directory)
         {
         }
@@ -51,17 +44,14 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         {
             switch (tagType)
             {
-                case KyoceraMakernoteDirectory.TagProprietaryThumbnail:
-                    return GetProprietaryThumbnailDataDescription();
-                default:
+                case PrintIMDirectory.TagPrintImVersion:
                     return base.GetDescription(tagType);
+                default:
+                    uint value;
+                    if(!Directory.TryGetUInt32(tagType, out value))
+                        return null;
+                    return "0x" + value.ToString("x8");
             }
-        }
-
-        [CanBeNull]
-        public string GetProprietaryThumbnailDataDescription()
-        {
-            return GetByteLengthDescription(KyoceraMakernoteDirectory.TagProprietaryThumbnail);
         }
     }
 }

--- a/MetadataExtractor/Formats/Exif/PrintIMDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/PrintIMDirectory.cs
@@ -1,0 +1,56 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif
+{
+    /// <remarks>These tags can be found in Epson proprietary metadata. The index values are 'fake' but
+    /// chosen specifically to make processing easier</remarks>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public class PrintIMDirectory : Directory
+    {
+        public const int TagPrintImVersion = 0x0000;
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        {
+            { TagPrintImVersion, "PrintIM Version" }
+        };
+
+        public PrintIMDirectory()
+        {
+            SetDescriptor(new PrintIMDescriptor(this));
+        }
+
+        public override string Name => "PrintIM";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/CasioType2MakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/CasioType2MakernoteDescriptor.cs
@@ -67,8 +67,6 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     return GetContrastDescription();
                 case CasioType2MakernoteDirectory.TagSharpness:
                     return GetSharpnessDescription();
-                case CasioType2MakernoteDirectory.TagPrintImageMatchingInfo:
-                    return GetPrintImageMatchingInfoDescription();
                 case CasioType2MakernoteDirectory.TagPreviewThumbnail:
                     return GetCasioPreviewThumbnailDescription();
                 case CasioType2MakernoteDirectory.TagWhiteBalanceBias:
@@ -217,13 +215,6 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 return null;
 
             return "<" + bytes.Length + " bytes of image data>";
-        }
-
-        [CanBeNull]
-        public string GetPrintImageMatchingInfoDescription()
-        {
-            // TODO research PIM specification http://www.ozhiker.com/electronics/pjmt/jpeg_info/pim.html
-            return Directory.GetString(CasioType2MakernoteDirectory.TagPrintImageMatchingInfo);
         }
 
         [CanBeNull]

--- a/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDirectory.cs
@@ -957,7 +957,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagUnknown49, "Unknown 49" },
             { TagUnknown50, "Unknown 50" },
             { TagUnknown51, "Unknown 51" },
-            { TagPrintIM, "Print IM" },
+            { TagPrintIM, "Print Image Matching (PIM) Info" },
             { TagUnknown52, "Unknown 52" },
             { TagUnknown53, "Unknown 53" },
             { TagNikonCaptureVersion, "Nikon Capture Version" },

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDirectory.cs
@@ -89,6 +89,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagPictureModeEffect = 0x52d;
         public const int TagToneLevel = 0x52e;
         public const int TagArtFilterEffect = 0x52f;
+        public const int TagColorCreatorEffect = 0x532;
 
         public const int TagDriveMode = 0x600;
         public const int TagPanoramaMode = 0x601;
@@ -160,6 +161,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagPictureModeEffect, "Picture Mode Effect" },
             { TagToneLevel, "Tone Level" },
             { TagArtFilterEffect, "Art Filter Effect" },
+            { TagColorCreatorEffect, "Color Creator Effect" },
 
             { TagDriveMode, "Drive Mode" },
             { TagPanoramaMode, "Panorama Mode" },

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusEquipmentMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusEquipmentMakernoteDescriptor.cs
@@ -52,6 +52,8 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             {
                 case OlympusEquipmentMakernoteDirectory.TagEquipmentVersion:
                     return GetEquipmentVersionDescription();
+                case OlympusEquipmentMakernoteDirectory.TagCameraType2:
+                    return GetCameraType2Description();
                 case OlympusEquipmentMakernoteDirectory.TagFocalPlaneDiagonal:
                     return GetFocalPlaneDiagonalDescription();
                 case OlympusEquipmentMakernoteDirectory.TagBodyFirmwareVersion:
@@ -86,6 +88,19 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         }
 
         [CanBeNull]
+        public string GetCameraType2Description()
+        {
+            var cameratype = Directory.GetString(OlympusEquipmentMakernoteDirectory.TagCameraType2);
+            if (cameratype == null)
+                return null;
+
+            if (OlympusMakernoteDirectory.OlympusCameraTypes.ContainsKey(cameratype))
+                return OlympusMakernoteDirectory.OlympusCameraTypes[cameratype];
+
+            return cameratype;
+        }
+
+        [CanBeNull]
         public string GetFocalPlaneDiagonalDescription()
         {
             return Directory.GetString(OlympusEquipmentMakernoteDirectory.TagFocalPlaneDiagonal) + " mm";
@@ -98,8 +113,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (!Directory.TryGetInt32(OlympusEquipmentMakernoteDirectory.TagBodyFirmwareVersion, out value))
                 return null;
 
-            var hexstring = ((uint)value).ToString("X4");
-            return hexstring.Insert(hexstring.Length - 3, ".");
+            return ((uint)value).ToString("X4");
         }
 
         [CanBeNull]

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDescriptor.cs
@@ -31,7 +31,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
     /// Provides human-readable string representations of tag values stored in a <see cref="OlympusImageProcessingMakernoteDirectory"/>.
     /// </summary>
     /// <remarks>
-    /// Some Description functions converted from Exiftool version 10.10 created by Phil Harvey
+    /// Some Description functions converted from Exiftool version 10.33 created by Phil Harvey
     /// http://www.sno.phy.queensu.ca/~phil/exiftool/
     /// lib\Image\ExifTool\Olympus.pm
     /// </remarks>
@@ -63,6 +63,10 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     return GetMultipleExposureModeDescription();
                 case OlympusImageProcessingMakernoteDirectory.TagAspectRatio:
                     return GetAspectRatioDescription();
+                case OlympusImageProcessingMakernoteDirectory.TagKeystoneCompensation:
+                    return GetKeystoneCompensationDescription();
+                case OlympusImageProcessingMakernoteDirectory.TagKeystoneDirection:
+                    return GetKeystoneDirectionDescription();
                 default:
                     return base.GetDescription(tagType);
             }
@@ -228,6 +232,39 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             }
 
             return ret;
+        }
+
+        [CanBeNull]
+        public string GetKeystoneCompensationDescription()
+        {
+            var values = Directory.GetObject(OlympusImageProcessingMakernoteDirectory.TagKeystoneCompensation) as byte[];
+            if (values == null || values.Length < 2)
+                return null;
+
+            var join = $"{values[0]} {values[1]}";
+
+            string ret;
+            switch (join)
+            {
+                case "0 0":
+                    ret = "Off";
+                    break;
+                case "0 1":
+                    ret = "On";
+                    break;
+                default:
+                    ret = "Unknown (" + join + ")";
+                    break;
+            }
+
+            return ret;
+        }
+
+        [CanBeNull]
+        public string GetKeystoneDirectionDescription()
+        {
+            return GetIndexedDescription(OlympusImageProcessingMakernoteDirectory.TagKeystoneDirection,
+                "Vertical", "Horizontal");
         }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDirectory.cs
@@ -112,7 +112,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagFaceDetectFrameSize = 0x1203;
         public const int TagFaceDetectFrameCrop = 0x1207;
         public const int TagCameraTemperature = 0x1306;
+
+        public const int TagKeystoneCompensation = 0x1900;
+        public const int TagKeystoneDirection = 0x1901;
         // 0x1905 - focal length (PH, E-M1)
+        public const int TagKeystoneValue = 0x1906;
 
         private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
         {
@@ -179,7 +183,10 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagMaxFaces, "Max Faces" },
             { TagFaceDetectFrameSize, "Face Detect Frame Size" },
             { TagFaceDetectFrameCrop, "Face Detect Frame Crop" },
-            { TagCameraTemperature , "Camera Temperature" }
+            { TagCameraTemperature , "Camera Temperature" },
+            { TagKeystoneCompensation, "Keystone Compensation" },
+            { TagKeystoneDirection, "Keystone Direction" },
+            { TagKeystoneValue, "Keystone Value" }
         };
 
         public OlympusImageProcessingMakernoteDirectory()

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
@@ -24,6 +24,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using System.Text;
 using JetBrains.Annotations;
 using MetadataExtractor.Util;
@@ -63,10 +64,22 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     return GetMacroModeDescription();
                 case OlympusMakernoteDirectory.TagBwMode:
                     return GetBwModeDescription();
-                case OlympusMakernoteDirectory.TagDigiZoomRatio:
-                    return GetDigiZoomRatioDescription();
+                case OlympusMakernoteDirectory.TagDigitalZoom:
+                    return GetDigitalZoomDescription();
+                case OlympusMakernoteDirectory.TagFocalPlaneDiagonal:
+                    return GetFocalPlaneDiagonalDescription();
+                case OlympusMakernoteDirectory.TagCameraType:
+                    return GetCameraTypeDescription();
                 case OlympusMakernoteDirectory.TagCameraId:
                     return GetCameraIdDescription();
+                case OlympusMakernoteDirectory.TagOneTouchWb:
+                    return GetOneTouchWbDescription();
+                case OlympusMakernoteDirectory.TagShutterSpeedValue:
+                    return GetShutterSpeedDescription();
+                case OlympusMakernoteDirectory.TagIsoValue:
+                    return GetIsoValueDescription();
+                case OlympusMakernoteDirectory.TagApertureValue:
+                    return GetApertureValueDescription();
                 case OlympusMakernoteDirectory.TagFlashMode:
                     return GetFlashModeDescription();
                 case OlympusMakernoteDirectory.TagFocusRange:
@@ -75,6 +88,18 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     return GetFocusModeDescription();
                 case OlympusMakernoteDirectory.TagSharpness:
                     return GetSharpnessDescription();
+                case OlympusMakernoteDirectory.TagColourMatrix:
+                    return GetColorMatrixDescription();
+                case OlympusMakernoteDirectory.TagWbMode:
+                    return GetWbModeDescription();
+                case OlympusMakernoteDirectory.TagRedBalance:
+                    return GetRedBalanceDescription();
+                case OlympusMakernoteDirectory.TagBlueBalance:
+                    return GetBlueBalanceDescription();
+                case OlympusMakernoteDirectory.TagContrast:
+                    return GetContrastDescription();
+                case OlympusMakernoteDirectory.TagPreviewImageValid:
+                    return GetPreviewImageValidDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagExposureMode:
                     return GetExposureModeDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagFlashMode:
@@ -98,7 +123,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 case OlympusMakernoteDirectory.CameraSettings.TagMacroMode:
                     return GetMacroModeCameraSettingDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagDigitalZoom:
-                    return GetDigitalZoomDescription();
+                    return GetDigitalZoomCameraSettingDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagExposureCompensation:
                     return GetExposureCompensationDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagBracketStep:
@@ -132,7 +157,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 case OlympusMakernoteDirectory.CameraSettings.TagSaturation:
                     return GetSaturationDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagContrast:
-                    return GetContrastDescription();
+                    return GetContrastCameraSettingDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagSharpness:
                     return GetSharpnessCameraSettingDescription();
                 case OlympusMakernoteDirectory.CameraSettings.TagSubjectProgram:
@@ -272,7 +297,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         }
 
         [CanBeNull]
-        public string GetDigitalZoomDescription()
+        public string GetDigitalZoomCameraSettingDescription()
         {
             return GetIndexedDescription(OlympusMakernoteDirectory.CameraSettings.TagDigitalZoom,
                 "Off", "Electronic magnification", "Digital zoom 2x");
@@ -451,7 +476,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         }
 
         [CanBeNull]
-        public string GetContrastDescription()
+        public string GetContrastCameraSettingDescription()
         {
             long value;
             return Directory.TryGetInt64(OlympusMakernoteDirectory.CameraSettings.TagContrast, out value)
@@ -623,6 +648,87 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         }
 
         [CanBeNull]
+        public string GetColorMatrixDescription()
+        {
+            var values = Directory.GetObject(OlympusMakernoteDirectory.TagColourMatrix) as short[];
+            if (values == null)
+                return null;
+
+            return string.Join(" ", values.Select(b => b.ToString()).ToArray());
+        }
+
+        [CanBeNull]
+        public string GetWbModeDescription()
+        {
+            var values = Directory.GetObject(OlympusMakernoteDirectory.TagWbMode) as short[];
+            if (values == null)
+                return null;
+
+            switch ($"{values[0]} {values[1]}".Trim())
+            {
+                case "1":
+                case "1 0":
+                    return "Auto";
+                case "1 2":
+                    return "Auto (2)";
+                case "1 4":
+                    return "Auto (4)";
+                case "2 2":
+                    return "3000 Kelvin";
+                case "2 3":
+                    return "3700 Kelvin";
+                case "2 4":
+                    return "4000 Kelvin";
+                case "2 5":
+                    return "4500 Kelvin";
+                case "2 6":
+                    return "5500 Kelvin";
+                case "2 7":
+                    return "6500 Kelvin";
+                case "2 8":
+                    return "7500 Kelvin";
+                case "3 0":
+                    return "One-touch";
+                default:
+                    return $"Unknown ({values[0]} {values[1]})";
+            }
+        }
+
+        [CanBeNull]
+        public string GetRedBalanceDescription()
+        {
+            var values = Directory.GetObject(OlympusMakernoteDirectory.TagRedBalance) as ushort[];
+            if (values == null || values.Length < 2)
+                return null;
+
+            return (values[0] / 256.0d).ToString();
+        }
+
+        [CanBeNull]
+        public string GetBlueBalanceDescription()
+        {
+            var values = Directory.GetObject(OlympusMakernoteDirectory.TagBlueBalance) as ushort[];
+            if (values == null || values.Length < 2)
+                return null;
+
+            return (values[0] / 256.0d).ToString();
+        }
+
+        [CanBeNull]
+        public string GetContrastDescription()
+        {
+            return GetIndexedDescription(OlympusMakernoteDirectory.TagContrast,
+                "High", "Normal", "Low");
+        }
+
+        [CanBeNull]
+        public string GetPreviewImageValidDescription()
+        {
+            return GetIndexedDescription(OlympusMakernoteDirectory.TagPreviewImageValid,
+                "No", "Yes");
+        }
+
+        [CanBeNull]
         public string GetFocusModeDescription()
         {
             return GetIndexedDescription(OlympusMakernoteDirectory.TagFocusMode,
@@ -644,10 +750,34 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         }
 
         [CanBeNull]
-        public string GetDigiZoomRatioDescription()
+        public string GetDigitalZoomDescription()
         {
-            return GetIndexedDescription(OlympusMakernoteDirectory.TagDigiZoomRatio,
-                "Normal", null, "Digital 2x Zoom");
+            Rational value;
+            if (!Directory.TryGetRational(OlympusMakernoteDirectory.TagDigitalZoom, out value))
+                return null;
+            return value.ToSimpleString(allowDecimal: false);
+        }
+
+        [CanBeNull]
+        public string GetFocalPlaneDiagonalDescription()
+        {
+            Rational value;
+            if (!Directory.TryGetRational(OlympusMakernoteDirectory.TagFocalPlaneDiagonal, out value))
+                return null;
+            return value.ToDouble().ToString("0.###") + " mm";
+        }
+
+        [CanBeNull]
+        public string GetCameraTypeDescription()
+        {
+            var cameratype = Directory.GetString(OlympusMakernoteDirectory.TagCameraType);
+            if (cameratype == null)
+                return null;
+
+            if(OlympusMakernoteDirectory.OlympusCameraTypes.ContainsKey(cameratype))
+                return OlympusMakernoteDirectory.OlympusCameraTypes[cameratype];
+
+            return cameratype;
         }
 
         [CanBeNull]
@@ -656,7 +786,40 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             var bytes = Directory.GetByteArray(OlympusMakernoteDirectory.TagCameraId);
             if (bytes == null)
                 return null;
+
             return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+        }
+
+        [CanBeNull]
+        public string GetOneTouchWbDescription()
+        {
+            return GetIndexedDescription(OlympusMakernoteDirectory.TagOneTouchWb,
+                "Off", "On", "On (Preset)");
+        }
+
+        [CanBeNull]
+        public string GetShutterSpeedDescription()
+        {
+            return GetShutterSpeedDescription(OlympusMakernoteDirectory.TagShutterSpeedValue);
+        }
+
+        [CanBeNull]
+        public string GetIsoValueDescription()
+        {
+            Rational value;
+            if (!Directory.TryGetRational(OlympusMakernoteDirectory.TagIsoValue, out value))
+                return null;
+
+            return Math.Round(Math.Pow(2, value.ToDouble() - 5) * 100, 0).ToString();
+        }
+
+        [CanBeNull]
+        public string GetApertureValueDescription()
+        {
+            double aperture;
+            if (!Directory.TryGetDouble(OlympusMakernoteDirectory.TagApertureValue, out aperture))
+                return null;
+            return GetFStopDescription(PhotographicConversions.ApertureToFStop(aperture));
         }
 
         [CanBeNull]
@@ -676,9 +839,58 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         [CanBeNull]
         public string GetJpegQualityDescription()
         {
-            return GetIndexedDescription(OlympusMakernoteDirectory.TagJpegQuality,
-                1,
-                "Standard Quality", "High Quality", "Super High Quality");
+            string cameratype = Directory.GetString(OlympusMakernoteDirectory.TagCameraType);
+
+            if(cameratype != null)
+            {
+                int value;
+                if (!Directory.TryGetInt32(OlympusMakernoteDirectory.TagJpegQuality, out value))
+                    return null;
+
+                if ((cameratype.StartsWith("SX", StringComparison.OrdinalIgnoreCase) && !cameratype.StartsWith("SX151", StringComparison.OrdinalIgnoreCase))
+                    || cameratype.StartsWith("D4322", StringComparison.OrdinalIgnoreCase))
+                {
+                    switch (value)
+                    {
+                        case 0:
+                            return "Standard Quality (Low)";
+                        case 1:
+                            return "High Quality (Normal)";
+                        case 2:
+                            return "Super High Quality (Fine)";
+                        case 6:
+                            return "RAW";
+                        default:
+                            return "Unknown (" + value + ")";
+                    }
+                }
+                else
+                {
+                    switch (value)
+                    {
+                        case 0:
+                            return "Standard Quality (Low)";
+                        case 1:
+                            return "High Quality (Normal)";
+                        case 2:
+                            return "Super High Quality (Fine)";
+                        case 4:
+                            return "RAW";
+                        case 5:
+                            return "Medium-Fine";
+                        case 6:
+                            return "Small-Fine";
+                        case 33:
+                            return "Uncompressed";
+                        default:
+                            return "Unknown (" + value + ")";
+                    }
+                }
+            }
+            else
+                return GetIndexedDescription(OlympusMakernoteDirectory.TagJpegQuality,
+                    1,
+                    "Standard Quality", "High Quality", "Super High Quality");
         }
 
         [CanBeNull]

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
@@ -126,12 +126,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         /// <summary>0 = Off, 1 = On</summary>
         public const int TagBwMode = 0x0203;
 
-        /// <summary>Zoom Factor (0 or 1 = normal)</summary>
-        public const int TagDigiZoomRatio = 0x0204;
+        ///// <summary>Zoom Factor (0 or 1 = normal)</summary>
+        public const int TagDigitalZoom = 0x0204;
 
         public const int TagFocalPlaneDiagonal = 0x0205;
         public const int TagLensDistortionParameters = 0x0206;
-        public const int TagFirmwareVersion = 0x0207;
+        public const int TagCameraType = 0x0207;
         public const int TagPictInfo = 0x0208;
         public const int TagCameraId = 0x0209;
 
@@ -188,12 +188,28 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagFlashChargeLevel = 0x1010;
         public const int TagColourMatrix = 0x1011;
         public const int TagBlackLevel = 0x1012;
-        public const int TagWhiteBalance = 0x1015;
-        public const int TagRedBias = 0x1017;
-        public const int TagBlueBias = 0x1018;
+
+        public const int TagColorTemperatureBG = 0x1013;
+        public const int TagColorTemperatureRG = 0x1014;
+        public const int TagWbMode = 0x1015;
+
+        public const int TagRedBalance = 0x1017;
+        public const int TagBlueBalance = 0x1018;
         public const int TagColorMatrixNumber = 0x1019;
         public const int TagSerialNumber2 = 0x101A;
+
+        public const int TagExternalFlashAE1_0 = 0x101B;
+        public const int TagExternalFlashAE2_0 = 0x101C;
+        public const int TagInternalFlashAE1_0 = 0x101D;
+        public const int TagInternalFlashAE2_0 = 0x101E;
+        public const int TagExternalFlashAE1 = 0x101F;
+        public const int TagExternalFlashAE2 = 0x1020;
+        public const int TagInternalFlashAE1 = 0x1021;
+        public const int TagInternalFlashAE2 = 0x1022;
+
         public const int TagFlashBias = 0x1023;
+        public const int TagInternalFlashTable = 0x1024;
+        public const int TagExternalFlashGValue = 0x1025;
         public const int TagExternalFlashBounce = 0x1026;
         public const int TagExternalFlashZoom = 0x1027;
         public const int TagExternalFlashMode = 0x1028;
@@ -202,16 +218,23 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagColourControl = 0x102B;
         public const int TagValidBits = 0x102C;
         public const int TagCoringFilter = 0x102D;
-        public const int TagFinalWidth = 0x102E;
-        public const int TagFinalHeight = 0x102F;
+        public const int TagOlympusImageWidth = 0x102E;
+        public const int TagOlympusImageHeight = 0x102F;
+        public const int TagSceneDetect = 0x1030;
+        public const int TagSceneArea = 0x1031;
+        public const int TagSceneDetectData = 0x1033;
         public const int TagCompressionRatio = 0x1034;
-        public const int TagThumbnail = 0x1035;
-        public const int TagThumbnailOffset = 0x1036;
-        public const int TagThumbnailLength = 0x1037;
+        public const int TagPreviewImageValid = 0x1035;
+        public const int TagPreviewImageStart = 0x1036;
+        public const int TagPreviewImageLength = 0x1037;
+        public const int TagAfResult = 0x1038;
         public const int TagCcdScanMode = 0x1039;
         public const int TagNoiseReduction = 0x103A;
         public const int TagInfinityLensStep = 0x103B;
         public const int TagNearLensStep = 0x103C;
+        public const int TagLightValueCenter = 0x103D;
+        public const int TagLightValuePeriphery = 0x103E;
+        public const int TagFieldCount = 0x103F;
         public const int TagEquipment = 0x2010;
         public const int TagCameraSettings = 0x2020;
         public const int TagRawDevelopment = 0x2030;
@@ -296,10 +319,10 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagJpegQuality, "JPEG Quality" },
             { TagMacroMode, "Macro" },
             { TagBwMode, "BW Mode" },
-            { TagDigiZoomRatio, "DigiZoom Ratio" },
+            { TagDigitalZoom, "Digital Zoom" },
             { TagFocalPlaneDiagonal, "Focal Plane Diagonal" },
             { TagLensDistortionParameters, "Lens Distortion Parameters" },
-            { TagFirmwareVersion, "Firmware Version" },
+            { TagCameraType, "Camera Type" },
             { TagPictInfo, "Pict Info" },
             { TagCameraId, "Camera Id" },
             { TagImageWidth, "Image Width" },
@@ -336,12 +359,24 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagFlashChargeLevel, "Flash Charge Level" },
             { TagColourMatrix, "Colour Matrix" },
             { TagBlackLevel, "Black Level" },
-            { TagWhiteBalance, "White Balance" },
-            { TagRedBias, "Red Bias" },
-            { TagBlueBias, "Blue Bias" },
+            { TagColorTemperatureBG, "Color Temperature BG" },
+            { TagColorTemperatureRG, "Color Temperature RG" },
+            { TagWbMode, "White Balance Mode" },
+            { TagRedBalance, "Red Balance" },
+            { TagBlueBalance, "Blue Balance" },
             { TagColorMatrixNumber, "Color Matrix Number" },
             { TagSerialNumber2, "Serial Number" },
+            { TagExternalFlashAE1_0, "External Flash AE1 0" },
+            { TagExternalFlashAE2_0, "External Flash AE2 0" },
+            { TagInternalFlashAE1_0, "Internal Flash AE1 0" },
+            { TagInternalFlashAE2_0, "Internal Flash AE2 0" },
+            { TagExternalFlashAE1, "External Flash AE1" },
+            { TagExternalFlashAE2, "External Flash AE2" },
+            { TagInternalFlashAE1, "Internal Flash AE1" },
+            { TagInternalFlashAE2, "Internal Flash AE2" },
             { TagFlashBias, "Flash Bias" },
+            { TagInternalFlashTable, "Internal Flash Table" },
+            { TagExternalFlashGValue, "External Flash G Value" },
             { TagExternalFlashBounce, "External Flash Bounce" },
             { TagExternalFlashZoom, "External Flash Zoom" },
             { TagExternalFlashMode, "External Flash Mode" },
@@ -350,16 +385,24 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagColourControl, "Colour Control" },
             { TagValidBits, "Valid Bits" },
             { TagCoringFilter, "Coring Filter" },
-            { TagFinalWidth, "Final Width" },
-            { TagFinalHeight, "Final Height" },
+            { TagOlympusImageWidth, "Olympus Image Width" },
+            { TagOlympusImageHeight, "Olympus Image Height" },
+            { TagSceneDetect, "Scene Detect" },
+            { TagSceneArea, "Scene Area" },
+            { TagSceneDetectData, "Scene Detect Data" },
             { TagCompressionRatio, "Compression Ratio" },
-            { TagThumbnail, "Thumbnail" },
-            { TagThumbnailOffset, "Thumbnail Offset" },
-            { TagThumbnailLength, "Thumbnail Length" },
+            { TagPreviewImageValid, "Preview Image Valid" },
+            { TagPreviewImageStart, "Preview Image Start" },
+            { TagPreviewImageLength, "Preview Image Length" },
+            { TagAfResult, "AF Result" },
             { TagCcdScanMode, "CCD Scan Mode" },
             { TagNoiseReduction, "Noise Reduction" },
             { TagInfinityLensStep, "Infinity Lens Step" },
             { TagNearLensStep, "Near Lens Step" },
+            { TagLightValueCenter, "Light Value Center" },
+            { TagLightValuePeriphery, "Light Value Periphery" },
+            { TagFieldCount, "Field Count" },
+
             { TagEquipment, "Equipment" },
             { TagCameraSettings, "Camera Settings" },
             { TagRawDevelopment, "Raw Development" },
@@ -453,5 +496,335 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         {
             return _tagNameMap.TryGetValue(tagType, out tagName);
         }
+
+        /// <summary>
+        /// These values are currently decoded only for Olympus models.  Models with
+        /// Olympus-style maker notes from other brands such as Acer, BenQ, Hitachi, HP,
+        /// Premier, Konica-Minolta, Maginon, Ricoh, Rollei, SeaLife, Sony, Supra,
+        /// Vivitar are not listed.
+        /// </summary>
+        /// <remarks>
+        /// Converted from Exiftool version 10.33 created by Phil Harvey
+        /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+        /// lib\Image\ExifTool\Olympus.pm
+        /// </remarks>
+        public static readonly Dictionary<string, string> OlympusCameraTypes = new Dictionary<string, string>
+        {
+            { "D4028", "X-2,C-50Z" },
+            { "D4029", "E-20,E-20N,E-20P" },
+            { "D4034", "C720UZ" },
+            { "D4040", "E-1" },
+            { "D4041", "E-300" },
+            { "D4083", "C2Z,D520Z,C220Z" },
+            { "D4106", "u20D,S400D,u400D" },
+            { "D4120", "X-1" },
+            { "D4122", "u10D,S300D,u300D" },
+            { "D4125", "AZ-1" },
+            { "D4141", "C150,D390" },
+            { "D4193", "C-5000Z" },
+            { "D4194", "X-3,C-60Z" },
+            { "D4199", "u30D,S410D,u410D" },
+            { "D4205", "X450,D535Z,C370Z" },
+            { "D4210", "C160,D395" },
+            { "D4211", "C725UZ" },
+            { "D4213", "FerrariMODEL2003" },
+            { "D4216", "u15D" },
+            { "D4217", "u25D" },
+            { "D4220", "u-miniD,Stylus V" },
+            { "D4221", "u40D,S500,uD500" },
+            { "D4231", "FerrariMODEL2004" },
+            { "D4240", "X500,D590Z,C470Z" },
+            { "D4244", "uD800,S800" },
+            { "D4256", "u720SW,S720SW" },
+            { "D4261", "X600,D630,FE5500" },
+            { "D4262", "uD600,S600" },
+            { "D4301", "u810/S810" }, // (yes, "/".  Olympus is not consistent in the notation)
+            { "D4302", "u710,S710" },
+            { "D4303", "u700,S700" },
+            { "D4304", "FE100,X710" },
+            { "D4305", "FE110,X705" },
+            { "D4310", "FE-130,X-720" },
+            { "D4311", "FE-140,X-725" },
+            { "D4312", "FE150,X730" },
+            { "D4313", "FE160,X735" },
+            { "D4314", "u740,S740" },
+            { "D4315", "u750,S750" },
+            { "D4316", "u730/S730" },
+            { "D4317", "FE115,X715" },
+            { "D4321", "SP550UZ" },
+            { "D4322", "SP510UZ" },
+            { "D4324", "FE170,X760" },
+            { "D4326", "FE200" },
+            { "D4327", "FE190/X750" }, // (also SX876)
+            { "D4328", "u760,S760" },
+            { "D4330", "FE180/X745" }, // (also SX875)
+            { "D4331", "u1000/S1000" },
+            { "D4332", "u770SW,S770SW" },
+            { "D4333", "FE240/X795" },
+            { "D4334", "FE210,X775" },
+            { "D4336", "FE230/X790" },
+            { "D4337", "FE220,X785" },
+            { "D4338", "u725SW,S725SW" },
+            { "D4339", "FE250/X800" },
+            { "D4341", "u780,S780" },
+            { "D4343", "u790SW,S790SW" },
+            { "D4344", "u1020,S1020" },
+            { "D4346", "FE15,X10" },
+            { "D4348", "FE280,X820,C520" },
+            { "D4349", "FE300,X830" },
+            { "D4350", "u820,S820" },
+            { "D4351", "u1200,S1200" },
+            { "D4352", "FE270,X815,C510" },
+            { "D4353", "u795SW,S795SW" },
+            { "D4354", "u1030SW,S1030SW" },
+            { "D4355", "SP560UZ" },
+            { "D4356", "u1010,S1010" },
+            { "D4357", "u830,S830" },
+            { "D4359", "u840,S840" },
+            { "D4360", "FE350WIDE,X865" },
+            { "D4361", "u850SW,S850SW" },
+            { "D4362", "FE340,X855,C560" },
+            { "D4363", "FE320,X835,C540" },
+            { "D4364", "SP570UZ" },
+            { "D4366", "FE330,X845,C550" },
+            { "D4368", "FE310,X840,C530" },
+            { "D4370", "u1050SW,S1050SW" },
+            { "D4371", "u1060,S1060" },
+            { "D4372", "FE370,X880,C575" },
+            { "D4374", "SP565UZ" },
+            { "D4377", "u1040,S1040" },
+            { "D4378", "FE360,X875,C570" },
+            { "D4379", "FE20,X15,C25" },
+            { "D4380", "uT6000,ST6000" },
+            { "D4381", "uT8000,ST8000" },
+            { "D4382", "u9000,S9000" },
+            { "D4384", "SP590UZ" },
+            { "D4385", "FE3010,X895" },
+            { "D4386", "FE3000,X890" },
+            { "D4387", "FE35,X30" },
+            { "D4388", "u550WP,S550WP" },
+            { "D4390", "FE5000,X905" },
+            { "D4391", "u5000" },
+            { "D4392", "u7000,S7000" },
+            { "D4396", "FE5010,X915" },
+            { "D4397", "FE25,X20" },
+            { "D4398", "FE45,X40" },
+            { "D4401", "XZ-1" },
+            { "D4402", "uT6010,ST6010" },
+            { "D4406", "u7010,S7010 / u7020,S7020" },
+            { "D4407", "FE4010,X930" },
+            { "D4408", "X560WP" },
+            { "D4409", "FE26,X21" },
+            { "D4410", "FE4000,X920,X925" },
+            { "D4411", "FE46,X41,X42" },
+            { "D4412", "FE5020,X935" },
+            { "D4413", "uTough-3000" },
+            { "D4414", "StylusTough-6020" },
+            { "D4415", "StylusTough-8010" },
+            { "D4417", "u5010,S5010" },
+            { "D4418", "u7040,S7040" },
+            { "D4419", "u9010,S9010" },
+            { "D4423", "FE4040" },
+            { "D4424", "FE47,X43" },
+            { "D4426", "FE4030,X950" },
+            { "D4428", "FE5030,X965,X960" },
+            { "D4430", "u7030,S7030" },
+            { "D4432", "SP600UZ" },
+            { "D4434", "SP800UZ" },
+            { "D4439", "FE4020,X940" },
+            { "D4442", "FE5035" },
+            { "D4448", "FE4050,X970" },
+            { "D4450", "FE5050,X985" },
+            { "D4454", "u-7050" },
+            { "D4464", "T10,X27" },
+            { "D4470", "FE5040,X980" },
+            { "D4472", "TG-310" },
+            { "D4474", "TG-610" },
+            { "D4476", "TG-810" },
+            { "D4478", "VG145,VG140,D715" },
+            { "D4479", "VG130,D710" },
+            { "D4480", "VG120,D705" },
+            { "D4482", "VR310,D720" },
+            { "D4484", "VR320,D725" },
+            { "D4486", "VR330,D730" },
+            { "D4488", "VG110,D700" },
+            { "D4490", "SP-610UZ" },
+            { "D4492", "SZ-10" },
+            { "D4494", "SZ-20" },
+            { "D4496", "SZ-30MR" },
+            { "D4498", "SP-810UZ" },
+            { "D4500", "SZ-11" },
+            { "D4504", "TG-615" },
+            { "D4508", "TG-620" },
+            { "D4510", "TG-820" },
+            { "D4512", "TG-1" },
+            { "D4516", "SH-21" },
+            { "D4519", "SZ-14" },
+            { "D4520", "SZ-31MR" },
+            { "D4521", "SH-25MR" },
+            { "D4523", "SP-720UZ" },
+            { "D4529", "VG170" },
+            { "D4531", "XZ-2" },
+            { "D4535", "SP-620UZ" },
+            { "D4536", "TG-320" },
+            { "D4537", "VR340,D750" },
+            { "D4538", "VG160,X990,D745" },
+            { "D4541", "SZ-12" },
+            { "D4545", "VH410" },
+            { "D4546", "XZ-10" }, //IB
+            { "D4547", "TG-2" },
+            { "D4548", "TG-830" },
+            { "D4549", "TG-630" },
+            { "D4550", "SH-50" },
+            { "D4553", "SZ-16,DZ-105" },
+            { "D4562", "SP-820UZ" },
+            { "D4566", "SZ-15" },
+            { "D4572", "STYLUS1" },
+            { "D4574", "TG-3" },
+            { "D4575", "TG-850" },
+            { "D4579", "SP-100EE" },
+            { "D4580", "SH-60" },
+            { "D4581", "SH-1" },
+            { "D4582", "TG-835" },
+            { "D4585", "SH-2 / SH-3" },
+            { "D4586", "TG-4" },
+            { "D4587", "TG-860" },
+            { "D4591", "TG-870" },
+            { "D4809", "C2500L" },
+            { "D4842", "E-10" },
+            { "D4856", "C-1" },
+            { "D4857", "C-1Z,D-150Z" },
+            { "DCHC", "D500L" },
+            { "DCHT", "D600L / D620L" },
+            { "K0055", "AIR-A01" },
+            { "S0003", "E-330" },
+            { "S0004", "E-500" },
+            { "S0009", "E-400" },
+            { "S0010", "E-510" },
+            { "S0011", "E-3" },
+            { "S0013", "E-410" },
+            { "S0016", "E-420" },
+            { "S0017", "E-30" },
+            { "S0018", "E-520" },
+            { "S0019", "E-P1" },
+            { "S0023", "E-620" },
+            { "S0026", "E-P2" },
+            { "S0027", "E-PL1" },
+            { "S0029", "E-450" },
+            { "S0030", "E-600" },
+            { "S0032", "E-P3" },
+            { "S0033", "E-5" },
+            { "S0034", "E-PL2" },
+            { "S0036", "E-M5" },
+            { "S0038", "E-PL3" },
+            { "S0039", "E-PM1" },
+            { "S0040", "E-PL1s" },
+            { "S0042", "E-PL5" },
+            { "S0043", "E-PM2" },
+            { "S0044", "E-P5" },
+            { "S0045", "E-PL6" },
+            { "S0046", "E-PL7" }, //IB
+            { "S0047", "E-M1" },
+            { "S0051", "E-M10" },
+            { "S0052", "E-M5MarkII" }, //IB
+            { "S0059", "E-M10MarkII" },
+            { "S0061", "PEN-F" }, //forum7005
+            { "S0065", "E-PL8" },
+            { "S0067", "E-M1MarkII" },
+            { "SR45", "D220" },
+            { "SR55", "D320L" },
+            { "SR83", "D340L" },
+            { "SR85", "C830L,D340R" },
+            { "SR852", "C860L,D360L" },
+            { "SR872", "C900Z,D400Z" },
+            { "SR874", "C960Z,D460Z" },
+            { "SR951", "C2000Z" },
+            { "SR952", "C21" },
+            { "SR953", "C21T.commu" },
+            { "SR954", "C2020Z" },
+            { "SR955", "C990Z,D490Z" },
+            { "SR956", "C211Z" },
+            { "SR959", "C990ZS,D490Z" },
+            { "SR95A", "C2100UZ" },
+            { "SR971", "C100,D370" },
+            { "SR973", "C2,D230" },
+            { "SX151", "E100RS" },
+            { "SX351", "C3000Z / C3030Z" },
+            { "SX354", "C3040Z" },
+            { "SX355", "C2040Z" },
+            { "SX357", "C700UZ" },
+            { "SX358", "C200Z,D510Z" },
+            { "SX374", "C3100Z,C3020Z" },
+            { "SX552", "C4040Z" },
+            { "SX553", "C40Z,D40Z" },
+            { "SX556", "C730UZ" },
+            { "SX558", "C5050Z" },
+            { "SX571", "C120,D380" },
+            { "SX574", "C300Z,D550Z" },
+            { "SX575", "C4100Z,C4000Z" },
+            { "SX751", "X200,D560Z,C350Z" },
+            { "SX752", "X300,D565Z,C450Z" },
+            { "SX753", "C750UZ" },
+            { "SX754", "C740UZ" },
+            { "SX755", "C755UZ" },
+            { "SX756", "C5060WZ" },
+            { "SX757", "C8080WZ" },
+            { "SX758", "X350,D575Z,C360Z" },
+            { "SX759", "X400,D580Z,C460Z" },
+            { "SX75A", "AZ-2ZOOM" },
+            { "SX75B", "D595Z,C500Z" },
+            { "SX75C", "X550,D545Z,C480Z" },
+            { "SX75D", "IR-300" },
+            { "SX75F", "C55Z,C5500Z" },
+            { "SX75G", "C170,D425" },
+            { "SX75J", "C180,D435" },
+            { "SX771", "C760UZ" },
+            { "SX772", "C770UZ" },
+            { "SX773", "C745UZ" },
+            { "SX774", "X250,D560Z,C350Z" },
+            { "SX775", "X100,D540Z,C310Z" },
+            { "SX776", "C460ZdelSol" },
+            { "SX777", "C765UZ" },
+            { "SX77A", "D555Z,C315Z" },
+            { "SX851", "C7070WZ" },
+            { "SX852", "C70Z,C7000Z" },
+            { "SX853", "SP500UZ" },
+            { "SX854", "SP310" },
+            { "SX855", "SP350" },
+            { "SX873", "SP320" },
+            { "SX875", "FE180/X745" }, // (also D4330)
+            { "SX876", "FE190/X750" } // (also D4327)
+
+            //   other brands
+            //    4MP9Q3", "Camera 4MP-9Q3'
+            //    4MP9T2", "BenQ DC C420 / Camera 4MP-9T2'
+            //    5MP9Q3", "Camera 5MP-9Q3" },
+            //    5MP9X9", "Camera 5MP-9X9" },
+            //   '5MP-9T'=> 'Camera 5MP-9T3" },
+            //   '5MP-9Y'=> 'Camera 5MP-9Y2" },
+            //   '6MP-9U'=> 'Camera 6MP-9U9" },
+            //    7MP9Q3", "Camera 7MP-9Q3" },
+            //   '8MP-9U'=> 'Camera 8MP-9U4" },
+            //    CE5330", "Acer CE-5330" },
+            //   'CP-853'=> 'Acer CP-8531" },
+            //    CS5531", "Acer CS5531" },
+            //    DC500 ", "SeaLife DC500" },
+            //    DC7370", "Camera 7MP-9GA" },
+            //    DC7371", "Camera 7MP-9GM" },
+            //    DC7371", "Hitachi HDC-751E" },
+            //    DC7375", "Hitachi HDC-763E / Rollei RCP-7330X / Ricoh Caplio RR770 / Vivitar ViviCam 7330" },
+            //   'DC E63'=> 'BenQ DC E63+" },
+            //   'DC P86'=> 'BenQ DC P860" },
+            //    DS5340", "Maginon Performic S5 / Premier 5MP-9M7" },
+            //    DS5341", "BenQ E53+ / Supra TCM X50 / Maginon X50 / Premier 5MP-9P8" },
+            //    DS5346", "Premier 5MP-9Q2" },
+            //    E500  ", "Konica Minolta DiMAGE E500" },
+            //    MAGINO", "Maginon X60" },
+            //    Mz60  ", "HP Photosmart Mz60" },
+            //    Q3DIGI", "Camera 5MP-9Q3" },
+            //    SLIMLI", "Supra Slimline X6" },
+            //    V8300s", "Vivitar V8300s" },
+        };
+
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDescriptor.cs
@@ -1,0 +1,129 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+using JetBrains.Annotations;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>
+    /// Provides human-readable string representations of tag values stored in a <see cref="OlympusRawInfoMakernoteDirectory"/>.
+    /// </summary>
+    /// <remarks>
+    /// Some Description functions converted from Exiftool version 10.33 created by Phil Harvey
+    /// http://www.sno.phy.queensu.ca/~phil/exiftool/
+    /// lib\Image\ExifTool\Olympus.pm
+    /// </remarks>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class OlympusRawInfoMakernoteDescriptor : TagDescriptor<OlympusRawInfoMakernoteDirectory>
+    {
+        public OlympusRawInfoMakernoteDescriptor([NotNull] OlympusRawInfoMakernoteDirectory directory)
+            : base(directory)
+        {
+        }
+
+        public override string GetDescription(int tagType)
+        {
+            switch (tagType)
+            {
+                case OlympusRawInfoMakernoteDirectory.TagRawInfoVersion:
+                    return GetVersionBytesDescription(OlympusRawInfoMakernoteDirectory.TagRawInfoVersion, 4);
+                case OlympusRawInfoMakernoteDirectory.TagColorMatrix2:
+                    return GetColorMatrix2Description();
+                case OlympusRawInfoMakernoteDirectory.TagYCbCrCoefficients:
+                    return GetYCbCrCoefficientsDescription();
+                case OlympusRawInfoMakernoteDirectory.TagLightSource:
+                    return GetOlympusLightSourceDescription();
+                default:
+                    return base.GetDescription(tagType);
+            }
+        }
+
+        [CanBeNull]
+        public string GetColorMatrix2Description()
+        {
+            var values = Directory.GetObject(OlympusRawInfoMakernoteDirectory.TagColorMatrix2) as short[];
+            if (values == null)
+                return null;
+
+            return string.Join(" ", values.Select(b => b.ToString()).ToArray());
+        }
+
+        [CanBeNull]
+        public string GetYCbCrCoefficientsDescription()
+        {
+            ushort[] values = Directory.GetObject(OlympusRawInfoMakernoteDirectory.TagYCbCrCoefficients) as ushort[];
+            if (values == null)
+                return null;
+
+            var ret = new Rational[values.Length / 2];
+            for(int i = 0; i < values.Length / 2; i++)
+            {
+                ret[i] = new Rational(values[2*i], values[2*i + 1]);
+            }
+
+            return string.Join(" ", ret.Select(r => r.ToDecimal().ToString()).ToArray());
+        }
+
+        [CanBeNull]
+        public string GetOlympusLightSourceDescription()
+        {
+            ushort value;
+            if (!Directory.TryGetUInt16(OlympusRawInfoMakernoteDirectory.TagLightSource, out value))
+                return null;
+
+            switch (value)
+            {
+                case 0:
+                    return "Unknown";
+                case 16:
+                    return "Shade";
+                case 17:
+                    return "Cloudy";
+                case 18:
+                    return "Fine Weather";
+                case 20:
+                    return "Tungsten (Incandescent)";
+                case 22:
+                    return "Evening Sunlight";
+                case 33:
+                    return "Daylight Fluorescent";
+                case 34:
+                    return "Day White Fluorescent";
+                case 35:
+                    return "Cool White Fluorescent";
+                case 36:
+                    return "White Fluorescent";
+                case 256:
+                    return "One Touch White Balance";
+                case 512:
+                    return "Custom 1-4";
+                default:
+                    return "Unknown (" + value + ")";
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDirectory.cs
@@ -1,0 +1,134 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>
+    /// These tags are found only in ORF images of some models (eg. C8080WZ)
+    /// </summary>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class OlympusRawInfoMakernoteDirectory : Directory
+    {
+        public const int TagRawInfoVersion = 0x0000;
+        public const int TagWbRbLevelsUsed = 0x0100;
+        public const int TagWbRbLevelsAuto = 0x0110;
+        public const int TagWbRbLevelsShade = 0x0120;
+        public const int TagWbRbLevelsCloudy = 0x0121;
+        public const int TagWbRbLevelsFineWeather = 0x0122;
+        public const int TagWbRbLevelsTungsten = 0x0123;
+        public const int TagWbRbLevelsEveningSunlight = 0x0124;
+        public const int TagWbRbLevelsDaylightFluor = 0x0130;
+        public const int TagWbRbLevelsDayWhiteFluor = 0x0131;
+        public const int TagWbRbLevelsCoolWhiteFluor = 0x0132;
+        public const int TagWbRbLevelsWhiteFluorescent = 0x0133;
+
+        public const int TagColorMatrix2 = 0x0200;
+        public const int TagCoringFilter = 0x0310;
+        public const int TagCoringValues = 0x0311;
+        public const int TagBlackLevel2 = 0x0600;
+        public const int TagYCbCrCoefficients = 0x0601;
+        public const int TagValidPixelDepth = 0x0611;
+        public const int TagCropLeft = 0x0612;
+        public const int TagCropTop = 0x0613;
+        public const int TagCropWidth = 0x0614;
+        public const int TagCropHeight = 0x0615;
+
+        public const int TagLightSource = 0x1000;
+
+        //the following 5 tags all have 3 values: val, min, max
+        public const int TagWhiteBalanceComp = 0x1001;
+        public const int TagSaturationSetting = 0x1010;
+        public const int TagHueSetting = 0x1011;
+        public const int TagContrastSetting = 0x1012;
+        public const int TagSharpnessSetting = 0x1013;
+
+        // settings written by Camedia Master 4.x
+        public const int TagCmExposureCompensation = 0x2000;
+        public const int TagCmWhiteBalance = 0x2001;
+        public const int TagCmWhiteBalanceComp = 0x2002;
+        public const int TagCmWhiteBalanceGrayPoint = 0x2010;
+        public const int TagCmSaturation = 0x2020;
+        public const int TagCmHue = 0x2021;
+        public const int TagCmContrast = 0x2022;
+        public const int TagCmSharpness = 0x2023;
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        {
+            { TagRawInfoVersion, "Raw Info Version" },
+            { TagWbRbLevelsUsed, "WB RB Levels Used" },
+            { TagWbRbLevelsAuto, "WB RB Levels Auto" },
+            { TagWbRbLevelsShade, "WB RB Levels Shade" },
+            { TagWbRbLevelsCloudy, "WB RB Levels Cloudy" },
+            { TagWbRbLevelsFineWeather, "WB RB Levels Fine Weather" },
+            { TagWbRbLevelsTungsten, "WB RB Levels Tungsten" },
+            { TagWbRbLevelsEveningSunlight, "WB RB Levels Evening Sunlight" },
+            { TagWbRbLevelsDaylightFluor, "WB RB Levels Daylight Fluor" },
+            { TagWbRbLevelsDayWhiteFluor, "WB RB Levels Day White Fluor" },
+            { TagWbRbLevelsCoolWhiteFluor, "WB RB Levels Cool White Fluor" },
+            { TagWbRbLevelsWhiteFluorescent, "WB RB Levels White Fluorescent" },
+            { TagColorMatrix2, "Color Matrix 2" },
+            { TagCoringFilter, "Coring Filter" },
+            { TagCoringValues, "Coring Values" },
+            { TagBlackLevel2, "Black Level 2" },
+            { TagYCbCrCoefficients, "YCbCrCoefficients" },
+            { TagValidPixelDepth, "Valid Pixel Depth" },
+            { TagCropLeft, "Crop Left" },
+            { TagCropTop, "Crop Top" },
+            { TagCropWidth, "Crop Width" },
+            { TagCropHeight, "Crop Height" },
+            { TagLightSource, "Light Source" },
+
+            { TagWhiteBalanceComp, "White Balance Comp" },
+            { TagSaturationSetting, "Saturation Setting" },
+            { TagHueSetting, "Hue Setting" },
+            { TagContrastSetting, "Contrast Setting" },
+            { TagSharpnessSetting, "Sharpness Setting" },
+
+            { TagCmExposureCompensation, "CM Exposure Compensation" },
+            { TagCmWhiteBalance, "CM White Balance" },
+            { TagCmWhiteBalanceComp, "CM White Balance Comp" },
+            { TagCmWhiteBalanceGrayPoint, "CM White Balance Gray Point" },
+            { TagCmSaturation, "CM Saturation" },
+            { TagCmHue, "CM Hue" },
+            { TagCmContrast, "CM Contrast" },
+            { TagCmSharpness, "CM Sharpness" }
+        };
+
+        public OlympusRawInfoMakernoteDirectory()
+        {
+            SetDescriptor(new OlympusRawInfoMakernoteDescriptor(this));
+        }
+
+        public override string Name => "Olympus Raw Info";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
@@ -126,8 +126,6 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     return GetIntelligentResolutionDescription();
                 case PanasonicMakernoteDirectory.TagFaceRecognitionInfo:
                     return GetRecognizedFacesDescription();
-                case PanasonicMakernoteDirectory.TagPrintImageMatchingInfo:
-                    return GetPrintImageMatchingInfoDescription();
                 case PanasonicMakernoteDirectory.TagSceneMode:
                     return GetSceneModeDescription();
                 case PanasonicMakernoteDirectory.TagFlashFired:
@@ -199,12 +197,6 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 default:
                     return base.GetDescription(tagType);
             }
-        }
-
-        [CanBeNull]
-        public string GetPrintImageMatchingInfoDescription()
-        {
-            return GetByteLengthDescription(PanasonicMakernoteDirectory.TagPrintImageMatchingInfo);
         }
 
         [CanBeNull]

--- a/MetadataExtractor/Formats/Exif/makernotes/SanyoMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SanyoMakernoteDirectory.cs
@@ -87,7 +87,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagManualFocusDistanceOrFaceInfo, "Manual Focus Distance or Face Info" },
             { TagSequenceShotInterval, "Sequence Shot Interval" },
             { TagFlashMode, "Flash Mode" },
-            { TagPrintIm, "Print IM" },
+            { TagPrintIm, "Print Image Matching (PIM) Info" },
             { TagDataDump, "Data Dump" }
         };
 

--- a/MetadataExtractor/Formats/Exif/makernotes/SonyType1MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SonyType1MakernoteDirectory.cs
@@ -124,7 +124,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagCameraSettings, "Camera Settings" },
             { TagWhiteBalance, "White Balance" },
             { TagExtraInfo, "Extra Info" },
-            { TagPrintImageMatchingInfo, "Print Image Matching Info" },
+            { TagPrintImageMatchingInfo, "Print Image Matching (PIM) Info" },
             { TagMultiBurstMode, "Multi Burst Mode" },
             { TagMultiBurstImageWidth, "Multi Burst Image Width" },
             { TagMultiBurstImageHeight, "Multi Burst Image Height" },

--- a/MetadataExtractor/TagDescriptor.cs
+++ b/MetadataExtractor/TagDescriptor.cs
@@ -360,6 +360,36 @@ namespace MetadataExtractor
                 "Left side, bottom (Rotate 270 CW)");
         }
 
+        [CanBeNull]
+        public string GetShutterSpeedDescription(int tagId)
+        {
+            // I believe this method to now be stable, but am leaving some alternative snippets of
+            // code in here, to assist anyone who's looking into this (given that I don't have a public CVS).
+            //        float apexValue = _directory.getFloat(ExifSubIFDDirectory.TAG_SHUTTER_SPEED);
+            //        int apexPower = (int)Math.pow(2.0, apexValue);
+            //        return "1/" + apexPower + " sec";
+            // TODO test this method
+            // thanks to Mark Edwards for spotting and patching a bug in the calculation of this
+            // description (spotted bug using a Canon EOS 300D)
+            // thanks also to Gli Blr for spotting this bug
+            float apexValue;
+            if (!Directory.TryGetSingle(tagId, out apexValue))
+                return null;
+
+            if (apexValue <= 1)
+            {
+                var apexPower = (float)(1 / Math.Exp(apexValue * Math.Log(2)));
+                var apexPower10 = (long)Math.Round(apexPower * 10.0);
+                var fApexPower = apexPower10 / 10.0f;
+                return fApexPower + " sec";
+            }
+            else
+            {
+                var apexPower = (int)Math.Exp(apexValue * Math.Log(2));
+                return "1/" + apexPower + " sec";
+            }
+        }
+
         // EXIF LightSource
         [CanBeNull]
         public string GetLightSourceDescription(ushort wbtype)

--- a/MetadataExtractor/Util/FileTypeDetector.cs
+++ b/MetadataExtractor/Util/FileTypeDetector.cs
@@ -70,6 +70,7 @@ namespace MetadataExtractor.Util
             _root.AddPath(FileType.Cr2, Encoding.UTF8.GetBytes("II"), new byte[] { 0x2a, 0x00, 0x10, 0x00, 0x00, 0x00, 0x43, 0x52 });
             _root.AddPath(FileType.Nef, Encoding.UTF8.GetBytes("MM"), new byte[] { 0x00, 0x2a, 0x00, 0x00, 0x00, 0x80, 0x00 });
             _root.AddPath(FileType.Orf, Encoding.UTF8.GetBytes("IIRO"), new byte[] { 0x08, 0x00 });
+            _root.AddPath(FileType.Orf, Encoding.UTF8.GetBytes("MMOR"), new byte[] { 0x00, 0x00 });
             _root.AddPath(FileType.Orf, Encoding.UTF8.GetBytes("IIRS"), new byte[] { 0x08, 0x00 });
             _root.AddPath(FileType.Raf, Encoding.UTF8.GetBytes("FUJIFILMCCD-RAW"));
             _root.AddPath(FileType.Rw2, Encoding.UTF8.GetBytes("II"), new byte[] { 0x55, 0x00 });


### PR DESCRIPTION
- Higher coverage of Olympus tags and ifd's
- Added Olympus RawData ifd
- "MMOR" detected for ORF in FileTypeDetector
- PrintIM implemented for all directories containing the 0x0E00 tag
- As of 11/25/16, tested all Olympus RAW files from http://www.rawsamples.ch/index.php/en/olympus

Resolves #32 and amends drewnoakes/metadata-extractor#175

Let me know if you have any questions or problems.