### PR TITLE
Describe the page number tag

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
@@ -58,6 +58,8 @@ namespace MetadataExtractor.Formats.Exif
                     return GetOrientationDescription();
                 case ExifDirectoryBase.TagResolutionUnit:
                     return GetResolutionDescription();
+                case ExifDirectoryBase.TagPageNumber:
+                    return GetPageNumberDescription();
                 case ExifDirectoryBase.TagYCbCrPositioning:
                     return GetYCbCrPositioningDescription();
                 case ExifDirectoryBase.TagXResolution:
@@ -269,6 +271,25 @@ namespace MetadataExtractor.Formats.Exif
                 "(No unit)",
                 "Inch",
                 "cm");
+        }
+
+        [CanBeNull]
+        public string GetPageNumberDescription()
+        {
+            var values = Directory.GetInt32Array(ExifDirectoryBase.TagPageNumber);
+
+            if (values?.Length != 2)
+                return null;
+
+            if (values[1] == 0)
+                return (values[0] + 1).ToString();
+
+            // The first number is the zero-based page index. However, support for this tag seems quite variable in the wild.
+            // If the page number seems within range, increment it to the more human friendly one-based index.
+            if (values[0] < values[1])
+                values[0]++;
+
+            return $"{values[0]} of {values[1]}";
         }
 
         /// <summary>The Windows specific tags uses plain Unicode.</summary>


### PR DESCRIPTION
@kwhopper could you review this and, if happy, merge it?

It seems to work on many of the ImageTestSuite TIFF files, however there are quite a few of those where the page numbers make little sense.

I used this page as a reference for the tag: http://www.awaresystems.be/imaging/tiff/tifftags/pagenumber.html