### PR TITLE
IPTC output fixes and additions + Deflate fix.

### DIFF
--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -410,6 +410,18 @@ namespace MetadataExtractor
             if (s != null)
                 return new[] { s };
 
+            if (o is StringValue)
+                return new string[] { o.ToString() };
+
+            if (o is StringValue[])
+            {
+                StringValue[] stringValues = (StringValue[])o;
+                string[] strs = new string[stringValues.Length];
+                for (int i = 0; i < strs.Length; i++)
+                    strs[i] = stringValues[i].ToString();
+                return strs;
+            }
+
             var ints = o as int[];
             if (ints != null)
             {
@@ -436,6 +448,25 @@ namespace MetadataExtractor
                     strings[i] = rationals[i].ToSimpleString(false);
                 return strings;
             }
+
+            return null;
+        }
+
+        /// <summary>Gets the specified tag's value as a StringValue array, if possible.</summary>
+        /// <remarks>Only succeeds if the tag is set as StringValue[], or String.</remarks>
+        /// <returns>the tag's value as an array of StringValues. If the value is unset or cannot be converted, <c>null</c> is returned.</returns>
+        [Pure]
+        [CanBeNull]
+        public static StringValue[] GetStringValueArray([NotNull] this Directory directory, int tagType)
+        {
+            var o = directory.GetObject(tagType);
+
+            if (o == null)
+                return null;
+            if (o is StringValue[])
+                return (StringValue[])o;
+            if (o is StringValue)
+                return new StringValue[] { (StringValue)o };
 
             return null;
         }
@@ -612,6 +643,7 @@ namespace MetadataExtractor
             "yyyy:MM:dd",
             "yyyy-MM-dd",
             "yyyy-MM",
+            "yyyyMMdd", // as used in IPTC data
             "yyyy"
         };
 
@@ -910,6 +942,17 @@ namespace MetadataExtractor
             return bytes == null
                 ? null
                 : encoding.GetString(bytes, 0, bytes.Length);
+        }
+
+        [Pure]
+        [CanBeNull]
+        public static StringValue GetStringValue([NotNull] this Directory directory, int tagType)
+        {
+            var o = directory.GetObject(tagType);
+            if (o is StringValue)
+                return (StringValue)o;
+
+            return default(StringValue);
         }
 
         [Pure]

--- a/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
+++ b/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
@@ -43,7 +43,7 @@ namespace MetadataExtractor.Formats.Iptc
             if (bytes.Length > 2 && bytes[0] == Esc && bytes[1] == PercentSign && bytes[2] == LatinCapitalG)
                 return "UTF-8";
 
-            if (bytes.Length > 3 && bytes[0] == Esc && (bytes[3] | bytes[2] << 8 | bytes[1] << 16) == Dot && bytes[4] == LatinCapitalA)
+            if (bytes.Length > 3 && bytes[0] == Esc && (bytes[3] | ((bytes[2] << 8) | (bytes[1] << 16))) == Dot && bytes[4] == LatinCapitalA)
                 return "ISO-8859-1";
 
             return null;

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -249,6 +249,12 @@ namespace MetadataExtractor.IO
             return encoding.GetString(bytes, 0, bytes.Length);
         }
 
+        [NotNull]
+        public StringValue GetStringValue(int bytesRequested, Encoding encoding = null)
+        {
+            return new StringValue(GetBytes(bytesRequested), encoding);
+        }
+
         /// <summary>
         /// Creates a <see cref="String"/> from the stream, ending where <c>byte=='\0'</c> or where <c>length==maxLength</c>.
         /// </summary>

--- a/MetadataExtractor/StringValue.cs
+++ b/MetadataExtractor/StringValue.cs
@@ -63,7 +63,23 @@ namespace MetadataExtractor
 
         short IConvertible.ToInt16(IFormatProvider provider) => short.Parse(ToString());
 
-        int IConvertible.ToInt32(IFormatProvider provider) => int.Parse(ToString());
+        int IConvertible.ToInt32(IFormatProvider provider)
+        {
+            try
+            {
+                return int.Parse(ToString());
+            }
+            catch(Exception)
+            {
+                long val = 0;
+                foreach(byte aByte in Bytes)
+                {
+                    val = val << 8;
+                    val += (aByte & 0xff);
+                }
+                return (int)val;
+            }
+        }
 
         long IConvertible.ToInt64(IFormatProvider provider) => long.Parse(ToString());
 


### PR DESCRIPTION
- port of drewnoakes/metadata-extractor@184ce9c
- refactor IPTCReader.ProcessTag to use StringValue and get closer to Java output
- Added some StringValue methods to DirectoryExtensions and SequentialReader
- DeflateStream implements RFC 1951, but not RFC 1950. Strip first two bytes of input array to make it 'deflate' compatible (should watch for any new issues in the future with this)
- If StringValue's ToInt32 converter can't parse the input as a string, loop through the bytes and make an int out of them (similar to the Java project's getInteger method)