### PR TITLE
Query underlying Stream object for Length, but fallback to original m…

### DIFF
--- a/MetadataExtractor/IO/IndexedCapturingReader.cs
+++ b/MetadataExtractor/IO/IndexedCapturingReader.cs
@@ -60,9 +60,16 @@ namespace MetadataExtractor.IO
         {
             get
             {
-                IsValidIndex(int.MaxValue, 1);
-                Debug.Assert(_isStreamFinished);
-                return _streamLength;
+                try
+                {
+                    return _stream.Length;
+                }
+                catch (NotSupportedException)
+                {
+                    IsValidIndex(int.MaxValue, 1);
+                    Debug.Assert(_isStreamFinished);
+                    return _streamLength;
+                }
             }
         }
 

--- a/MetadataExtractor/IO/IndexedCapturingReader.cs
+++ b/MetadataExtractor/IO/IndexedCapturingReader.cs
@@ -41,6 +41,7 @@ namespace MetadataExtractor.IO
         private readonly List<byte[]> _chunks = new List<byte[]>();
         private bool _isStreamFinished;
         private int _streamLength;
+        private bool _streamLengthThrewException = false;
 
         public IndexedCapturingReader([NotNull] Stream stream, int chunkLength = DefaultChunkLength, bool isMotorolaByteOrder = true)
             : base(isMotorolaByteOrder)
@@ -60,16 +61,21 @@ namespace MetadataExtractor.IO
         {
             get
             {
-                try
+                if (!_streamLengthThrewException)
                 {
-                    return _stream.Length;
+                    try
+                    {
+                        return _stream.Length;
+                    }
+                    catch (NotSupportedException)
+                    {
+                        _streamLengthThrewException = true;
+                    }
                 }
-                catch (NotSupportedException)
-                {
-                    IsValidIndex(int.MaxValue, 1);
-                    Debug.Assert(_isStreamFinished);
-                    return _streamLength;
-                }
+                
+                IsValidIndex(int.MaxValue, 1);
+                Debug.Assert(_isStreamFinished);
+                return _streamLength;
             }
         }
 


### PR DESCRIPTION
…echanism if the stream doesn't support the Length operation. Addresses https://github.com/drewnoakes/metadata-extractor-dotnet/issues/122 by allowing for streamed parsing of metadata.