### PR TITLE
Bugfix: IsCloserToEnd returns true on reading last byte, should be false

### DIFF
--- a/MetadataExtractor/IO/SequentialByteArrayReader.cs
+++ b/MetadataExtractor/IO/SequentialByteArrayReader.cs
@@ -104,7 +104,7 @@ namespace MetadataExtractor.IO
 
 		public override bool IsCloserToEnd(long numberOfBytes)
 		{
-			return _index + numberOfBytes >= _bytes.Length;
+			return _index + numberOfBytes > _bytes.Length;
 		}
 	}
 }

--- a/MetadataExtractor/IO/SequentialStreamReader.cs
+++ b/MetadataExtractor/IO/SequentialStreamReader.cs
@@ -101,7 +101,7 @@ namespace MetadataExtractor.IO
 
         public override bool IsCloserToEnd(long numberOfBytes)
         {
-            return _stream.Position + numberOfBytes >= _stream.Length;
+            return _stream.Position + numberOfBytes > _stream.Length;
         }
     }
 }


### PR DESCRIPTION
Bugfix: IsCloserToEnd returns true on reading last byte, should be false. IsCloserToEnd must return true if we read after EOF only.