### PR TITLE
Better handling of broken mp4-files

### DIFF
--- a/MetadataExtractor.sln
+++ b/MetadataExtractor.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26430.4
+VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8CF154EA-6A2C-4BF4-B263-78758F834192}"
 	ProjectSection(SolutionItems) = preProject
@@ -35,7 +35,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Wiki", "Wiki", "{DD8398AB-E
 		wiki\Contributing.md = wiki\Contributing.md
 		wiki\FAQ.md = wiki\FAQ.md
 		wiki\File-Type-Detection.md = wiki\File-Type-Detection.md
+		wiki\Getting Started (dotnet).md = wiki\Getting Started (dotnet).md
 		wiki\Getting Started (Java).md = wiki\Getting Started (Java).md
+		wiki\Getting Started.md = wiki\Getting Started.md
 		wiki\Home.md = wiki\Home.md
 		wiki\JPEG.md = wiki\JPEG.md
 		wiki\ProGuard.md = wiki\ProGuard.md
@@ -48,8 +50,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Wiki", "Wiki", "{DD8398AB-E
 		wiki\UsedBy.md = wiki\UsedBy.md
 		wiki\Working-with-test-images.md = wiki\Working-with-test-images.md
 		wiki\XMP.md = wiki\XMP.md
-		wiki\Getting Started.md = wiki\Getting Started.md
-		wiki\Getting Started (dotnet).md = wiki\Getting Started (dotnet).md
 	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Specs", "Specs", "{1806EC0F-839C-45A4-9778-11A89CFD5C14}"
@@ -86,7 +86,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Wiki (Images)", "Wiki (Imag
 		wiki-images\Home.md = wiki-images\Home.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MetadataExtractor.Samples", "MetadataExtractor.Samples\MetadataExtractor.Samples.csproj", "{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MetadataExtractor.Samples", "MetadataExtractor.Samples\MetadataExtractor.Samples.csproj", "{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -146,14 +146,17 @@ Global
 		{96158958-7CA7-4BFC-A573-30F31E7F39A4}.Release|x64.Build.0 = Release|Any CPU
 		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Debug|x64.ActiveCfg = Debug|x64
-		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Debug|x64.Build.0 = Debug|x64
+		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Debug|x64.Build.0 = Debug|Any CPU
 		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Release|Any CPU.Build.0 = Release|Any CPU
-		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Release|x64.ActiveCfg = Release|x64
-		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Release|x64.Build.0 = Release|x64
+		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Release|x64.ActiveCfg = Release|Any CPU
+		{F8B15C79-7D2A-44F2-9E8A-1D5127FE6D91}.Release|x64.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {15F8CDD5-5EFF-4277-8559-5AA83D1353C8}
 	EndGlobalSection
 EndGlobal

--- a/MetadataExtractor/Formats/Avi/AviDescriptor.cs
+++ b/MetadataExtractor/Formats/Avi/AviDescriptor.cs
@@ -1,0 +1,50 @@
+#region License
+//
+// Copyright 2002-2017 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Diagnostics.CodeAnalysis;
+using JetBrains.Annotations;
+
+namespace MetadataExtractor.Formats.Avi
+{
+	/// <author>Payton Garland</author>
+	[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public class AviDescriptor : TagDescriptor<AviDirectory>
+    {
+        public AviDescriptor([NotNull] AviDirectory directory)
+            : base(directory)
+        {
+        }
+
+		public override string GetDescription(int tagType)
+		{
+			switch (tagType)
+			{
+			case AviDirectory.TAG_WIDTH:
+			case AviDirectory.TAG_HEIGHT:
+				return Directory.GetString(tagType) + " pixels";
+			}
+			return base.GetDescription(tagType);
+		}
+	}
+}

--- a/MetadataExtractor/Formats/Avi/AviDescriptor.cs
+++ b/MetadataExtractor/Formats/Avi/AviDescriptor.cs
@@ -27,8 +27,8 @@ using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.Avi
 {
-	/// <author>Payton Garland</author>
-	[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    /// <author>Payton Garland</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public class AviDescriptor : TagDescriptor<AviDirectory>
     {
         public AviDescriptor([NotNull] AviDirectory directory)
@@ -36,15 +36,15 @@ namespace MetadataExtractor.Formats.Avi
         {
         }
 
-		public override string GetDescription(int tagType)
-		{
-			switch (tagType)
-			{
-			case AviDirectory.TAG_WIDTH:
-			case AviDirectory.TAG_HEIGHT:
-				return Directory.GetString(tagType) + " pixels";
-			}
-			return base.GetDescription(tagType);
-		}
-	}
+        public override string GetDescription(int tagType)
+        {
+            switch (tagType)
+            {
+            case AviDirectory.TAG_WIDTH:
+            case AviDirectory.TAG_HEIGHT:
+                return Directory.GetString(tagType) + " pixels";
+            }
+            return base.GetDescription(tagType);
+        }
+    }
 }

--- a/MetadataExtractor/Formats/Avi/AviDirectory.cs
+++ b/MetadataExtractor/Formats/Avi/AviDirectory.cs
@@ -27,29 +27,29 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace MetadataExtractor.Formats.Avi
 {
-	/// <author>Payton Garland</author>
-	[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    /// <author>Payton Garland</author>
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public class AviDirectory : Directory
     {
-		public const int TAG_FRAMES_PER_SECOND = 1;
-		public const int TAG_SAMPLES_PER_SECOND = 2;
-		public const int TAG_DURATION = 3;
-		public const int TAG_VIDEO_CODEC = 4;
-		public const int TAG_AUDIO_CODEC = 5;
-		public const int TAG_WIDTH = 6;
-		public const int TAG_HEIGHT = 7;
-		public const int TAG_STREAMS = 8;
+        public const int TAG_FRAMES_PER_SECOND = 1;
+        public const int TAG_SAMPLES_PER_SECOND = 2;
+        public const int TAG_DURATION = 3;
+        public const int TAG_VIDEO_CODEC = 4;
+        public const int TAG_AUDIO_CODEC = 5;
+        public const int TAG_WIDTH = 6;
+        public const int TAG_HEIGHT = 7;
+        public const int TAG_STREAMS = 8;
 
-		private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
         {
-			{TAG_FRAMES_PER_SECOND, "Frames Per Second"},
-			{TAG_SAMPLES_PER_SECOND, "Samples Per Second"},
-			{TAG_DURATION, "Duration"},
-			{TAG_VIDEO_CODEC, "Video Codec"},
-			{TAG_AUDIO_CODEC, "Audio Codec"},
-			{TAG_WIDTH, "Width"},
-			{TAG_HEIGHT, "Height"},
-			{TAG_STREAMS, "Stream Count"}
+            {TAG_FRAMES_PER_SECOND, "Frames Per Second"},
+            {TAG_SAMPLES_PER_SECOND, "Samples Per Second"},
+            {TAG_DURATION, "Duration"},
+            {TAG_VIDEO_CODEC, "Video Codec"},
+            {TAG_AUDIO_CODEC, "Audio Codec"},
+            {TAG_WIDTH, "Width"},
+            {TAG_HEIGHT, "Height"},
+            {TAG_STREAMS, "Stream Count"}
         };
 
         public AviDirectory()

--- a/MetadataExtractor/Formats/Avi/AviDirectory.cs
+++ b/MetadataExtractor/Formats/Avi/AviDirectory.cs
@@ -1,0 +1,67 @@
+#region License
+//
+// Copyright 2002-2017 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Avi
+{
+	/// <author>Payton Garland</author>
+	[SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public class AviDirectory : Directory
+    {
+		public const int TAG_FRAMES_PER_SECOND = 1;
+		public const int TAG_SAMPLES_PER_SECOND = 2;
+		public const int TAG_DURATION = 3;
+		public const int TAG_VIDEO_CODEC = 4;
+		public const int TAG_AUDIO_CODEC = 5;
+		public const int TAG_WIDTH = 6;
+		public const int TAG_HEIGHT = 7;
+		public const int TAG_STREAMS = 8;
+
+		private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        {
+			{TAG_FRAMES_PER_SECOND, "Frames Per Second"},
+			{TAG_SAMPLES_PER_SECOND, "Samples Per Second"},
+			{TAG_DURATION, "Duration"},
+			{TAG_VIDEO_CODEC, "Video Codec"},
+			{TAG_AUDIO_CODEC, "Audio Codec"},
+			{TAG_WIDTH, "Width"},
+			{TAG_HEIGHT, "Height"},
+			{TAG_STREAMS, "Stream Count"}
+        };
+
+        public AviDirectory()
+        {
+            SetDescriptor(new AviDescriptor(this));
+        }
+
+        public override string Name => "Avi";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
+++ b/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
@@ -1,0 +1,69 @@
+#region License
+//
+// Copyright 2002-2017 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System.Collections.Generic;
+using System.IO;
+using JetBrains.Annotations;
+using MetadataExtractor.Formats.FileSystem;
+using MetadataExtractor.Formats.Riff;
+using MetadataExtractor.IO;
+
+#if NET35
+using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
+#else
+using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
+#endif
+
+namespace MetadataExtractor.Formats.Avi
+{
+    /// <summary>Obtains metadata from Avi files.</summary>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public static class AviMetadataReader
+    {
+        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="RiffProcessingException"/>
+        [NotNull]
+        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        {
+            var directories = new List<Directory>();
+
+            using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
+                directories.AddRange(ReadMetadata(stream));
+
+            directories.Add(new FileMetadataReader().Read(filePath));
+
+            return directories;
+        }
+
+        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="RiffProcessingException"/>
+        [NotNull]
+        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        {
+            var directories = new List<Directory>();
+            new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new AviRiffHandler(directories));
+            return directories;
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
+++ b/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
@@ -32,22 +32,22 @@ using MetadataExtractor.IO;
 
 namespace MetadataExtractor.Formats.Avi
 {
-	/// <summary>
-	/// Implementation of <see cref="IRiffHandler"/> specialising in AVI support.
-	/// </summary>
-	/// <remarks>
-	/// Extracts data from chunk/list types:
-	/// <list type="bullet">
-	///   <item><c>"avih"</c>: width, height, streams</item>
-	///   <item><c>"strh"</c>: frames/second, samples/second, duration, video codec</item>
-	/// </list>
-	/// Sources:
-	/// http://www.alexander-noe.com/video/documentation/avi.pdf
-	/// https://msdn.microsoft.com/en-us/library/ms899422.aspx
-	/// https://www.loc.gov/preservation/digital/formats/fdd/fdd000025.shtml
-	/// </remarks>
+    /// <summary>
+    /// Implementation of <see cref="IRiffHandler"/> specialising in AVI support.
+    /// </summary>
+    /// <remarks>
+    /// Extracts data from chunk/list types:
+    /// <list type="bullet">
+    ///   <item><c>"avih"</c>: width, height, streams</item>
+    ///   <item><c>"strh"</c>: frames/second, samples/second, duration, video codec</item>
+    /// </list>
+    /// Sources:
+    /// http://www.alexander-noe.com/video/documentation/avi.pdf
+    /// https://msdn.microsoft.com/en-us/library/ms899422.aspx
+    /// https://www.loc.gov/preservation/digital/formats/fdd/fdd000025.shtml
+    /// </remarks>
     /// <author>Payton Garland</author>
-	public sealed class AviRiffHandler : IRiffHandler
+    public sealed class AviRiffHandler : IRiffHandler
     {
         [NotNull]
         private readonly List<Directory> _directories;
@@ -59,112 +59,112 @@ namespace MetadataExtractor.Formats.Avi
 
         public bool ShouldAcceptRiffIdentifier(string identifier) => identifier == "AVI ";
 
-		public bool ShouldAcceptChunk(string fourCc) =>	fourCc == "strh" ||
-														fourCc == "avih";
+        public bool ShouldAcceptChunk(string fourCc) => fourCc == "strh" ||
+                                                        fourCc == "avih";
 
-		public bool ShouldAcceptList(string fourCc) =>	fourCc == "hdrl" ||
-														fourCc == "strl" ||
-														fourCc == "AVI ";
+        public bool ShouldAcceptList(string fourCc) => fourCc == "hdrl" ||
+                                                       fourCc == "strl" ||
+                                                       fourCc == "AVI ";
 
-		public void ProcessChunk(string fourCc, byte[] payload)
+        public void ProcessChunk(string fourCc, byte[] payload)
         {
             switch (fourCc)
             {
-                case "strh":
+            case "strh":
                 {
                     string error = null;
                     var reader = new ByteArrayReader(payload, isMotorolaByteOrder: false);
-					string fccType = null;
-					string fccHandler = null;
-					float dwScale = 0;
-					float dwRate = 0;
-					int dwLength = 0;
-					try
-					{
-						fccType = reader.GetString(0, 4, Encoding.ASCII);
-						fccHandler = reader.GetString(4, 4, Encoding.ASCII);
-						//int dwFlags = reader.GetInt32(8);
-						//int wPriority = reader.GetInt16(12);
-						//int wLanguage = reader.GetInt16(14);
-						//int dwInitialFrames = reader.GetInt32(16);
-						dwScale = reader.GetFloat32(20);
-						dwRate = reader.GetFloat32(24);
-						//int dwStart = reader.GetInt32(28);
-						dwLength = reader.GetInt32(32);
-						//int dwSuggestedBufferSize = reader.GetInt32(36);
-						//int dwQuality = reader.GetInt32(40);
-						//int dwSampleSize = reader.GetInt32(44);
-						//byte[] rcFrame = reader.GetBytes(48, 2);
-					}
-					catch (IOException e)
-					{
-						error = "Exception reading AviRiff chunk 'strh' : " + e.Message;
-					}
+                    string fccType = null;
+                    string fccHandler = null;
+                    float dwScale = 0;
+                    float dwRate = 0;
+                    int dwLength = 0;
+                    try
+                    {
+                        fccType = reader.GetString(0, 4, Encoding.ASCII);
+                        fccHandler = reader.GetString(4, 4, Encoding.ASCII);
+                        //int dwFlags = reader.GetInt32(8);
+                        //int wPriority = reader.GetInt16(12);
+                        //int wLanguage = reader.GetInt16(14);
+                        //int dwInitialFrames = reader.GetInt32(16);
+                        dwScale = reader.GetFloat32(20);
+                        dwRate = reader.GetFloat32(24);
+                        //int dwStart = reader.GetInt32(28);
+                        dwLength = reader.GetInt32(32);
+                        //int dwSuggestedBufferSize = reader.GetInt32(36);
+                        //int dwQuality = reader.GetInt32(40);
+                        //int dwSampleSize = reader.GetInt32(44);
+                        //byte[] rcFrame = reader.GetBytes(48, 2);
+                    }
+                    catch (IOException e)
+                    {
+                        error = "Exception reading AviRiff chunk 'strh' : " + e.Message;
+                    }
 
-					var directory = new AviDirectory();
-					if (error == null)
-					{
-						if (fccType == "vids")
-						{
-							directory.Set(AviDirectory.TAG_FRAMES_PER_SECOND, (dwRate / dwScale));
+                    var directory = new AviDirectory();
+                    if (error == null)
+                    {
+                        if (fccType == "vids")
+                        {
+                            directory.Set(AviDirectory.TAG_FRAMES_PER_SECOND, (dwRate / dwScale));
 
-							double duration = dwLength / (dwRate / dwScale);
-							int hours = (int)duration / (int)(Math.Pow(60, 2));
-							int minutes = ((int)duration / (int)(Math.Pow(60, 1))) - (hours * 60);
-							int seconds = (int)Math.Round((duration / (Math.Pow(60, 0))) - (minutes * 60));
-							string time = new DateTime(2000, 1, 1, hours, minutes, seconds).ToString("hh:mm:ss");
+                            double duration = dwLength / (dwRate / dwScale);
+                            int hours = (int)duration / (int)(Math.Pow(60, 2));
+                            int minutes = ((int)duration / (int)(Math.Pow(60, 1))) - (hours * 60);
+                            int seconds = (int)Math.Round((duration / (Math.Pow(60, 0))) - (minutes * 60));
+                            string time = new DateTime(2000, 1, 1, hours, minutes, seconds).ToString("hh:mm:ss");
 
-							directory.Set(AviDirectory.TAG_DURATION, time);
-							directory.Set(AviDirectory.TAG_VIDEO_CODEC, fccHandler);
-						}
-						else
-						if (fccType == "auds")
-						{
-							directory.Set(AviDirectory.TAG_SAMPLES_PER_SECOND, (dwRate / dwScale));
-						}
-					}
-					else
-						directory.AddError(error);
-					_directories.Add(directory);
+                            directory.Set(AviDirectory.TAG_DURATION, time);
+                            directory.Set(AviDirectory.TAG_VIDEO_CODEC, fccHandler);
+                        }
+                        else
+                        if (fccType == "auds")
+                        {
+                            directory.Set(AviDirectory.TAG_SAMPLES_PER_SECOND, (dwRate / dwScale));
+                        }
+                    }
+                    else
+                        directory.AddError(error);
+                    _directories.Add(directory);
                     break;
                 }
-                case "avih":
+            case "avih":
                 {
-					string error = null;
-					var reader = new ByteArrayReader(payload, isMotorolaByteOrder: false);
-					int dwStreams = 0;
-					int dwWidth = 0;
-					int dwHeight =0;
-					try
-					{
-						//int dwMicroSecPerFrame = reader.GetInt32(0);
-						//int dwMaxBytesPerSec = reader.GetInt32(4);
-						//int dwPaddingGranularity = reader.GetInt32(8);
-						//int dwFlags = reader.GetInt32(12);
-						//int dwTotalFrames = reader.GetInt32(16);
-						//int dwInitialFrames = reader.GetInt32(20);
-						dwStreams = reader.GetInt32(24);
-						//int dwSuggestedBufferSize = reader.GetInt32(28);
-						dwWidth = reader.GetInt32(32);
-						dwHeight = reader.GetInt32(36);
-						//byte[] dwReserved = reader.GetBytes(40, 4);
-					}
-					catch (IOException e)
-					{
-						error = "Exception reading AviRiff chunk 'avih' : " + e.Message;
-					}
+                    string error = null;
+                    var reader = new ByteArrayReader(payload, isMotorolaByteOrder: false);
+                    int dwStreams = 0;
+                    int dwWidth = 0;
+                    int dwHeight = 0;
+                    try
+                    {
+                        //int dwMicroSecPerFrame = reader.GetInt32(0);
+                        //int dwMaxBytesPerSec = reader.GetInt32(4);
+                        //int dwPaddingGranularity = reader.GetInt32(8);
+                        //int dwFlags = reader.GetInt32(12);
+                        //int dwTotalFrames = reader.GetInt32(16);
+                        //int dwInitialFrames = reader.GetInt32(20);
+                        dwStreams = reader.GetInt32(24);
+                        //int dwSuggestedBufferSize = reader.GetInt32(28);
+                        dwWidth = reader.GetInt32(32);
+                        dwHeight = reader.GetInt32(36);
+                        //byte[] dwReserved = reader.GetBytes(40, 4);
+                    }
+                    catch (IOException e)
+                    {
+                        error = "Exception reading AviRiff chunk 'avih' : " + e.Message;
+                    }
 
-					var directory = new AviDirectory();
-					if (error == null)
-					{
-						directory.Set(AviDirectory.TAG_WIDTH, dwWidth);
-						directory.Set(AviDirectory.TAG_HEIGHT, dwHeight);
-						directory.Set(AviDirectory.TAG_STREAMS, dwStreams);
-					}
-					else
-						directory.AddError(error);
-					_directories.Add(directory);
-					break;
+                    var directory = new AviDirectory();
+                    if (error == null)
+                    {
+                        directory.Set(AviDirectory.TAG_WIDTH, dwWidth);
+                        directory.Set(AviDirectory.TAG_HEIGHT, dwHeight);
+                        directory.Set(AviDirectory.TAG_STREAMS, dwStreams);
+                    }
+                    else
+                        directory.AddError(error);
+                    _directories.Add(directory);
+                    break;
                 }
             }
         }

--- a/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
+++ b/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
@@ -1,0 +1,172 @@
+#region License
+//
+// Copyright 2002-2017 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using JetBrains.Annotations;
+using MetadataExtractor.Formats.Riff;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Avi
+{
+	/// <summary>
+	/// Implementation of <see cref="IRiffHandler"/> specialising in AVI support.
+	/// </summary>
+	/// <remarks>
+	/// Extracts data from chunk/list types:
+	/// <list type="bullet">
+	///   <item><c>"avih"</c>: width, height, streams</item>
+	///   <item><c>"strh"</c>: frames/second, samples/second, duration, video codec</item>
+	/// </list>
+	/// Sources:
+	/// http://www.alexander-noe.com/video/documentation/avi.pdf
+	/// https://msdn.microsoft.com/en-us/library/ms899422.aspx
+	/// https://www.loc.gov/preservation/digital/formats/fdd/fdd000025.shtml
+	/// </remarks>
+    /// <author>Payton Garland</author>
+	public sealed class AviRiffHandler : IRiffHandler
+    {
+        [NotNull]
+        private readonly List<Directory> _directories;
+
+        public AviRiffHandler([NotNull] List<Directory> directories)
+        {
+            _directories = directories;
+        }
+
+        public bool ShouldAcceptRiffIdentifier(string identifier) => identifier == "AVI ";
+
+		public bool ShouldAcceptChunk(string fourCc) =>	fourCc == "strh" ||
+														fourCc == "avih";
+
+		public bool ShouldAcceptList(string fourCc) =>	fourCc == "hdrl" ||
+														fourCc == "strl" ||
+														fourCc == "AVI ";
+
+		public void ProcessChunk(string fourCc, byte[] payload)
+        {
+            switch (fourCc)
+            {
+                case "strh":
+                {
+                    string error = null;
+                    var reader = new ByteArrayReader(payload, isMotorolaByteOrder: false);
+					string fccType = null;
+					string fccHandler = null;
+					float dwScale = 0;
+					float dwRate = 0;
+					int dwLength = 0;
+					try
+					{
+						fccType = reader.GetString(0, 4, Encoding.ASCII);
+						fccHandler = reader.GetString(4, 4, Encoding.ASCII);
+						//int dwFlags = reader.GetInt32(8);
+						//int wPriority = reader.GetInt16(12);
+						//int wLanguage = reader.GetInt16(14);
+						//int dwInitialFrames = reader.GetInt32(16);
+						dwScale = reader.GetFloat32(20);
+						dwRate = reader.GetFloat32(24);
+						//int dwStart = reader.GetInt32(28);
+						dwLength = reader.GetInt32(32);
+						//int dwSuggestedBufferSize = reader.GetInt32(36);
+						//int dwQuality = reader.GetInt32(40);
+						//int dwSampleSize = reader.GetInt32(44);
+						//byte[] rcFrame = reader.GetBytes(48, 2);
+					}
+					catch (IOException e)
+					{
+						error = "Exception reading AviRiff chunk 'strh' : " + e.Message;
+					}
+
+					var directory = new AviDirectory();
+					if (error == null)
+					{
+						if (fccType == "vids")
+						{
+							directory.Set(AviDirectory.TAG_FRAMES_PER_SECOND, (dwRate / dwScale));
+
+							double duration = dwLength / (dwRate / dwScale);
+							int hours = (int)duration / (int)(Math.Pow(60, 2));
+							int minutes = ((int)duration / (int)(Math.Pow(60, 1))) - (hours * 60);
+							int seconds = (int)Math.Round((duration / (Math.Pow(60, 0))) - (minutes * 60));
+							string time = new DateTime(2000, 1, 1, hours, minutes, seconds).ToString("hh:mm:ss");
+
+							directory.Set(AviDirectory.TAG_DURATION, time);
+							directory.Set(AviDirectory.TAG_VIDEO_CODEC, fccHandler);
+						}
+						else
+						if (fccType == "auds")
+						{
+							directory.Set(AviDirectory.TAG_SAMPLES_PER_SECOND, (dwRate / dwScale));
+						}
+					}
+					else
+						directory.AddError(error);
+					_directories.Add(directory);
+                    break;
+                }
+                case "avih":
+                {
+					string error = null;
+					var reader = new ByteArrayReader(payload, isMotorolaByteOrder: false);
+					int dwStreams = 0;
+					int dwWidth = 0;
+					int dwHeight =0;
+					try
+					{
+						//int dwMicroSecPerFrame = reader.GetInt32(0);
+						//int dwMaxBytesPerSec = reader.GetInt32(4);
+						//int dwPaddingGranularity = reader.GetInt32(8);
+						//int dwFlags = reader.GetInt32(12);
+						//int dwTotalFrames = reader.GetInt32(16);
+						//int dwInitialFrames = reader.GetInt32(20);
+						dwStreams = reader.GetInt32(24);
+						//int dwSuggestedBufferSize = reader.GetInt32(28);
+						dwWidth = reader.GetInt32(32);
+						dwHeight = reader.GetInt32(36);
+						//byte[] dwReserved = reader.GetBytes(40, 4);
+					}
+					catch (IOException e)
+					{
+						error = "Exception reading AviRiff chunk 'avih' : " + e.Message;
+					}
+
+					var directory = new AviDirectory();
+					if (error == null)
+					{
+						directory.Set(AviDirectory.TAG_WIDTH, dwWidth);
+						directory.Set(AviDirectory.TAG_HEIGHT, dwHeight);
+						directory.Set(AviDirectory.TAG_STREAMS, dwStreams);
+					}
+					else
+						directory.AddError(error);
+					_directories.Add(directory);
+					break;
+                }
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
@@ -126,56 +126,56 @@ namespace MetadataExtractor.Formats.QuickTime
             {
                 var atomStartPos = stream.Position;
 
-				try
-				{
-					// Check if the end of the stream is closer then 8 bytes to current position (Length of the atom's data + atom type)
-					if( reader.IsCloserToEnd(8)) return;
+                try
+                {
+                    // Check if the end of the stream is closer then 8 bytes to current position (Length of the atom's data + atom type)
+                    if (reader.IsCloserToEnd(8)) return;
 
-					// Length of the atom's data, in bytes, including size bytes
-					long atomSize = reader.GetUInt32();
+                    // Length of the atom's data, in bytes, including size bytes
+                    long atomSize = reader.GetUInt32();
 
-					// Typically four ASCII characters, but may be non-printable.
-					// By convention, lowercase 4CCs are reserved by Apple.
-					var atomType = reader.GetUInt32();
+                    // Typically four ASCII characters, but may be non-printable.
+                    // By convention, lowercase 4CCs are reserved by Apple.
+                    var atomType = reader.GetUInt32();
 
-					if (atomSize == 1)
-					{
-						// Check if the end of the stream is closer then 8 bytes
-						if (reader.IsCloserToEnd(8)) return;
+                    if (atomSize == 1)
+                    {
+                        // Check if the end of the stream is closer then 8 bytes
+                        if (reader.IsCloserToEnd(8)) return;
 
-						// Size doesn't fit in 32 bits so read the 64 bit size here
-						atomSize = checked((long)reader.GetUInt64());
-					}
-					else
-					{
-						Debug.Assert(atomSize >= 8, "Atom should be at least 8 bytes long");
-					}
+                        // Size doesn't fit in 32 bits so read the 64 bit size here
+                        atomSize = checked((long)reader.GetUInt64());
+                    }
+                    else
+                    {
+                        Debug.Assert(atomSize >= 8, "Atom should be at least 8 bytes long");
+                    }
 
-					var args = new AtomCallbackArgs(atomType, atomSize, stream, atomStartPos, reader);
+                    var args = new AtomCallbackArgs(atomType, atomSize, stream, atomStartPos, reader);
 
-					handler(args);
+                    handler(args);
 
-					if (args.Cancel)
-						return;
+                    if (args.Cancel)
+                        return;
 
-					if (atomSize == 0)
-						return;
+                    if (atomSize == 0)
+                        return;
 
-					var toSkip = atomStartPos + atomSize - stream.Position;
+                    var toSkip = atomStartPos + atomSize - stream.Position;
 
-					if (toSkip < 0)
-						throw new Exception("Handler moved stream beyond end of atom");
+                    if (toSkip < 0)
+                        throw new Exception("Handler moved stream beyond end of atom");
 
-					// To avoid exception handling we can check if needed number of bytes are available
-					if(!reader.IsCloserToEnd(toSkip))
-						reader.TrySkip(toSkip);
-				}
-				catch (IOException)
-				{
-					// Exception trapping is used when stream doen't support stream length method only
-					return;
-				}
-			}
-		}
+                    // To avoid exception handling we can check if needed number of bytes are available
+                    if (!reader.IsCloserToEnd(toSkip))
+                        reader.TrySkip(toSkip);
+                }
+                catch (IOException)
+                {
+                    // Exception trapping is used when stream doen't support stream length method only
+                    return;
+                }
+            }
+        }
     }
 }

--- a/MetadataExtractor/Formats/Riff/IRiffHandler.cs
+++ b/MetadataExtractor/Formats/Riff/IRiffHandler.cs
@@ -49,10 +49,20 @@ namespace MetadataExtractor.Formats.Riff
         /// <returns><c>true</c> if <see cref="ProcessChunk(string, byte[])"/> should be called, otherwise <c>false</c>.</returns>
         bool ShouldAcceptChunk([NotNull] string fourCc);
 
-        /// <summary>Perform whatever processing is necessary for the type of chunk with its payload.</summary>
-        /// <remarks>This is only called if a previous call to <see cref="ShouldAcceptChunk(string)"/> with the same <c>fourCC</c> returned <c>true</c>.</remarks>
-        /// <param name="fourCc">the four character code of the chunk</param>
-        /// <param name="payload">they payload of the chunk as a byte array</param>
-        void ProcessChunk([NotNull] string fourCc, [NotNull] byte[] payload);
+		/// <summary>Gets whether this handler is interested in the specific list type.</summary>
+		/// <remarks>
+		/// Returns <c>true</c> if the data should be copied into an array and passed
+		/// to <see cref="ProcessChunk(string, byte[])"/>, or <c>false</c> to avoid
+		/// the copy and skip to the next chunk in the file, if any.
+		/// </remarks>
+		/// <param name="fourCc">the four character code of this chunk</param>
+		/// <returns><c>true</c> if <see cref="ProcessChunk(string, byte[])"/> should be called, otherwise <c>false</c>.</returns>
+		bool ShouldAcceptList([NotNull] string fourCc);
+
+		/// <summary>Perform whatever processing is necessary for the type of chunk with its payload.</summary>
+		/// <remarks>This is only called if a previous call to <see cref="ShouldAcceptChunk(string)"/> with the same <c>fourCC</c> returned <c>true</c>.</remarks>
+		/// <param name="fourCc">the four character code of the chunk</param>
+		/// <param name="payload">they payload of the chunk as a byte array</param>
+		void ProcessChunk([NotNull] string fourCc, [NotNull] byte[] payload);
     }
 }

--- a/MetadataExtractor/Formats/Riff/IRiffHandler.cs
+++ b/MetadataExtractor/Formats/Riff/IRiffHandler.cs
@@ -49,20 +49,20 @@ namespace MetadataExtractor.Formats.Riff
         /// <returns><c>true</c> if <see cref="ProcessChunk(string, byte[])"/> should be called, otherwise <c>false</c>.</returns>
         bool ShouldAcceptChunk([NotNull] string fourCc);
 
-		/// <summary>Gets whether this handler is interested in the specific list type.</summary>
-		/// <remarks>
-		/// Returns <c>true</c> if the data should be copied into an array and passed
-		/// to <see cref="ProcessChunk(string, byte[])"/>, or <c>false</c> to avoid
-		/// the copy and skip to the next chunk in the file, if any.
-		/// </remarks>
-		/// <param name="fourCc">the four character code of this chunk</param>
-		/// <returns><c>true</c> if <see cref="ProcessChunk(string, byte[])"/> should be called, otherwise <c>false</c>.</returns>
-		bool ShouldAcceptList([NotNull] string fourCc);
+        /// <summary>Gets whether this handler is interested in the specific list type.</summary>
+        /// <remarks>
+        /// Returns <c>true</c> if the data should be copied into an array and passed
+        /// to <see cref="ProcessChunk(string, byte[])"/>, or <c>false</c> to avoid
+        /// the copy and skip to the next chunk in the file, if any.
+        /// </remarks>
+        /// <param name="fourCc">the four character code of this chunk</param>
+        /// <returns><c>true</c> if <see cref="ProcessChunk(string, byte[])"/> should be called, otherwise <c>false</c>.</returns>
+        bool ShouldAcceptList([NotNull] string fourCc);
 
-		/// <summary>Perform whatever processing is necessary for the type of chunk with its payload.</summary>
-		/// <remarks>This is only called if a previous call to <see cref="ShouldAcceptChunk(string)"/> with the same <c>fourCC</c> returned <c>true</c>.</remarks>
-		/// <param name="fourCc">the four character code of the chunk</param>
-		/// <param name="payload">they payload of the chunk as a byte array</param>
-		void ProcessChunk([NotNull] string fourCc, [NotNull] byte[] payload);
+        /// <summary>Perform whatever processing is necessary for the type of chunk with its payload.</summary>
+        /// <remarks>This is only called if a previous call to <see cref="ShouldAcceptChunk(string)"/> with the same <c>fourCC</c> returned <c>true</c>.</remarks>
+        /// <param name="fourCc">the four character code of the chunk</param>
+        /// <param name="payload">they payload of the chunk as a byte array</param>
+        void ProcessChunk([NotNull] string fourCc, [NotNull] byte[] payload);
     }
 }

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -42,86 +42,86 @@ namespace MetadataExtractor.Formats.Riff
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class RiffReader
     {
-		/// <summary>Processes a RIFF data sequence.</summary>
-		/// <param name="reader">The <see cref="SequentialReader"/> from which the data should be read.</param>
-		/// <param name="handler">The <see cref="IRiffHandler"/> that will coordinate processing and accept read values.</param>
-		/// <exception cref="RiffProcessingException">An error occurred during the processing of RIFF data that could not be ignored or recovered from.</exception>
-		/// <exception cref="System.IO.IOException">an error occurred while accessing the required data</exception>
-		public void ProcessRiff([NotNull] SequentialReader reader, [NotNull] IRiffHandler handler)
-		{
-			// RIFF files are always little-endian
-			reader = reader.WithByteOrder(isMotorolaByteOrder: false);
+        /// <summary>Processes a RIFF data sequence.</summary>
+        /// <param name="reader">The <see cref="SequentialReader"/> from which the data should be read.</param>
+        /// <param name="handler">The <see cref="IRiffHandler"/> that will coordinate processing and accept read values.</param>
+        /// <exception cref="RiffProcessingException">An error occurred during the processing of RIFF data that could not be ignored or recovered from.</exception>
+        /// <exception cref="System.IO.IOException">an error occurred while accessing the required data</exception>
+        public void ProcessRiff([NotNull] SequentialReader reader, [NotNull] IRiffHandler handler)
+        {
+            // RIFF files are always little-endian
+            reader = reader.WithByteOrder(isMotorolaByteOrder: false);
 
-			// PROCESS FILE HEADER
+            // PROCESS FILE HEADER
 
-			var fileFourCc = reader.GetString(4, Encoding.ASCII);
-			if (fileFourCc != "RIFF")
-				throw new RiffProcessingException("Invalid RIFF header: " + fileFourCc);
+            var fileFourCc = reader.GetString(4, Encoding.ASCII);
+            if (fileFourCc != "RIFF")
+                throw new RiffProcessingException("Invalid RIFF header: " + fileFourCc);
 
-			// The total size of the chunks that follow plus 4 bytes for the 'WEBP' or 'AVI ' FourCC
-			int fileSize = reader.GetInt32();
-			int sizeLeft = fileSize;
-			string identifier = reader.GetString(4, Encoding.ASCII);
-			sizeLeft -= 4;
+            // The total size of the chunks that follow plus 4 bytes for the 'WEBP' or 'AVI ' FourCC
+            int fileSize = reader.GetInt32();
+            int sizeLeft = fileSize;
+            string identifier = reader.GetString(4, Encoding.ASCII);
+            sizeLeft -= 4;
 
-			if (!handler.ShouldAcceptRiffIdentifier(identifier))
-				return;
+            if (!handler.ShouldAcceptRiffIdentifier(identifier))
+                return;
 
-			ProcessChunks(reader, sizeLeft, handler);
-		}
+            ProcessChunks(reader, sizeLeft, handler);
+        }
 
-		// PROCESS CHUNKS
-		public void ProcessChunks([NotNull] SequentialReader reader, int sizeLeft, [NotNull] IRiffHandler handler)
-		{
-			// Processing chunks. Each chunk is 8 bytes header (4 bytes CC code + 4 bytes length of chunk) + data of the chunk
+        // PROCESS CHUNKS
+        public void ProcessChunks([NotNull] SequentialReader reader, int sizeLeft, [NotNull] IRiffHandler handler)
+        {
+            // Processing chunks. Each chunk is 8 bytes header (4 bytes CC code + 4 bytes length of chunk) + data of the chunk
 
-            while (reader.Position<sizeLeft)
+            while (reader.Position < sizeLeft)
             {
-				// Check if end of the file is closer then 8 bytes
-				if (reader.IsCloserToEnd(8)) return;
+                // Check if end of the file is closer then 8 bytes
+                if (reader.IsCloserToEnd(8)) return;
 
                 string chunkFourCc = reader.GetString(4, Encoding.ASCII);
                 int chunkSize = reader.GetInt32();
 
-				sizeLeft -= 8;
+                sizeLeft -= 8;
 
-				// NOTE we fail a negative chunk size here (greater than 0x7FFFFFFF) as we cannot allocate arrays larger than this
-				if (chunkSize < 0 || sizeLeft < chunkSize)
+                // NOTE we fail a negative chunk size here (greater than 0x7FFFFFFF) as we cannot allocate arrays larger than this
+                if (chunkSize < 0 || sizeLeft < chunkSize)
                     throw new RiffProcessingException("Invalid RIFF chunk size");
 
-				// Check if end of the file is closer then chunkSize bytes
-				if (reader.IsCloserToEnd(chunkSize)) return;
+                // Check if end of the file is closer then chunkSize bytes
+                if (reader.IsCloserToEnd(chunkSize)) return;
 
-				if (chunkFourCc == "LIST" || chunkFourCc == "RIFF")
-				{
-					string listName = reader.GetString(4, Encoding.ASCII);
-					if (handler.ShouldAcceptList(listName))
-						ProcessChunks(reader, sizeLeft - 4, handler);
-					else
-						reader.Skip(sizeLeft - 4);
-					sizeLeft -= chunkSize;
-				}
-				else
-				{
-					if (handler.ShouldAcceptChunk(chunkFourCc))
-					{
-						// TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
-						handler.ProcessChunk(chunkFourCc, reader.GetBytes(chunkSize));
-					}
-					else
-					{
-						reader.Skip(chunkSize);
-					}
+                if (chunkFourCc == "LIST" || chunkFourCc == "RIFF")
+                {
+                    string listName = reader.GetString(4, Encoding.ASCII);
+                    if (handler.ShouldAcceptList(listName))
+                        ProcessChunks(reader, sizeLeft - 4, handler);
+                    else
+                        reader.Skip(sizeLeft - 4);
+                    sizeLeft -= chunkSize;
+                }
+                else
+                {
+                    if (handler.ShouldAcceptChunk(chunkFourCc))
+                    {
+                        // TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
+                        handler.ProcessChunk(chunkFourCc, reader.GetBytes(chunkSize));
+                    }
+                    else
+                    {
+                        reader.Skip(chunkSize);
+                    }
 
-					sizeLeft -= chunkSize;
+                    sizeLeft -= chunkSize;
 
-					// Skip any padding byte added to keep chunks aligned to even numbers of bytes
-					if (chunkSize % 2 == 1)
-					{
-						reader.GetSByte();
-						sizeLeft--;
-					}
-				}
+                    // Skip any padding byte added to keep chunks aligned to even numbers of bytes
+                    if (chunkSize % 2 == 1)
+                    {
+                        reader.GetSByte();
+                        sizeLeft--;
+                    }
+                }
             }
         }
     }

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -42,62 +42,86 @@ namespace MetadataExtractor.Formats.Riff
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class RiffReader
     {
-        /// <summary>Processes a RIFF data sequence.</summary>
-        /// <param name="reader">The <see cref="SequentialReader"/> from which the data should be read.</param>
-        /// <param name="handler">The <see cref="IRiffHandler"/> that will coordinate processing and accept read values.</param>
-        /// <exception cref="RiffProcessingException">An error occurred during the processing of RIFF data that could not be ignored or recovered from.</exception>
-        /// <exception cref="System.IO.IOException">an error occurred while accessing the required data</exception>
-        public void ProcessRiff([NotNull] SequentialReader reader, [NotNull] IRiffHandler handler)
-        {
-            // RIFF files are always little-endian
-            reader = reader.WithByteOrder(isMotorolaByteOrder: false);
+		/// <summary>Processes a RIFF data sequence.</summary>
+		/// <param name="reader">The <see cref="SequentialReader"/> from which the data should be read.</param>
+		/// <param name="handler">The <see cref="IRiffHandler"/> that will coordinate processing and accept read values.</param>
+		/// <exception cref="RiffProcessingException">An error occurred during the processing of RIFF data that could not be ignored or recovered from.</exception>
+		/// <exception cref="System.IO.IOException">an error occurred while accessing the required data</exception>
+		public void ProcessRiff([NotNull] SequentialReader reader, [NotNull] IRiffHandler handler)
+		{
+			// RIFF files are always little-endian
+			reader = reader.WithByteOrder(isMotorolaByteOrder: false);
 
-            // PROCESS FILE HEADER
+			// PROCESS FILE HEADER
 
-            var fileFourCc = reader.GetString(4, Encoding.UTF8);
-            if (fileFourCc != "RIFF")
-                throw new RiffProcessingException("Invalid RIFF header: " + fileFourCc);
+			var fileFourCc = reader.GetString(4, Encoding.ASCII);
+			if (fileFourCc != "RIFF")
+				throw new RiffProcessingException("Invalid RIFF header: " + fileFourCc);
 
-            // The total size of the chunks that follow plus 4 bytes for the 'WEBP' FourCC
-            var fileSize = reader.GetInt32();
-            var sizeLeft = fileSize;
-            var identifier = reader.GetString(4, Encoding.UTF8);
-            sizeLeft -= 4;
+			// The total size of the chunks that follow plus 4 bytes for the 'WEBP' or 'AVI ' FourCC
+			int fileSize = reader.GetInt32();
+			int sizeLeft = fileSize;
+			string identifier = reader.GetString(4, Encoding.ASCII);
+			sizeLeft -= 4;
 
-            if (!handler.ShouldAcceptRiffIdentifier(identifier))
-                return;
+			if (!handler.ShouldAcceptRiffIdentifier(identifier))
+				return;
 
-            // PROCESS CHUNKS
+			ProcessChunks(reader, sizeLeft, handler);
+		}
 
-            while (sizeLeft != 0)
+		// PROCESS CHUNKS
+		public void ProcessChunks([NotNull] SequentialReader reader, int sizeLeft, [NotNull] IRiffHandler handler)
+		{
+			// Processing chunks. Each chunk is 8 bytes header (4 bytes CC code + 4 bytes length of chunk) + data of the chunk
+
+            while (reader.Position<sizeLeft)
             {
-                var chunkFourCc = reader.GetString(4, Encoding.UTF8);
-                var chunkSize = reader.GetInt32();
+				// Check if end of the file is closer then 8 bytes
+				if (reader.IsCloserToEnd(8)) return;
 
-                sizeLeft -= 8;
+                string chunkFourCc = reader.GetString(4, Encoding.ASCII);
+                int chunkSize = reader.GetInt32();
 
-                // NOTE we fail a negative chunk size here (greater than 0x7FFFFFFF) as we cannot allocate arrays larger than this
-                if (chunkSize < 0 || sizeLeft < chunkSize)
+				sizeLeft -= 8;
+
+				// NOTE we fail a negative chunk size here (greater than 0x7FFFFFFF) as we cannot allocate arrays larger than this
+				if (chunkSize < 0 || sizeLeft < chunkSize)
                     throw new RiffProcessingException("Invalid RIFF chunk size");
 
-                if (handler.ShouldAcceptChunk(chunkFourCc))
-                {
-                    // TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
-                    handler.ProcessChunk(chunkFourCc, reader.GetBytes(chunkSize));
-                }
-                else
-                {
-                    reader.Skip(chunkSize);
-                }
+				// Check if end of the file is closer then chunkSize bytes
+				if (reader.IsCloserToEnd(chunkSize)) return;
 
-                sizeLeft -= chunkSize;
+				if (chunkFourCc == "LIST" || chunkFourCc == "RIFF")
+				{
+					string listName = reader.GetString(4, Encoding.ASCII);
+					if (handler.ShouldAcceptList(listName))
+						ProcessChunks(reader, sizeLeft - 4, handler);
+					else
+						reader.Skip(sizeLeft - 4);
+					sizeLeft -= chunkSize;
+				}
+				else
+				{
+					if (handler.ShouldAcceptChunk(chunkFourCc))
+					{
+						// TODO is it feasible to avoid copying the chunk here, and to pass the sequential reader to the handler?
+						handler.ProcessChunk(chunkFourCc, reader.GetBytes(chunkSize));
+					}
+					else
+					{
+						reader.Skip(chunkSize);
+					}
 
-                // Skip any padding byte added to keep chunks aligned to even numbers of bytes
-                if (chunkSize % 2 == 1)
-                {
-                    reader.GetSByte();
-                    sizeLeft--;
-                }
+					sizeLeft -= chunkSize;
+
+					// Skip any padding byte added to keep chunks aligned to even numbers of bytes
+					if (chunkSize % 2 == 1)
+					{
+						reader.GetSByte();
+						sizeLeft--;
+					}
+				}
             }
         }
     }

--- a/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
+++ b/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
@@ -66,9 +66,9 @@ namespace MetadataExtractor.Formats.WebP
                                                         fourCc == "ICCP" ||
                                                         fourCc == "XMP ";
 
-		public bool ShouldAcceptList(string fourCc) =>	false;
+        public bool ShouldAcceptList(string fourCc) => false;
 
-		public void ProcessChunk(string fourCc, byte[] payload)
+        public void ProcessChunk(string fourCc, byte[] payload)
         {
             switch (fourCc)
             {

--- a/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
+++ b/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
@@ -66,7 +66,9 @@ namespace MetadataExtractor.Formats.WebP
                                                         fourCc == "ICCP" ||
                                                         fourCc == "XMP ";
 
-        public void ProcessChunk(string fourCc, byte[] payload)
+		public bool ShouldAcceptList(string fourCc) =>	false;
+
+		public void ProcessChunk(string fourCc, byte[] payload)
         {
             switch (fourCc)
             {

--- a/MetadataExtractor/IO/SequentialByteArrayReader.cs
+++ b/MetadataExtractor/IO/SequentialByteArrayReader.cs
@@ -101,5 +101,10 @@ namespace MetadataExtractor.IO
 
             return true;
         }
-    }
+
+		public override bool IsCloserToEnd(long numberOfBytes)
+		{
+			return _index + numberOfBytes >= _bytes.Length;
+		}
+	}
 }

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -346,5 +346,16 @@ namespace MetadataExtractor.IO
                 Array.Copy(buffer, bytes, length);
             return bytes;
         }
-    }
+
+		/// <summary>
+		/// Returns true in case the stream supports length checking and distance to the end of the stream is less then number of bytes in parameter.
+		/// Otherwise false.
+		/// </summary>
+		/// <param name="numberOfBytes"></param>
+		/// <returns>True if we going to have an exception while reading next numberOfBytes bytes from the stream</returns>
+		public virtual bool IsCloserToEnd(long numberOfBytes)
+		{
+			return false;
+		}
+	}
 }

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -347,15 +347,15 @@ namespace MetadataExtractor.IO
             return bytes;
         }
 
-		/// <summary>
-		/// Returns true in case the stream supports length checking and distance to the end of the stream is less then number of bytes in parameter.
-		/// Otherwise false.
-		/// </summary>
-		/// <param name="numberOfBytes"></param>
-		/// <returns>True if we going to have an exception while reading next numberOfBytes bytes from the stream</returns>
-		public virtual bool IsCloserToEnd(long numberOfBytes)
-		{
-			return false;
-		}
-	}
+        /// <summary>
+        /// Returns true in case the stream supports length checking and distance to the end of the stream is less then number of bytes in parameter.
+        /// Otherwise false.
+        /// </summary>
+        /// <param name="numberOfBytes"></param>
+        /// <returns>True if we going to have an exception while reading next numberOfBytes bytes from the stream</returns>
+        public virtual bool IsCloserToEnd(long numberOfBytes)
+        {
+            return false;
+        }
+    }
 }

--- a/MetadataExtractor/IO/SequentialStreamReader.cs
+++ b/MetadataExtractor/IO/SequentialStreamReader.cs
@@ -98,5 +98,10 @@ namespace MetadataExtractor.IO
                 return false;
             }
         }
-    }
+    
+		public override bool IsCloserToEnd(long numberOfBytes)
+		{
+			return _stream.Position + numberOfBytes >= _stream.Length;
+		}
+	}
 }

