### PR TITLE
Xmp allow raw data

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root = true
+
+[*.cs]
+indent_size = 4
+indent_style = space
+trim_trailing_whitespace = true
+insert_final_newline = true

--- a/MetadataExtractor.sln
+++ b/MetadataExtractor.sln
@@ -5,6 +5,7 @@ VisualStudioVersion = 15.0.27130.2010
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{8CF154EA-6A2C-4BF4-B263-78758F834192}"
 	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
 		.gitattributes = .gitattributes
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml

--- a/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
@@ -25,6 +25,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using System.Xml.Linq;
 using JetBrains.Annotations;
 using XmpCore;
 
@@ -60,6 +61,11 @@ namespace MetadataExtractor.Formats.Xmp
         [CanBeNull]
         public byte[] XmpRawData { get; private set; }
 
+        /// <summary>Root XMP <see cref="XDocument"/> as read from the file.</summary>
+        /// <remarks>Allows processing data from this element if the data is not standards-compliant.</remarks>
+        [CanBeNull]
+        public XDocument Root { get; private set; }
+
         public XmpDirectory()
         {
             SetDescriptor(new XmpDescriptor(this));
@@ -93,9 +99,14 @@ namespace MetadataExtractor.Formats.Xmp
             Set(TagXmpValueCount, XmpMeta.Properties.Count(prop => prop.Path != null));
         }
 
-        public void SetXmpRawData([NotNull]byte[] data)
+        public void SetXmpRawData([NotNull] byte[] data)
         {
             XmpRawData = data;
+        }
+
+        public void SetRootDocument([NotNull] XDocument root)
+        {
+            Root = root;
         }
     }
 }

--- a/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
@@ -45,7 +45,6 @@ namespace MetadataExtractor.Formats.Xmp
     {
         public const int TagXmpValueCount = 0xFFFF;
 
-
         private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
         {
             { TagXmpValueCount, "XMP Value Count" }
@@ -55,6 +54,11 @@ namespace MetadataExtractor.Formats.Xmp
         /// <remarks>This object provides a rich API for working with XMP data.</remarks>
         [CanBeNull]
         public IXmpMeta XmpMeta { get; private set; }
+
+        /// <summary>Gets the raw data exposed by the Xmp element within this directory.</summary>
+        /// <remarks>Allows processing data from this element if the data is not standards-compliant.</remarks>
+        [CanBeNull]
+        public byte[] XmpRawData { get; private set; }
 
         public XmpDirectory()
         {
@@ -87,6 +91,11 @@ namespace MetadataExtractor.Formats.Xmp
             XmpMeta = xmpMeta;
 
             Set(TagXmpValueCount, XmpMeta.Properties.Count(prop => prop.Path != null));
+        }
+
+        public void SetXmpRawData([NotNull]byte[] data)
+        {
+            XmpRawData = data;
         }
     }
 }

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -104,6 +104,7 @@ namespace MetadataExtractor.Formats.Xmp
         public XmpDirectory Extract([NotNull] byte[] xmpBytes, int offset, int length)
         {
             var directory = new XmpDirectory();
+            directory.SetXmpRawData(xmpBytes);
             try
             {
                 var xmpMeta = XmpMetaFactory.ParseFromBuffer(xmpBytes, offset, length);

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -22,6 +22,7 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -104,10 +105,16 @@ namespace MetadataExtractor.Formats.Xmp
         public XmpDirectory Extract([NotNull] byte[] xmpBytes, int offset, int length)
         {
             var directory = new XmpDirectory();
-            directory.SetXmpRawData(xmpBytes);
             try
             {
-                var xmpMeta = XmpMetaFactory.ParseFromBuffer(xmpBytes, offset, length);
+                var bytes = new byte[length];
+                Array.Copy(xmpBytes, offset, bytes, 0, length);
+                directory.SetXmpRawData(bytes);
+
+                var xdoc = XmpMetaFactory.ExtractXDocumentFromBuffer(bytes);
+                directory.SetRootDocument(xdoc);
+
+                var xmpMeta = XmpMetaFactory.ParseFromXDocument(xdoc);
                 directory.SetXmpMeta(xmpMeta);
             }
             catch (XmpException e)


### PR DESCRIPTION
Two improvements:
1. Adding a .editorconfig, which is now supported by VS 2017. This ensures spacing/tab style consistency from anyone who edits files in this solution going forward.
1. Add `XmpRawData` property. Xmp Core enforces strict compliance with the Xmp standard, but at times, it is necessary to extract xmp data from a file where the provider of the file does not meet the standard. Adding this property allows accessing the data directly so users can access the data if it is non-compliant.
** I am not beholden to using `byte[]` for the raw data. I would be happy to change it to `XDocument` if it would make more sense. This seemed the easiest and most flexible way to provide access to the data.