### PR TITLE
Execute .net45 and .netcoreapp1.0 tests

### DIFF
--- a/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
+++ b/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
@@ -24,7 +24,7 @@
     <Content Include="Data\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
When xUnit was releasing 2.2.0 they dropped support for net451, see https://xunit.github.io/release-notes/2017-02-19.html

This PR contains updated TFM to net452 that only is for test-project so the class library will still compuled for lower TFM. You can see that in this https://ci.appveyor.com/project/Tasteful/metadata-extractor-dotnet/build/2.0.3 build.

If removing the `test_script` from `appveyor.yml` only the `net452` build is executing, with the `test_script` both test for `net452` and `netcoreapp1.0` is executed.