--- a/MetadataExtractor/IO/SequentialStreamReader.cs
+++ b/MetadataExtractor/IO/SequentialStreamReader.cs
@@ -98,10 +98,10 @@ namespace MetadataExtractor.IO
                 return false;
             }
         }
-    
-		public override bool IsCloserToEnd(long numberOfBytes)
-		{
-			return _stream.Position + numberOfBytes >= _stream.Length;
-		}
-	}
+
+        public override bool IsCloserToEnd(long numberOfBytes)
+        {
+            return _stream.Position + numberOfBytes >= _stream.Length;
+        }
+    }
 }

--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -39,6 +39,7 @@ using MetadataExtractor.Formats.QuickTime;
 using MetadataExtractor.Formats.Raf;
 using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.Formats.WebP;
+using MetadataExtractor.Formats.Avi;
 using MetadataExtractor.Util;
 
 #if NET35
@@ -118,6 +119,8 @@ namespace MetadataExtractor
                     return new Directory[] { PcxMetadataReader.ReadMetadata(stream), fileTypeDirectory };
                 case FileType.WebP:
                     return Append(WebPMetadataReader.ReadMetadata(stream), fileTypeDirectory);
+                case FileType.Avi:
+                    return Append(AviMetadataReader.ReadMetadata(stream), fileTypeDirectory);
                 case FileType.Raf:
                     return Append(RafMetadataReader.ReadMetadata(stream), fileTypeDirectory);
                 case FileType.QuickTime:
@@ -128,7 +131,6 @@ namespace MetadataExtractor
                     throw new ImageProcessingException("File format could not be determined");
                 case FileType.Riff:
                 case FileType.Wav:
-                case FileType.Avi:
                 case FileType.Crw:
                 default:
                     throw new ImageProcessingException("File format is not supported");


### PR DESCRIPTION
I have a mp4 video file made by camera with no other modifications. The QuickTimeReader crashes with no exif information about the file. It looks like the file ends between atom size and atom type bytes where is not exception handling at all. I put whole code in try-catch and add methods to avoid rising of exceptions for stability and performance.
MetadataExtractor.sln: I have no idea what for  MS VS changes project file on open.