### PR TITLE
support Reconyx UltraFire makernote

### DIFF
--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -32,6 +32,46 @@ namespace MetadataExtractor
     [SuppressMessage("ReSharper", "UnusedMember.Global")]
     public static class DirectoryExtensions
     {
+        #region Byte
+
+        /// <summary>Returns a tag's value as a <see cref="byte"/>, or throws if conversion is not possible.</summary>
+        /// <remarks>
+        /// If the value is <see cref="IConvertible"/>, then that interface is used for conversion of the value.
+        /// If the value is an array of <see cref="IConvertible"/> having length one, then the single item is converted.
+        /// </remarks>
+        /// <exception cref="MetadataException">No value exists for <paramref name="tagType"/>, or the value is not convertible to the requested type.</exception>
+        [Pure]
+        public static byte GetByte([NotNull] this Directory directory, int tagType)
+        {
+            byte value;
+            if (directory.TryGetByte(tagType, out value))
+                return value;
+
+            return ThrowValueNotPossible<byte>(directory, tagType);
+        }
+
+        [Pure]
+        public static bool TryGetByte([NotNull] this Directory directory, int tagType, out byte value)
+        {
+            var convertible = GetConvertibleObject(directory, tagType);
+
+            if (convertible != null)
+            {
+                try
+                {
+                    value = convertible.ToByte(null);
+                    return true;
+                }
+                catch
+                { }
+            }
+
+            value = default(byte);
+            return false;
+        }
+
+        #endregion
+
         #region Int16
 
         /// <summary>Returns a tag's value as a <see cref="short"/>, or throws if conversion is not possible.</summary>

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFireMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFireMakernoteDescriptor.cs
@@ -28,13 +28,13 @@ using JetBrains.Annotations;
 namespace MetadataExtractor.Formats.Exif.Makernotes
 {
     /// <summary>
-    /// Provides human-readable string representations of tag values stored in a <see cref="ReconyxMakernoteDirectory"/>.
+    /// Provides human-readable string representations of tag values stored in a <see cref="ReconyxHyperFireMakernoteDirectory"/>.
     /// </summary>
     /// <author>Todd West http://cascadescarnivoreproject.blogspot.com</author>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public sealed class ReconyxMakernoteDescriptor : TagDescriptor<ReconyxMakernoteDirectory>
+    public sealed class ReconyxHyperFireMakernoteDescriptor : TagDescriptor<ReconyxHyperFireMakernoteDirectory>
     {
-        public ReconyxMakernoteDescriptor([NotNull] ReconyxMakernoteDirectory directory)
+        public ReconyxHyperFireMakernoteDescriptor([NotNull] ReconyxHyperFireMakernoteDirectory directory)
             : base(directory)
         {
         }
@@ -43,39 +43,39 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         {
             switch (tagType)
             {
-                case ReconyxMakernoteDirectory.TagMakernoteVersion:
+                case ReconyxHyperFireMakernoteDirectory.TagMakernoteVersion:
                     return Directory.GetUInt16(tagType).ToString();
-                case ReconyxMakernoteDirectory.TagFirmwareVersion:
+                case ReconyxHyperFireMakernoteDirectory.TagFirmwareVersion:
                     // invokes Version.ToString()
                     return Directory.GetString(tagType);
-                case ReconyxMakernoteDirectory.TagTriggerMode:
+                case ReconyxHyperFireMakernoteDirectory.TagTriggerMode:
                     return Directory.GetString(tagType);
-                case ReconyxMakernoteDirectory.TagSequence:
+                case ReconyxHyperFireMakernoteDirectory.TagSequence:
                     int[] sequence = Directory.GetInt32Array(tagType);
                     return string.Format("{0}/{1}", sequence[0], sequence[1]);
-                case ReconyxMakernoteDirectory.TagEventNumber:
+                case ReconyxHyperFireMakernoteDirectory.TagEventNumber:
                     return Directory.GetUInt32(tagType).ToString();
-                case ReconyxMakernoteDirectory.TagMotionSensitivity:
+                case ReconyxHyperFireMakernoteDirectory.TagMotionSensitivity:
                     return Directory.GetUInt16(tagType).ToString();
-                case ReconyxMakernoteDirectory.TagBatteryVoltage:
+                case ReconyxHyperFireMakernoteDirectory.TagBatteryVoltage:
                     return Directory.GetDouble(tagType).ToString("0.000");
-                case ReconyxMakernoteDirectory.TagDateTimeOriginal:
+                case ReconyxHyperFireMakernoteDirectory.TagDateTimeOriginal:
                     return Directory.GetDateTime(tagType).ToString("yyyy:MM:dd HH:mm:ss");
-                case ReconyxMakernoteDirectory.TagMoonPhase:
+                case ReconyxHyperFireMakernoteDirectory.TagMoonPhase:
                     return GetIndexedDescription(tagType, "New", "Waxing Crescent", "First Quarter", "Waxing Gibbous", "Full", "Waning Gibbous", "Last Quarter", "Waning Crescent");
-                case ReconyxMakernoteDirectory.TagAmbientTemperatureFarenheit:
-                case ReconyxMakernoteDirectory.TagAmbientTemperature:
+                case ReconyxHyperFireMakernoteDirectory.TagAmbientTemperatureFahrenheit:
+                case ReconyxHyperFireMakernoteDirectory.TagAmbientTemperature:
                     return Directory.GetInt16(tagType).ToString();
-                case ReconyxMakernoteDirectory.TagSerialNumber:
+                case ReconyxHyperFireMakernoteDirectory.TagSerialNumber:
                     return Directory.GetString(tagType);
-                case ReconyxMakernoteDirectory.TagContrast:
-                case ReconyxMakernoteDirectory.TagBrightness:
-                case ReconyxMakernoteDirectory.TagSharpness:
-                case ReconyxMakernoteDirectory.TagSaturation:
+                case ReconyxHyperFireMakernoteDirectory.TagContrast:
+                case ReconyxHyperFireMakernoteDirectory.TagBrightness:
+                case ReconyxHyperFireMakernoteDirectory.TagSharpness:
+                case ReconyxHyperFireMakernoteDirectory.TagSaturation:
                     return Directory.GetUInt16(tagType).ToString();
-                case ReconyxMakernoteDirectory.TagInfraredIlluminator:
+                case ReconyxHyperFireMakernoteDirectory.TagInfraredIlluminator:
                     return GetIndexedDescription(tagType, "Off", "On");
-                case ReconyxMakernoteDirectory.TagUserLabel:
+                case ReconyxHyperFireMakernoteDirectory.TagUserLabel:
                     return Directory.GetString(tagType);
                 default:
                     return base.GetDescription(tagType);

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFireMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFireMakernoteDirectory.cs
@@ -27,16 +27,16 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace MetadataExtractor.Formats.Exif.Makernotes
 {
-    /// <summary>Describes tags specific to Reconyx cameras.</summary>
+    /// <summary>Describes tags specific to Reconyx HyperFire cameras.</summary>
     /// <author>Todd West http://cascadescarnivoreproject.blogspot.com</author>
-    /// <remarks>Reconyx uses a fixed firmware block.  Tag values are the byte index of the tag within the makernote.</remarks>
+    /// <remarks>Reconyx uses a fixed makernote block.  Tag values are the byte index of the tag within the makernote.</remarks>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    public class ReconyxMakernoteDirectory : Directory
+    public class ReconyxHyperFireMakernoteDirectory : Directory
     {
         /// <summary>
-        /// Version number used for identifying makernotes from Reconyx HyperFire cameras.  May also apply to some UltraFire models.
+        /// Version number used for identifying makernotes from Reconyx HyperFire cameras.
         /// </summary>
-        public static readonly ushort HyperFireMakernoteVersion = 61697;
+        public static readonly ushort MakernoteVersion = 61697;
 
         public const int TagMakernoteVersion = 0;
         public const int TagFirmwareVersion = 2;
@@ -45,7 +45,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagEventNumber = 18;
         public const int TagDateTimeOriginal = 22;
         public const int TagMoonPhase = 36;
-        public const int TagAmbientTemperatureFarenheit = 38;
+        public const int TagAmbientTemperatureFahrenheit = 38;
         public const int TagAmbientTemperature = 40;
         public const int TagSerialNumber = 42;
         public const int TagContrast = 72;
@@ -66,7 +66,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
              { TagEventNumber, "Event Number" },
              { TagDateTimeOriginal, "Date/Time Original" },
              { TagMoonPhase, "Moon Phase" },
-             { TagAmbientTemperatureFarenheit, "Ambient Temperature Farenheit" },
+             { TagAmbientTemperatureFahrenheit, "Ambient Temperature Fahrenheit" },
              { TagAmbientTemperature, "Ambient Temperature" },
              { TagSerialNumber, "Serial Number" },
              { TagContrast, "Contrast" },
@@ -76,15 +76,15 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
              { TagInfraredIlluminator, "Infrared Illuminator" },
              { TagMotionSensitivity, "Motion Sensitivity" },
              { TagBatteryVoltage, "Battery Voltage" },
-             { TagUserLabel, "UserLabel" }
+             { TagUserLabel, "User Label" }
         };
 
-        public ReconyxMakernoteDirectory()
+        public ReconyxHyperFireMakernoteDirectory()
         {
-            SetDescriptor(new ReconyxMakernoteDescriptor(this));
+            SetDescriptor(new ReconyxHyperFireMakernoteDescriptor(this));
         }
 
-        public override string Name => "Reconyx Makernote";
+        public override string Name => "Reconyx HyperFire Makernote";
 
         protected override bool TryGetTagName(int tagType, out string tagName)
         {

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDescriptor.cs
@@ -1,0 +1,90 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using JetBrains.Annotations;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>
+    /// Provides human-readable string representations of tag values stored in a <see cref="ReconyxHyperFireMakernoteDirectory"/>.
+    /// </summary>
+    /// <author>Todd West http://cascadescarnivoreproject.blogspot.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class ReconyxUltraFireMakernoteDescriptor : TagDescriptor<ReconyxUltraFireMakernoteDirectory>
+    {
+        public ReconyxUltraFireMakernoteDescriptor([NotNull] ReconyxUltraFireMakernoteDirectory directory)
+            : base(directory)
+        {
+        }
+
+        public override string GetDescription(int tagType)
+        {
+            switch (tagType)
+            {
+                case ReconyxUltraFireMakernoteDirectory.TagLabel:
+                    return Directory.GetString(tagType);
+                case ReconyxUltraFireMakernoteDirectory.TagMakernoteID:
+                    return "0x" + Directory.GetUInt32(tagType).ToString("x8");
+                case ReconyxUltraFireMakernoteDirectory.TagMakernoteSize:
+                    return Directory.GetUInt32(tagType).ToString();
+                case ReconyxUltraFireMakernoteDirectory.TagMakernotePublicID:
+                    return "0x" + Directory.GetUInt32(tagType).ToString("x8");
+                case ReconyxUltraFireMakernoteDirectory.TagMakernotePublicSize:
+                    return Directory.GetUInt16(tagType).ToString();
+                case ReconyxUltraFireMakernoteDirectory.TagAmbientTemperatureFahrenheit:
+                case ReconyxUltraFireMakernoteDirectory.TagAmbientTemperature:
+                    return Directory.GetInt16(tagType).ToString();
+                case ReconyxUltraFireMakernoteDirectory.TagCameraVersion:
+                case ReconyxUltraFireMakernoteDirectory.TagUibVersion:
+                case ReconyxUltraFireMakernoteDirectory.TagBtlVersion:
+                case ReconyxUltraFireMakernoteDirectory.TagPexVersion:
+                case ReconyxUltraFireMakernoteDirectory.TagEventType:
+                    return Directory.GetString(tagType);
+                case ReconyxUltraFireMakernoteDirectory.TagSequence:
+                    int[] sequence = Directory.GetInt32Array(tagType);
+                    return string.Format("{0}/{1}", sequence[0], sequence[1]);
+                case ReconyxUltraFireMakernoteDirectory.TagEventNumber:
+                    return Directory.GetUInt32(tagType).ToString();
+                case ReconyxUltraFireMakernoteDirectory.TagDateTimeOriginal:
+                    return Directory.GetDateTime(tagType).ToString("yyyy:MM:dd HH:mm:ss");
+                case ReconyxUltraFireMakernoteDirectory.TagDayOfWeek:
+                    return GetIndexedDescription(tagType, CultureInfo.CurrentCulture.DateTimeFormat.DayNames);
+                case ReconyxUltraFireMakernoteDirectory.TagMoonPhase:
+                    return GetIndexedDescription(tagType, "New", "Waxing Crescent", "First Quarter", "Waxing Gibbous", "Full", "Waning Gibbous", "Last Quarter", "Waning Crescent");
+                case ReconyxUltraFireMakernoteDirectory.TagFlash:
+                    return GetIndexedDescription(tagType, "Off", "On");
+                case ReconyxUltraFireMakernoteDirectory.TagSerialNumber:
+                    return Directory.GetString(tagType);
+                case ReconyxUltraFireMakernoteDirectory.TagBatteryVoltage:
+                    return Directory.GetDouble(tagType).ToString("0.000");
+                case ReconyxUltraFireMakernoteDirectory.TagUserLabel:
+                    return Directory.GetString(tagType);
+                default:
+                    return base.GetDescription(tagType);
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDirectory.cs
@@ -1,0 +1,105 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    /// <summary>Describes tags specific to Reconyx UltraFire cameras.</summary>
+    /// <author>Todd West http://cascadescarnivoreproject.blogspot.com</author>
+    /// <remarks>Reconyx uses a fixed makernote block.  Tag values are the byte index of the tag within the makernote.</remarks>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public class ReconyxUltraFireMakernoteDirectory : Directory
+    {
+        /// <summary>
+        /// Version number used for identifying makernotes from Reconyx UltraFire cameras.
+        /// </summary>
+        public static readonly uint MakernoteID = 0x00010000;
+
+        /// <summary>
+        /// Version number used for identifying the public portion of makernotes from Reconyx UltraFire cameras.
+        /// </summary>
+        public static readonly uint MakernotePublicID = 0x07f10001;
+
+        public const int TagLabel = 0;
+        public const int TagMakernoteID = 10;
+        public const int TagMakernoteSize = 14;
+        public const int TagMakernotePublicID = 18;
+        public const int TagMakernotePublicSize = 22;
+        public const int TagCameraVersion = 24;
+        public const int TagUibVersion = 31;
+        public const int TagBtlVersion = 38;
+        public const int TagPexVersion = 45;
+        public const int TagEventType = 52;
+        public const int TagSequence = 53;
+        public const int TagEventNumber = 55;
+        public const int TagDateTimeOriginal = 59;
+        public const int TagDayOfWeek = 66;
+        public const int TagMoonPhase = 67;
+        public const int TagAmbientTemperatureFahrenheit = 68;
+        public const int TagAmbientTemperature = 70;
+        public const int TagFlash = 72;
+        public const int TagBatteryVoltage = 73;
+        public const int TagSerialNumber = 75;
+        public const int TagUserLabel = 80;
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        {
+             { TagLabel, "Makernote Label" },
+             { TagMakernoteID, "Makernote ID" },
+             { TagMakernoteSize, "Makernote Size" },
+             { TagMakernotePublicID, "Makernote Public ID" },
+             { TagMakernotePublicSize, "Makernote Public Size" },
+             { TagCameraVersion, "Camera Version" },
+             { TagUibVersion, "Uib Version" },
+             { TagBtlVersion, "Btl Version" },
+             { TagPexVersion, "Pex Version" },
+             { TagEventType, "Event Type" },
+             { TagSequence, "Sequence" },
+             { TagEventNumber, "Event Number" },
+             { TagDateTimeOriginal, "Date/Time Original" },
+             { TagDayOfWeek, "Day of Week" },
+             { TagMoonPhase, "Moon Phase" },
+             { TagAmbientTemperatureFahrenheit, "Ambient Temperature Fahrenheit" },
+             { TagAmbientTemperature, "Ambient Temperature" },
+             { TagFlash, "Flash" },
+             { TagBatteryVoltage, "Battery Voltage" },
+             { TagSerialNumber, "Serial Number" },
+             { TagUserLabel, "User Label" }
+        };
+
+        public ReconyxUltraFireMakernoteDirectory()
+        {
+            SetDescriptor(new ReconyxUltraFireMakernoteDescriptor(this));
+        }
+
+        public override string Name => "Reconyx UltraFire Makernote";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/Util/ByteConvert.cs
+++ b/MetadataExtractor/Util/ByteConvert.cs
@@ -1,9 +1,49 @@
 using JetBrains.Annotations;
+using System;
 
 namespace MetadataExtractor.Util
 {
     public static class ByteConvert
     {
+        [Pure]
+        public static uint FromBigEndianToNative(uint bigEndian)
+        {
+            if (BitConverter.IsLittleEndian == false)
+            {
+                return bigEndian;
+            }
+
+            byte[] bigEndianBytes = BitConverter.GetBytes(bigEndian);
+            byte[] littleEndianBytes = new byte[4] { bigEndianBytes[3], bigEndianBytes[2], bigEndianBytes[1], bigEndianBytes[0] };
+            return BitConverter.ToUInt32(littleEndianBytes, 0);
+        }
+
+        [Pure]
+        public static ushort FromBigEndianToNative(ushort bigEndian)
+        {
+            if (BitConverter.IsLittleEndian == false)
+            {
+                return bigEndian;
+            }
+
+            byte[] bigEndianBytes = BitConverter.GetBytes(bigEndian);
+            byte[] littleEndianBytes = new byte[2] { bigEndianBytes[1], bigEndianBytes[0] };
+            return BitConverter.ToUInt16(littleEndianBytes, 0);
+        }
+
+        [Pure]
+        public static short FromBigEndianToNative(short bigEndian)
+        {
+            if (BitConverter.IsLittleEndian == false)
+            {
+                return bigEndian;
+            }
+
+            byte[] bigEndianBytes = BitConverter.GetBytes(bigEndian);
+            byte[] littleEndianBytes = new byte[2] { bigEndianBytes[1], bigEndianBytes[0] };
+            return BitConverter.ToInt16(littleEndianBytes, 0);
+        }
+
         [Pure]
         public static int ToInt32BigEndian([NotNull] byte[] bytes) => bytes[0] << 24 |
                                                                       bytes[1] << 16 |


### PR DESCRIPTION
Should be pretty straightforward.  A common base class between the HyperFire and UltraFire makernotes seems desirable but---as tag offsets differ, tag values are of different types and formats, and tag names aren't always the same---is not trivial to express safely and clearly.