### PR TITLE
sort XMP strings in FileProcessor utility

### DIFF
--- a/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
+++ b/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
@@ -96,17 +96,23 @@ namespace MetadataExtractor.Tools.FileProcessor
                             var xmpDirectory = directory as XmpDirectory;
                             if (xmpDirectory?.XmpMeta != null)
                             {
-                                var wrote = false;
+                                var props = new List<string>();
                                 foreach (var prop in xmpDirectory.XmpMeta.Properties)
                                 {
                                     var value = prop.Value;
                                     if (value?.Length > 512)
                                         value = value.Substring(0, 512) + $" <truncated from {value.Length} characters>";
-                                    writer.WriteLine($"[XMPMeta - {prop.Namespace}] {prop.Path} = {value}");
-                                    wrote = true;
+                                    props.Add($"[XMPMeta - {prop.Namespace}] {prop.Path} = {value}");
                                 }
-                                if (wrote)
+                                if (props.Count > 0)
+                                {
+                                    props.Sort();
+
+                                    foreach (var prop in props)
+                                        writer.WriteLine(prop);
+
                                     writer.Write('\n');
+                                }
                             }
                         }
 


### PR DESCRIPTION
This is aimed at the metadata-extractor-images project. It sorts the XMP output strings to make it easier for diff detection with the Java project.

If the code works and if possible, you might update the images metadata txt files after this. The sorted XMP will remove a very large number of diffs with the Java output.

A couple more catch-up things and it might be worth another minor release for both projects. Up to you though.  :-)