### PR TITLE
adjust Reconyx UltraFire makernote to match MapView

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -896,14 +896,13 @@ namespace MetadataExtractor.Formats.Exif
 
         private static string ProcessReconyxUltraFireVersion(int versionOffset, [NotNull] IndexedReader reader)
         {
-            var major = reader.GetByte(versionOffset);
-            var minor = reader.GetByte(versionOffset + 1);
-            var year = ByteConvert.FromBigEndianToNative(reader.GetUInt16(versionOffset + 2));
-            var month = reader.GetByte(versionOffset + 4);
-            var day = reader.GetByte(versionOffset + 5);
-            var revision = reader.GetString(versionOffset + 6, 1, Encoding.UTF8);
-
-            return $"{major}.{minor}.{year:x4}{month:00}{day:00}{revision}";
+            string major = reader.GetByte(versionOffset).ToString();
+            string minor = reader.GetByte(versionOffset + 1).ToString();
+            string year = ByteConvert.FromBigEndianToNative(reader.GetUInt16(versionOffset + 2)).ToString("x4");
+            string month = reader.GetByte(versionOffset + 4).ToString("x2");
+            string day = reader.GetByte(versionOffset + 5).ToString("x2");
+            string revision = reader.GetString(versionOffset + 6, 1, Encoding.UTF8);
+            return major + "." + minor + "." + year + "." + month + "." + day + revision;
         }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDirectory.cs
@@ -63,7 +63,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public const int TagFlash = 72;
         public const int TagBatteryVoltage = 73;
         public const int TagSerialNumber = 75;
-        public const int TagUserLabel = 80;
+        public const int TagUserLabel = 90;
 
         private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
         {


### PR DESCRIPTION
Three small changes to conform match Reconyx's MapView software.  Coded these back in January but neglected to put in the pull.  They passed tests at the time and build clean on current bits but have only been manually tested via MetadataExtractor due to #93.  Therefore falling back to AppVeyor alone.