### PR TITLE
Cross target NETSTANDARD 2.0

### DIFF
--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -13,7 +13,7 @@
     <AssemblyTitle>Metadata Extractor</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Drew Noakes</Authors>
-    <TargetFrameworks>netstandard1.3;net35;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net35;net45</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>


### PR DESCRIPTION
This eliminates dependencies (excluding XmpCore) on modern runtimes.