### PR TITLE
Add Follower IFD check for multipage tiff files

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
@@ -430,9 +430,10 @@ namespace MetadataExtractor.Formats.Exif
         [CanBeNull]
         public string GetNewSubfileTypeDescription()
         {
-            return GetIndexedDescription(ExifDirectoryBase.TagNewSubfileType, 1,
+            return GetIndexedDescription(ExifDirectoryBase.TagNewSubfileType, 0,
                 "Full-resolution image",
                 "Reduced-resolution image",
+                "Single page of multi-page image",
                 "Single page of multi-page reduced-resolution image",
                 "Transparency mask",
                 "Transparency mask of reduced-resolution image",

--- a/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
@@ -184,6 +184,15 @@ namespace MetadataExtractor.Formats.Exif
 
         public const int TagJpegProc = 0x0200;
 
+        // 0x0201 can have all kinds of descriptions for thumbnail starting index
+        // 0x0202 can have all kinds of descriptions for thumbnail length
+        public const int TagJpegRestartInterval = 0x0203;
+        public const int TagJpegLosslessPredictors = 0x0205;
+        public const int TagJpegPointTransforms = 0x0206;
+        public const int TagJpegQTables = 0x0207;
+        public const int TagJpegDcTables = 0x0208;
+        public const int TagJpegAcTables = 0x0209;
+
         public const int TagYCbCrCoefficients = 0x0211;
 
         public const int TagYCbCrSubsampling = 0x0212;
@@ -760,6 +769,14 @@ namespace MetadataExtractor.Formats.Exif
             map[TagTransferRange] = "Transfer Range";
             map[TagJpegTables] = "JPEG Tables";
             map[TagJpegProc] = "JPEG Proc";
+
+            map[TagJpegRestartInterval] = "JPEG Restart Interval";
+            map[TagJpegLosslessPredictors] = "JPEG Lossless Predictors";
+            map[TagJpegPointTransforms] = "JPEG Point Transforms";
+            map[TagJpegQTables] = "JPEGQ Tables";
+            map[TagJpegDcTables] = "JPEGDC Tables";
+            map[TagJpegAcTables] = "JPEGAC Tables";
+
             map[TagYCbCrCoefficients] = "YCbCr Coefficients";
             map[TagYCbCrSubsampling] = "YCbCr Sub-Sampling";
             map[TagYCbCrPositioning] = "YCbCr Positioning";

--- a/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
@@ -148,6 +148,7 @@ namespace MetadataExtractor.Formats.Exif
         public const int TagPageName = 0x011D;
 
         public const int TagResolutionUnit = 0x0128;
+        public const int TagPageNumber = 0x0129;
 
         public const int TagTransferFunction = 0x012D;
 
@@ -742,6 +743,7 @@ namespace MetadataExtractor.Formats.Exif
             map[TagPlanarConfiguration] = "Planar Configuration";
             map[TagPageName] = "Page Name";
             map[TagResolutionUnit] = "Resolution Unit";
+            map[TagPageNumber] = "Page Number";
             map[TagTransferFunction] = "Transfer Function";
             map[TagSoftware] = "Software";
             map[TagDateTime] = "Date/Time";

--- a/MetadataExtractor/Formats/Exif/ExifImageDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/ExifImageDescriptor.cs
@@ -1,0 +1,42 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace MetadataExtractor.Formats.Exif
+{
+    /// <summary>
+    /// Provides human-readable string representations of tag values stored in a <see cref="ExifImageDirectory"/>.
+    /// </summary>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class ExifImageDescriptor : ExifDescriptorBase<ExifImageDirectory>
+    {
+        public ExifImageDescriptor([NotNull] ExifImageDirectory directory)
+            : base(directory)
+        {
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/ExifImageDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/ExifImageDirectory.cs
@@ -1,0 +1,56 @@
+#region License
+//
+// Copyright 2002-2016 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif
+{
+    /// <summary>One of several Exif directories.</summary>
+    /// <remarks>Holds information about image IFD's in a chain after the first. The first page is stored in IFD0.</remarks>
+    /// <remarks>Currently, this only applies to multi-page TIFF images</remarks>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class ExifImageDirectory : ExifDirectoryBase
+    {
+        public ExifImageDirectory()
+        {
+            SetDescriptor(new ExifImageDescriptor(this));
+        }
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>();
+
+        static ExifImageDirectory()
+        {
+            AddExifTagNames(_tagNameMap);
+        }
+
+        public override string Name => "Exif Image";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}


### PR DESCRIPTION
drewnoakes/metadata-extractor#223

- Bug fix in ExifDescriptorBase for a missing subfiletype description.
- Added Page Number (0x0129) tag to ExifDescriptorBase
- First go at detecting and displaying multipage tiff images

The problems I see with this PR:
- The new check in HasFollowerIfd() isn't based on a concrete way of knowing it's an 'image' that I can find so far. It's mostly intuition that the page number tag won't exist in other cases.
- Adding additional ExifIfd0Directory's was my first solution. That seemed wrong since these aren't IFD0 and instead created a new directory (ExifImageDirectory). I can't say either way whether that's a good solution, better name, etc.
- Using "PushDirectory" in this case can create a very long indented output of the structure

It makes significant additions (and corrections actually) to the images repo -- a number of TIFF's were multipage but being loading into Thumbnail directories. Let me know what you think.
