### PR TITLE
Retarget and utilize System.Memory

### DIFF
--- a/MetadataExtractor.Benchmarks/MetadataExtractor.Benchmarks.csproj
+++ b/MetadataExtractor.Benchmarks/MetadataExtractor.Benchmarks.csproj
@@ -25,7 +25,6 @@
     <Reference Include="System.Xaml" />
     <Reference Include="System.Drawing" />
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.Benchmarks/MetadataExtractor.Benchmarks.csproj
+++ b/MetadataExtractor.Benchmarks/MetadataExtractor.Benchmarks.csproj
@@ -12,8 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.10.12" />
-    <PackageReference Include="BenchmarkDotNet.Core" Version="0.10.12" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.11.1" />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/MetadataExtractor.Benchmarks/Program.cs
+++ b/MetadataExtractor.Benchmarks/Program.cs
@@ -101,7 +101,9 @@ namespace MetadataExtractor.Benchmarks
 
             // This is the largest JPEG file in this repository
             using (var fs = File.OpenRead("../MetadataExtractor.Tests/Data/nikonMakernoteType2b.jpg"))
+            {
                 fs.CopyTo(_stream);
+            }
         }
 
         [Benchmark(Baseline = true)]

--- a/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
+++ b/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
+++ b/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net461</TargetFramework>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -14,7 +14,7 @@
     <PackageReference Include="System.Management.Automation" Version="6.1.7601.17515" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>

--- a/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
+++ b/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
@@ -17,7 +17,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
+++ b/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <LangVersion>latest</LangVersion>
@@ -13,10 +13,4 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
-</Project>
+  </ItemGroup></Project>

--- a/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
+++ b/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net35;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
-    <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
-    <RuntimeFrameworkVersion Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">1.0.4</RuntimeFrameworkVersion>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
@@ -15,10 +13,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/MetadataExtractor.Tests/Formats/Bmp/BmpReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Bmp/BmpReaderTest.cs
@@ -37,7 +37,9 @@ namespace MetadataExtractor.Tests.Formats.Bmp
         private static BmpHeaderDirectory ProcessBytes([NotNull] string filePath)
         {
             using (var stream = TestDataUtil.OpenRead(filePath))
-                return new BmpReader().Extract(new SequentialStreamReader(stream));
+            {
+                return BmpReader.Extract(new SequentialStreamReader(stream));
+            }
         }
 
         [Fact]

--- a/MetadataExtractor.Tests/Formats/Gif/GifReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Gif/GifReaderTest.cs
@@ -39,7 +39,7 @@ namespace MetadataExtractor.Tests.Formats.Gif
         private static IEnumerable<Directory> ProcessBytes([NotNull] string file)
         {
             using (var stream = TestDataUtil.OpenRead(file))
-                return new GifReader().Extract(new SequentialStreamReader(stream));
+                return GifReader.Extract(new SequentialStreamReader(stream));
         }
 
         [Fact]

--- a/MetadataExtractor.Tests/Formats/Netpbm/NetpbmReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Netpbm/NetpbmReaderTest.cs
@@ -55,7 +55,7 @@ namespace MetadataExtractor.Tests.Formats.Netpbm
         private static void Verify(string content, int formatType, int width, int height, int? maxVal)
         {
             var stream = new MemoryStream(Encoding.UTF8.GetBytes(content));
-            var directory = new NetpbmReader().Extract(stream);
+            var directory = NetpbmReader.Extract(stream);
 
             Assert.Equal(formatType, directory.GetInt32(NetpbmHeaderDirectory.TagFormatType));
             Assert.Equal(width, directory.GetInt32(NetpbmHeaderDirectory.TagWidth));

--- a/MetadataExtractor.Tests/Formats/Photoshop/PsdReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Photoshop/PsdReaderTest.cs
@@ -39,7 +39,7 @@ namespace MetadataExtractor.Tests.Formats.Photoshop
         {
             using (var stream = TestDataUtil.OpenRead(filePath))
             {
-                var directory = new PsdReader().Extract(new SequentialStreamReader(stream)).OfType<PsdHeaderDirectory>().FirstOrDefault();
+                var directory = PsdReader.Extract(new SequentialStreamReader(stream)).OfType<PsdHeaderDirectory>().FirstOrDefault();
                 Assert.NotNull(directory);
                 return directory;
             }

--- a/MetadataExtractor.Tests/Formats/Png/PngChunkReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Png/PngChunkReaderTest.cs
@@ -39,7 +39,7 @@ namespace MetadataExtractor.Tests.Formats.Png
         private static IList<PngChunk> ProcessFile(string filePath)
         {
             using (var stream = TestDataUtil.OpenRead(filePath))
-                return new PngChunkReader().Extract(new SequentialStreamReader(stream), null).ToList();
+                return PngChunkReader.Extract(new SequentialStreamReader(stream), null).ToList();
         }
 
         [Fact]

--- a/MetadataExtractor.Tests/Formats/Xmp/XmpReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Xmp/XmpReaderTest.cs
@@ -52,7 +52,7 @@ namespace MetadataExtractor.Tests.Formats.Xmp
         [Fact]
         public void testExtract_PropertyCount()
         {
-            Assert.Equal(179, _directory.GetInt32(XmpDirectory.TagXmpValueCount));
+            Assert.Equal(178, _directory.GetInt32(XmpDirectory.TagXmpValueCount));
         }
 
         [Fact]
@@ -60,7 +60,7 @@ namespace MetadataExtractor.Tests.Formats.Xmp
         {
             var propertyMap = _directory.GetXmpProperties();
 
-            Assert.Equal(179, propertyMap.Count);
+            Assert.Equal(178, propertyMap.Count);
 
             Assert.True(propertyMap.ContainsKey("photoshop:Country"));
             Assert.Equal("Deutschland", propertyMap["photoshop:Country"]);

--- a/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
+++ b/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
@@ -28,9 +28,8 @@
     <Content Include="Data\**" CopyToOutputDirectory="PreserveNewest" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
+++ b/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net452</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net452</TargetFrameworks>
     <DebugType>portable</DebugType>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dotnet5.4;portable-net451+win8</PackageTargetFallback>
@@ -15,10 +15,13 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.8.0" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.3.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
+    <PackageReference Include="xunit" Version="2.4.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
@@ -28,10 +31,6 @@
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.Tests/TestHelper.cs
+++ b/MetadataExtractor.Tests/TestHelper.cs
@@ -35,7 +35,9 @@ namespace MetadataExtractor.Tests
                 throw new ArgumentException("Attempting to skip more bytes than exist in the array.");
 
             var output = new byte[input.Length - countToSkip];
-            Array.Copy(input, countToSkip, output, 0, input.Length - countToSkip);
+
+            input.AsSpan(countToSkip, output.Length).CopyTo(output);
+
             return output;
         }
     }

--- a/MetadataExtractor.Tests/Util/ByteConvertTest.cs
+++ b/MetadataExtractor.Tests/Util/ByteConvertTest.cs
@@ -24,6 +24,7 @@
 
 #endregion
 
+using System.Buffers.Binary;
 using MetadataExtractor.Util;
 using Xunit;
 
@@ -35,15 +36,15 @@ namespace MetadataExtractor.Tests.Util
         [Fact]
         public void ToInt32BigEndian()
         {
-            Assert.Equal(0x01020304, ByteConvert.ToInt32BigEndian(new byte[] { 1, 2, 3, 4 }));
-            Assert.Equal(0x01020304, ByteConvert.ToInt32BigEndian(new byte[] { 1, 2, 3, 4, 5 }));
+            Assert.Equal(0x01020304, BinaryPrimitives.ReadInt32BigEndian(new byte[] { 1, 2, 3, 4 }));
+            Assert.Equal(0x01020304, BinaryPrimitives.ReadInt32BigEndian(new byte[] { 1, 2, 3, 4, 5 }));
         }
 
         [Fact]
         public void ToInt32LittleEndian()
         {
-            Assert.Equal(0x04030201, ByteConvert.ToInt32LittleEndian(new byte[] { 1, 2, 3, 4 }));
-            Assert.Equal(0x04030201, ByteConvert.ToInt32LittleEndian(new byte[] { 1, 2, 3, 4, 5 }));
+            Assert.Equal(0x04030201, BinaryPrimitives.ReadInt32LittleEndian(new byte[] { 1, 2, 3, 4 }));
+            Assert.Equal(0x04030201, BinaryPrimitives.ReadInt32LittleEndian(new byte[] { 1, 2, 3, 4, 5 }));
         }
     }
 }

--- a/MetadataExtractor.Tools.FileProcessor/MetadataExtractor.Tools.FileProcessor.csproj
+++ b/MetadataExtractor.Tools.FileProcessor/MetadataExtractor.Tools.FileProcessor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
@@ -15,11 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.Tools.FileProcessor/MetadataExtractor.Tools.FileProcessor.csproj
+++ b/MetadataExtractor.Tools.FileProcessor/MetadataExtractor.Tools.FileProcessor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net35;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <PackageTargetFallback Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">$(PackageTargetFallback);dnxcore50</PackageTargetFallback>
@@ -15,10 +15,6 @@
 
   <ItemGroup>
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/MetadataExtractor.Tools.JpegSegmentExtractor/MetadataExtractor.Tools.JpegSegmentExtractor.csproj
+++ b/MetadataExtractor.Tools.JpegSegmentExtractor/MetadataExtractor.Tools.JpegSegmentExtractor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net461</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <LangLevel>latest</LangLevel>
@@ -15,7 +15,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="System" />
   </ItemGroup>
 

--- a/MetadataExtractor.Tools.JpegSegmentExtractor/MetadataExtractor.Tools.JpegSegmentExtractor.csproj
+++ b/MetadataExtractor.Tools.JpegSegmentExtractor/MetadataExtractor.Tools.JpegSegmentExtractor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.0;net35;net45</TargetFrameworks>
+    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
     <DebugType>portable</DebugType>
     <OutputType>Exe</OutputType>
     <LangLevel>latest</LangLevel>
@@ -15,13 +15,8 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System" />
-  </ItemGroup>
-
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -25,9 +25,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-#if NETSTANDARD1_3
 using System.Text;
-#endif
 using JetBrains.Annotations;
 
 namespace MetadataExtractor
@@ -39,7 +37,7 @@ namespace MetadataExtractor
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public abstract class Directory
     {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || NETSTANDARD2_0
         static Directory()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);

--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -37,7 +37,7 @@ namespace MetadataExtractor
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public abstract class Directory
     {
-#if NETSTANDARD1_3 || NETSTANDARD2_0
+#if NETSTANDARD2_0
         static Directory()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);

--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -88,13 +88,7 @@ namespace MetadataExtractor
         /// <summary>Returns all <see cref="Tag"/> objects that have been set in this <see cref="Directory"/>.</summary>
         /// <value>The list of <see cref="Tag"/> objects.</value>
         [NotNull]
-        public
-#if NET35
-            IEnumerable<Tag>
-#else
-            IReadOnlyList<Tag>
-#endif
-            Tags => _definedTagList;
+        public IReadOnlyList<Tag> Tags => _definedTagList;
 
         /// <summary>Returns the number of tags set in this Directory.</summary>
         /// <value>the number of tags set in this Directory</value>
@@ -121,13 +115,7 @@ namespace MetadataExtractor
         /// <summary>Used to iterate over any error messages contained in this directory.</summary>
         /// <value>The collection of error message strings.</value>
         [NotNull]
-        public
-#if NET35
-            IEnumerable<string>
-#else
-            IReadOnlyList<string>
-#endif
-            Errors => _errorList;
+        public IReadOnlyList<string> Errors => _errorList;
 
         #endregion
 

--- a/MetadataExtractor/Formats/Adobe/AdobeJpegReader.cs
+++ b/MetadataExtractor/Formats/Adobe/AdobeJpegReader.cs
@@ -31,12 +31,6 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Adobe
 {
     /// <summary>Decodes Adobe formatted data stored in JPEG files, normally in the APPE (App14) segment.</summary>
@@ -48,14 +42,11 @@ namespace MetadataExtractor.Formats.Adobe
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.AppE };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             return segments
                 .Where(segment => segment.Bytes.Length == 12 && JpegSegmentPreamble.Equals(Encoding.UTF8.GetString(segment.Bytes, 0, JpegSegmentPreamble.Length), StringComparison.OrdinalIgnoreCase))
                 .Select(bytes => Extract(new SequentialByteArrayReader(bytes.Bytes)))
-#if NET35
-                .Cast<Directory>()
-#endif
                 .ToList();
         }
 

--- a/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
+++ b/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
@@ -45,18 +45,18 @@ namespace MetadataExtractor.Formats.Avi
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.AddRange(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }
 
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
         [NotNull]
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             var directories = new List<Directory>();
-            new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new AviRiffHandler(directories));
+            RiffReader.ProcessRiff(new SequentialStreamReader(stream), new AviRiffHandler(directories));
             return directories;
         }
     }

--- a/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
+++ b/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
@@ -29,12 +29,6 @@ using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Riff;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Avi
 {
     /// <summary>Obtains metadata from Avi files.</summary>
@@ -44,7 +38,7 @@ namespace MetadataExtractor.Formats.Avi
         /// <exception cref="System.IO.IOException"/>
         /// <exception cref="RiffProcessingException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 
@@ -59,7 +53,7 @@ namespace MetadataExtractor.Formats.Avi
         /// <exception cref="System.IO.IOException"/>
         /// <exception cref="RiffProcessingException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             var directories = new List<Directory>();
             new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new AviRiffHandler(directories));

--- a/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
@@ -51,7 +51,7 @@ namespace MetadataExtractor.Formats.Bmp
         [NotNull]
         public static BmpHeaderDirectory ReadMetadata([NotNull] Stream stream)
         {
-            return new BmpReader().Extract(new SequentialStreamReader(stream));
+            return BmpReader.Extract(new SequentialStreamReader(stream));
         }
     }
 }

--- a/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
@@ -28,21 +28,15 @@ using System.Collections.Generic;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Bmp
 {
     /// <summary>Obtains metadata from BMP files.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class BmpMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>(2);
 

--- a/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
@@ -43,7 +43,7 @@ namespace MetadataExtractor.Formats.Bmp
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.Add(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Bmp/BmpReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpReader.cs
@@ -29,10 +29,10 @@ using MetadataExtractor.IO;
 namespace MetadataExtractor.Formats.Bmp
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class BmpReader
+    public static class BmpReader
     {
         [NotNull]
-        public BmpHeaderDirectory Extract([NotNull] SequentialReader reader)
+        public static BmpHeaderDirectory Extract([NotNull] SequentialReader reader)
         {
             var directory = new BmpHeaderDirectory();
 

--- a/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
@@ -742,7 +742,7 @@ namespace MetadataExtractor.Formats.Exif
             string[] cfaColors = { "Red", "Green", "Blue", "Cyan", "Magenta", "Yellow", "White" };
 
             var ret = new StringBuilder();
-            ret.Append("[");
+            ret.Append('[');
             for (var pos = 2; pos < end; pos++)
             {
                 if (pattern[pos] <= cfaColors.Length - 1)
@@ -751,11 +751,11 @@ namespace MetadataExtractor.Formats.Exif
                     ret.Append("Unknown");  // indicated pattern position is outside the array bounds
 
                 if ((pos - 2) % pattern[1] == 0)
-                    ret.Append(",");
+                    ret.Append(',');
                 else if (pos != end - 1)
                     ret.Append("][");
             }
-            ret.Append("]");
+            ret.Append(']');
 
             return ret.ToString();
         }

--- a/MetadataExtractor/Formats/Exif/ExifReader.cs
+++ b/MetadataExtractor/Formats/Exif/ExifReader.cs
@@ -31,12 +31,6 @@ using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Exif
 {
     /// <summary>
@@ -52,7 +46,7 @@ namespace MetadataExtractor.Formats.Exif
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.App1 };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             return segments
                 .Where(segment => segment.Bytes.Length >= JpegSegmentPreamble.Length && Encoding.UTF8.GetString(segment.Bytes, 0, JpegSegmentPreamble.Length) == JpegSegmentPreamble)
@@ -64,7 +58,7 @@ namespace MetadataExtractor.Formats.Exif
         /// Reads TIFF formatted Exif data a specified offset within a <see cref="IndexedReader"/>.
         /// </summary>
         [NotNull]
-        public DirectoryList Extract([NotNull] IndexedReader reader)
+        public IReadOnlyList<Directory> Extract([NotNull] IndexedReader reader)
         {
             var directories = new List<Directory>();
             var exifTiffHandler = new ExifTiffHandler(directories);

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
@@ -1079,7 +1079,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             for (var i = 0; i < values.Length; i++)
             {
                 if (i == 0)
-                    sb.Append((_filters.ContainsKey(values[i]) ? _filters[values[i]] : "[unknown]") + "; ");
+                    sb.Append((_filters.TryGetValue(values[i], out string value) ? value : "[unknown]") + "; ");
                 else if (i == 3)
                     sb.Append("Partial Color " + values[i] + "; ");
                 else if (i == 4)
@@ -1400,7 +1400,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             for (var i = 0; i < values.Length; i++)
             {
                 if (i == 0)
-                    sb.Append(_filters.ContainsKey(values[i]) ? _filters[values[i]] : "[unknown]");
+                    sb.Append(_filters.TryGetValue(values[i], out string value) ? value : "[unknown]");
                 else
                     sb.Append(values[i]);
                 sb.Append("; ");

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDescriptor.cs
@@ -170,7 +170,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             for (var i = 0; i < values.Length; i++)
             {
                 if (i == 0)
-                    sb.Append(_filters.ContainsKey(values[i]) ? _filters[values[i]] : "[unknown]");
+                    sb.Append(_filters.TryGetValue(values[i], out string value) ? value : "[unknown]");
                 else
                     sb.Append(values[i]);
                 sb.Append("; ");

--- a/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
@@ -694,12 +694,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (faces == null)
                 return null;
 
-            var description = string.Join(Environment.NewLine,
-                faces.Select((f, i) => $"Face {i + 1}: {f}")
-#if NET35
-                .ToArray()
-#endif
-                );
+            var description = string.Join(Environment.NewLine, faces.Select((f, i) => $"Face {i + 1}: {f}"));
 
             return description.Length == 0 ? null : description;
         }

--- a/MetadataExtractor/Formats/FileSystem/FileMetadataReader.cs
+++ b/MetadataExtractor/Formats/FileSystem/FileMetadataReader.cs
@@ -27,11 +27,11 @@ using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.FileSystem
 {
-    public sealed class FileMetadataReader
+    public static class FileMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public FileMetadataDirectory Read([NotNull] string file)
+        public static FileMetadataDirectory Read([NotNull] string file)
         {
             var attr = File.GetAttributes(file);
 

--- a/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
@@ -29,21 +29,15 @@ using System.Collections.Generic;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Gif
 {
     /// <summary>Obtains metadata from GIF files.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class GifMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>(2);
 
@@ -56,7 +50,7 @@ namespace MetadataExtractor.Formats.Gif
         }
 
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             return new GifReader().Extract(new SequentialStreamReader(stream)).ToList();
         }

--- a/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
@@ -52,7 +52,7 @@ namespace MetadataExtractor.Formats.Gif
         [NotNull]
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
-            return new GifReader().Extract(new SequentialStreamReader(stream)).ToList();
+            return GifReader.Extract(new SequentialStreamReader(stream)).ToList();
         }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
@@ -22,10 +22,9 @@
 //
 #endregion
 
-using System.IO;
-using System.Linq;
-using JetBrains.Annotations;
 using System.Collections.Generic;
+using System.IO;
+using JetBrains.Annotations;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.IO;
 
@@ -44,7 +43,7 @@ namespace MetadataExtractor.Formats.Gif
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.AddRange(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }
@@ -52,7 +51,7 @@ namespace MetadataExtractor.Formats.Gif
         [NotNull]
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
-            return GifReader.Extract(new SequentialStreamReader(stream)).ToList();
+            return GifReader.Extract(new SequentialStreamReader(stream));
         }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifReader.cs
@@ -30,12 +30,6 @@ using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Gif
 {
     /// <summary>Reader of GIF encoded data.</summary>
@@ -55,7 +49,7 @@ namespace MetadataExtractor.Formats.Gif
         private const string Gif89AVersionIdentifier = "89a";
 
         [NotNull]
-        public DirectoryList Extract([NotNull] SequentialReader reader)
+        public IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
         {
             reader = reader.WithByteOrder(isMotorolaByteOrder: false);
 

--- a/MetadataExtractor/Formats/Gif/GifReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifReader.cs
@@ -43,13 +43,13 @@ namespace MetadataExtractor.Formats.Gif
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     /// <author>Kevin Mott https://github.com/kwhopper</author>
-    public sealed class GifReader
+    public static class GifReader
     {
         private const string Gif87AVersionIdentifier = "87a";
         private const string Gif89AVersionIdentifier = "89a";
 
         [NotNull]
-        public IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
+        public static IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
         {
             reader = reader.WithByteOrder(isMotorolaByteOrder: false);
 

--- a/MetadataExtractor/Formats/Icc/IccDescriptor.cs
+++ b/MetadataExtractor/Formats/Icc/IccDescriptor.cs
@@ -231,7 +231,7 @@ namespace MetadataExtractor.Formats.Icc
                             {
                                 name = Encoding.UTF8.GetString(bytes, ofs, len);
                             }
-                            res.Append(" ").Append(str).Append("(").Append(name).Append(")");
+                            res.Append(' ').Append(str).Append('(').Append(name).Append(')');
                         }
                         return res.ToString();
                     }

--- a/MetadataExtractor/Formats/Icc/IccDescriptor.cs
+++ b/MetadataExtractor/Formats/Icc/IccDescriptor.cs
@@ -91,13 +91,11 @@ namespace MetadataExtractor.Formats.Icc
                 {
                     case IccTagType.Text:
                     {
-#if !NETSTANDARD1_3
                         try
                         {
                             return Encoding.ASCII.GetString(bytes, 8, bytes.Length - 8 - 1);
                         }
                         catch
-#endif
                         {
                             return Encoding.UTF8.GetString(bytes, 8, bytes.Length - 8 - 1);
                         }

--- a/MetadataExtractor/Formats/Icc/IccReader.cs
+++ b/MetadataExtractor/Formats/Icc/IccReader.cs
@@ -31,12 +31,6 @@ using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
 using MetadataExtractor.Util;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Icc
 {
     /// <summary>Reads ICC profile data.</summary>
@@ -60,7 +54,7 @@ namespace MetadataExtractor.Formats.Icc
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.App2 };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // ICC data can be spread across multiple JPEG segments.
 

--- a/MetadataExtractor/Formats/Icc/IccReader.cs
+++ b/MetadataExtractor/Formats/Icc/IccReader.cs
@@ -62,7 +62,9 @@ namespace MetadataExtractor.Formats.Icc
             var iccSegments = segments.Where(segment => segment.Bytes.Length > JpegSegmentPreambleLength && IsSubarrayEqualTo(segment.Bytes, 0, _jpegSegmentPreambleBytes)).ToList();
 
             if (iccSegments.Count == 0)
-                return new Directory[0];
+            {
+                return Array.Empty<Directory>();
+            }
 
             byte[] buffer;
             if (iccSegments.Count == 1)

--- a/MetadataExtractor/Formats/Icc/IccReader.cs
+++ b/MetadataExtractor/Formats/Icc/IccReader.cs
@@ -70,7 +70,8 @@ namespace MetadataExtractor.Formats.Icc
             if (iccSegments.Count == 1)
             {
                 buffer = new byte[iccSegments[0].Bytes.Length - JpegSegmentPreambleLength];
-                Array.Copy(iccSegments[0].Bytes, JpegSegmentPreambleLength, buffer, 0, iccSegments[0].Bytes.Length - JpegSegmentPreambleLength);
+
+                iccSegments[0].Bytes.AsSpan(JpegSegmentPreambleLength, buffer.Length).CopyTo(buffer);
             }
             else
             {
@@ -80,7 +81,9 @@ namespace MetadataExtractor.Formats.Icc
                 for (int i = 0, pos = 0; i < iccSegments.Count; i++)
                 {
                     var segment = iccSegments[i];
-                    Array.Copy(segment.Bytes, JpegSegmentPreambleLength, buffer, pos, segment.Bytes.Length - JpegSegmentPreambleLength);
+
+                    segment.Bytes.AsSpan(JpegSegmentPreambleLength, segment.Bytes.Length - JpegSegmentPreambleLength).CopyTo(buffer.AsSpan(pos));
+
                     pos += segment.Bytes.Length - JpegSegmentPreambleLength;
                 }
             }

--- a/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
+++ b/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
@@ -34,7 +34,7 @@ namespace MetadataExtractor.Formats.Ico
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class IcoMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
@@ -51,7 +51,7 @@ namespace MetadataExtractor.Formats.Ico
         [NotNull]
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
-            return new IcoReader().Extract(new SequentialStreamReader(stream));
+            return IcoReader.Extract(new SequentialStreamReader(stream));
         }
     }
 }

--- a/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
+++ b/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
@@ -28,12 +28,6 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Ico
 {
     /// <summary>Obtains metadata from ICO (Windows Icon) files.</summary>
@@ -42,7 +36,7 @@ namespace MetadataExtractor.Formats.Ico
     {
         /// <exception cref="System.IO.IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 
@@ -55,7 +49,7 @@ namespace MetadataExtractor.Formats.Ico
         }
 
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             return new IcoReader().Extract(new SequentialStreamReader(stream));
         }

--- a/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
+++ b/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
@@ -43,7 +43,7 @@ namespace MetadataExtractor.Formats.Ico
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.AddRange(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Ico/IcoReader.cs
+++ b/MetadataExtractor/Formats/Ico/IcoReader.cs
@@ -36,10 +36,10 @@ namespace MetadataExtractor.Formats.Ico
     /// </list>
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class IcoReader
+    public static class IcoReader
     {
         [NotNull]
-        public IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
+        public static IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Ico/IcoReader.cs
+++ b/MetadataExtractor/Formats/Ico/IcoReader.cs
@@ -27,12 +27,6 @@ using System.IO;
 using JetBrains.Annotations;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Ico
 {
     /// <summary>Reads ICO (Windows Icon) file metadata.</summary>
@@ -45,7 +39,7 @@ namespace MetadataExtractor.Formats.Ico
     public sealed class IcoReader
     {
         [NotNull]
-        public DirectoryList Extract([NotNull] SequentialReader reader)
+        public IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Iptc/IptcReader.cs
+++ b/MetadataExtractor/Formats/Iptc/IptcReader.cs
@@ -31,12 +31,6 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Iptc
 {
     /// <summary>Reads IPTC data.</summary>
@@ -68,15 +62,12 @@ namespace MetadataExtractor.Formats.Iptc
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.AppD };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // Ensure data starts with the IPTC marker byte
             return segments
                 .Where(segment => segment.Bytes.Length != 0 && segment.Bytes[0] == IptcMarkerByte)
                 .Select(segment => Extract(new SequentialByteArrayReader(segment.Bytes), segment.Bytes.Length))
-#if NET35
-                .Cast<Directory>()
-#endif
                 .ToList();
         }
 

--- a/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
+++ b/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
@@ -83,11 +83,7 @@ namespace MetadataExtractor.Formats.Iptc
 
             if (ascii)
             {
-#if NETSTANDARD1_3
-                return Encoding.UTF8;
-#else
                 return Encoding.ASCII;
-#endif
             }
 
             var utf8 = false;

--- a/MetadataExtractor/Formats/Jfif/JfifReader.cs
+++ b/MetadataExtractor/Formats/Jfif/JfifReader.cs
@@ -30,12 +30,6 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Jfif
 {
     /// <summary>Reads JFIF (JPEG File Interchange Format) data.</summary>
@@ -53,15 +47,12 @@ namespace MetadataExtractor.Formats.Jfif
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.App0 };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // Skip segments not starting with the required header
             return segments
                 .Where(segment => segment.Bytes.Length >= JpegSegmentPreamble.Length && JpegSegmentPreamble == Encoding.UTF8.GetString(segment.Bytes, 0, JpegSegmentPreamble.Length))
                 .Select(segment => Extract(new ByteArrayReader(segment.Bytes)))
-#if NET35
-                .Cast<Directory>()
-#endif
                 .ToList();
         }
 

--- a/MetadataExtractor/Formats/Jfxx/JfxxReader.cs
+++ b/MetadataExtractor/Formats/Jfxx/JfxxReader.cs
@@ -30,12 +30,6 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Jfxx
 {
     /// <summary>Reads JFXX (JFIF Extensions) data.</summary>
@@ -53,15 +47,12 @@ namespace MetadataExtractor.Formats.Jfxx
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.App0 };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // Skip segments not starting with the required header
             return segments
                 .Where(segment => segment.Bytes.Length >= JpegSegmentPreamble.Length && JpegSegmentPreamble == Encoding.UTF8.GetString(segment.Bytes, 0, JpegSegmentPreamble.Length))
                 .Select(segment => Extract(new ByteArrayReader(segment.Bytes)))
-#if NET35
-                .Cast<Directory>()
-#endif
                 .ToList();
         }
 

--- a/MetadataExtractor/Formats/Jpeg/IJpegSegmentMetadataReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/IJpegSegmentMetadataReader.cs
@@ -25,12 +25,6 @@
 using System.Collections.Generic;
 using JetBrains.Annotations;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Jpeg
 {
     /// <summary>Defines an object that extracts metadata from in JPEG segments.</summary>
@@ -45,6 +39,6 @@ namespace MetadataExtractor.Formats.Jpeg
         /// A sequence of JPEG segments from which the metadata should be extracted. These are in the order encountered in the original file.
         /// </param>
         [NotNull]
-        DirectoryList ReadJpegSegments([NotNull] IEnumerable<JpegSegment> segments);
+        IReadOnlyList<Directory> ReadJpegSegments([NotNull] IEnumerable<JpegSegment> segments);
     }
 }

--- a/MetadataExtractor/Formats/Jpeg/JpegCommentReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegCommentReader.cs
@@ -26,12 +26,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Jpeg
 {
     /// <summary>Reads JPEG comments.</summary>
@@ -42,13 +36,10 @@ namespace MetadataExtractor.Formats.Jpeg
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.Com };
 
         /// <summary>Reads JPEG comments, returning each in a <see cref="JpegCommentDirectory"/>.</summary>
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // The entire contents of the segment are the comment
             return segments.Select(segment => new JpegCommentDirectory(new StringValue(segment.Bytes, Encoding.UTF8)))
-#if NET35
-                .Cast<Directory>()
-#endif
                 .ToList();
         }
     }

--- a/MetadataExtractor/Formats/Jpeg/JpegComponent.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegComponent.cs
@@ -22,9 +22,8 @@
 //
 #endregion
 
-#if !NETSTANDARD1_3
 using System;
-#endif
+
 using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.Jpeg
@@ -34,9 +33,7 @@ namespace MetadataExtractor.Formats.Jpeg
     /// quantization table number.
     /// </summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public sealed class JpegComponent
     {
         private readonly byte _samplingFactorByte;

--- a/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
@@ -76,7 +76,7 @@ namespace MetadataExtractor.Formats.Jpeg
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.AddRange(ReadMetadata(stream, readers));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
@@ -37,12 +37,6 @@ using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Jpeg
 {
     /// <summary>Obtains all available metadata from JPEG formatted files.</summary>
@@ -65,17 +59,17 @@ namespace MetadataExtractor.Formats.Jpeg
         };
 
         /// <exception cref="JpegProcessingException"/>
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream, [CanBeNull] ICollection<IJpegSegmentMetadataReader> readers = null)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream, [CanBeNull] ICollection<IJpegSegmentMetadataReader> readers = null)
         {
             return Process(stream, readers);
         }
 
         /// <exception cref="JpegProcessingException"/>
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath, [CanBeNull] ICollection<IJpegSegmentMetadataReader> readers = null)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath, [CanBeNull] ICollection<IJpegSegmentMetadataReader> readers = null)
         {
             var directories = new List<Directory>();
 
@@ -88,9 +82,9 @@ namespace MetadataExtractor.Formats.Jpeg
         }
 
         /// <exception cref="JpegProcessingException"/>
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList Process([NotNull] Stream stream, [CanBeNull] ICollection<IJpegSegmentMetadataReader> readers = null)
+        public static IReadOnlyList<Directory> Process([NotNull] Stream stream, [CanBeNull] ICollection<IJpegSegmentMetadataReader> readers = null)
         {
             if (readers == null)
                 readers = _allReaders;
@@ -106,7 +100,7 @@ namespace MetadataExtractor.Formats.Jpeg
         }
 
         [NotNull]
-        public static DirectoryList ProcessJpegSegments([NotNull] IEnumerable<IJpegSegmentMetadataReader> readers, [NotNull] ICollection<JpegSegment> segments)
+        public static IReadOnlyList<Directory> ProcessJpegSegments([NotNull] IEnumerable<IJpegSegmentMetadataReader> readers, [NotNull] ICollection<JpegSegment> segments)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Jpeg/JpegProcessingException.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegProcessingException.cs
@@ -23,18 +23,15 @@
 #endregion
 
 using System;
-#if !NETSTANDARD1_3
 using System.Runtime.Serialization;
-#endif
+
 using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.Jpeg
 {
     /// <summary>An exception class thrown upon unexpected and fatal conditions while processing a JPEG file.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public class JpegProcessingException : ImageProcessingException
     {
         public JpegProcessingException([CanBeNull] string message)
@@ -52,11 +49,9 @@ namespace MetadataExtractor.Formats.Jpeg
         {
         }
 
-#if !NETSTANDARD1_3
         protected JpegProcessingException([NotNull] SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/MetadataExtractor/Formats/Jpeg/JpegReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegReader.cs
@@ -44,13 +44,8 @@ namespace MetadataExtractor.Formats.Jpeg
             JpegSegmentType.Sof15
         };
 
-#if NET35
-        public IList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
-            => segments.Select(Extract).Cast<Directory>().ToList();
-#else
         public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
             => segments.Select(Extract).ToList();
-#endif
 
         /// <summary>Reads JPEG SOF values and returns them in a <see cref="JpegDirectory"/>.</summary>
         [NotNull]

--- a/MetadataExtractor/Formats/Jpeg/JpegSegmentType.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegSegmentType.cs
@@ -244,11 +244,8 @@ namespace MetadataExtractor.Formats.Jpeg
         }
 
         /// <summary>Gets JPEG segment types that might contain metadata.</summary>
-#if NET35
-        public static IEnumerable<JpegSegmentType> CanContainMetadataTypes { get; }
-#else
+
         public static IReadOnlyList<JpegSegmentType> CanContainMetadataTypes { get; }
-#endif
             = Enum.GetValues(typeof(JpegSegmentType)).Cast<JpegSegmentType>().Where(type => type.CanContainMetadata()).ToList();
 
         /// <summary>Gets whether this JPEG segment type's marker is followed by a length indicator.</summary>

--- a/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
+++ b/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
@@ -41,7 +41,7 @@ namespace MetadataExtractor.Formats.Netpbm
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.Add(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
+++ b/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
@@ -26,21 +26,15 @@ using JetBrains.Annotations;
 using System.Collections.Generic;
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Netpbm
 {
     /// <summary>Obtains metadata from BMP files.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class NetpbmMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>(2);
 

--- a/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
+++ b/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
@@ -21,9 +21,9 @@
 //
 #endregion
 
+using System.Collections.Generic;
 using System.IO;
 using JetBrains.Annotations;
-using System.Collections.Generic;
 using MetadataExtractor.Formats.FileSystem;
 
 namespace MetadataExtractor.Formats.Netpbm
@@ -49,7 +49,7 @@ namespace MetadataExtractor.Formats.Netpbm
         [NotNull]
         public static NetpbmHeaderDirectory ReadMetadata([NotNull] Stream stream)
         {
-            return new NetpbmReader().Extract(stream);
+            return NetpbmReader.Extract(stream);
         }
     }
 }

--- a/MetadataExtractor/Formats/Netpbm/NetpbmReader.cs
+++ b/MetadataExtractor/Formats/Netpbm/NetpbmReader.cs
@@ -41,9 +41,9 @@ namespace MetadataExtractor.Formats.Netpbm
     /// </list>
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class NetpbmReader
+    public static class NetpbmReader
     {
-        public NetpbmHeaderDirectory Extract(Stream stream)
+        public static NetpbmHeaderDirectory Extract(Stream stream)
         {
             var directory = new NetpbmHeaderDirectory();
 

--- a/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
+++ b/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
@@ -51,7 +51,7 @@ namespace MetadataExtractor.Formats.Pcx
         [NotNull]
         public static PcxDirectory ReadMetadata([NotNull] Stream stream)
         {
-            return new PcxReader().Extract(new SequentialStreamReader(stream));
+            return PcxReader.Extract(new SequentialStreamReader(stream));
         }
     }
 }

--- a/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
+++ b/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
@@ -28,21 +28,15 @@ using System.Collections.Generic;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Pcx
 {
     /// <summary>Obtains metadata from PCX image files.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class PcxMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
+++ b/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
@@ -43,7 +43,7 @@ namespace MetadataExtractor.Formats.Pcx
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.Add(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Pcx/PcxReader.cs
+++ b/MetadataExtractor/Formats/Pcx/PcxReader.cs
@@ -37,10 +37,10 @@ namespace MetadataExtractor.Formats.Pcx
     /// </list>
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class PcxReader
+    public static class PcxReader
     {
         [NotNull]
-        public PcxDirectory Extract([NotNull] SequentialReader reader)
+        public static PcxDirectory Extract([NotNull] SequentialReader reader)
         {
             reader = reader.WithByteOrder(isMotorolaByteOrder: false);
 

--- a/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
@@ -30,12 +30,6 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Reads Photoshop "ducky" segments, created during Save-for-Web.</summary>
@@ -46,15 +40,12 @@ namespace MetadataExtractor.Formats.Photoshop
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.AppC };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // Skip segments not starting with the required header
             return segments
                 .Where(segment => segment.Bytes.Length >= JpegSegmentPreamble.Length && JpegSegmentPreamble == Encoding.UTF8.GetString(segment.Bytes, 0, JpegSegmentPreamble.Length))
                 .Select(segment => Extract(new SequentialByteArrayReader(segment.Bytes, JpegSegmentPreamble.Length)))
-#if NET35
-                .Cast<Directory>()
-#endif
                 .ToList();
         }
 

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopDirectory.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopDirectory.cs
@@ -230,9 +230,10 @@ namespace MetadataExtractor.Formats.Photoshop
             if (storedBytes == null || storedBytes.Length <= 28)
                 return null;
 
-            var thumbSize = storedBytes.Length - 28;
+            int thumbSize = storedBytes.Length - 28;
             var thumbBytes = new byte[thumbSize];
-            Array.Copy(storedBytes, 28, thumbBytes, 0, thumbSize);
+
+            storedBytes.AsSpan(28, thumbSize).CopyTo(thumbBytes);
 
             return thumbBytes;
         }

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
@@ -34,12 +34,6 @@ using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Reads metadata created by Photoshop and stored in the APPD segment of JPEG files.</summary>
@@ -56,7 +50,7 @@ namespace MetadataExtractor.Formats.Photoshop
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.AppD };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             var preambleLength = JpegSegmentPreamble.Length;
             return segments
@@ -66,7 +60,7 @@ namespace MetadataExtractor.Formats.Photoshop
         }
 
         [NotNull]
-        public DirectoryList Extract([NotNull] SequentialReader reader, int length)
+        public IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader, int length)
         {
             var directory = new PhotoshopDirectory();
 

--- a/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
@@ -28,21 +28,15 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Obtains metadata from Photoshop's PSD files.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class PsdMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 
@@ -55,7 +49,7 @@ namespace MetadataExtractor.Formats.Photoshop
         }
 
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             return new PsdReader().Extract(new SequentialStreamReader(stream));
         }

--- a/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
@@ -45,7 +45,7 @@ namespace MetadataExtractor.Formats.Photoshop
                 directories.AddRange(PsdReader.Extract(new SequentialStreamReader(stream)));
             }
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
@@ -41,7 +41,9 @@ namespace MetadataExtractor.Formats.Photoshop
             var directories = new List<Directory>();
 
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                directories.AddRange(new PsdReader().Extract(new SequentialStreamReader(stream)));
+            {
+                directories.AddRange(PsdReader.Extract(new SequentialStreamReader(stream)));
+            }
 
             directories.Add(new FileMetadataReader().Read(filePath));
 
@@ -51,7 +53,7 @@ namespace MetadataExtractor.Formats.Photoshop
         [NotNull]
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
-            return new PsdReader().Extract(new SequentialStreamReader(stream));
+            return PsdReader.Extract(new SequentialStreamReader(stream));
         }
     }
 }

--- a/MetadataExtractor/Formats/Photoshop/PsdReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdReader.cs
@@ -32,10 +32,10 @@ namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Reads metadata stored within PSD file format data.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class PsdReader
+    public static class PsdReader
     {
         [NotNull]
-        public IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
+        public static IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
         {
             var directory = new PsdHeaderDirectory();
 

--- a/MetadataExtractor/Formats/Photoshop/PsdReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdReader.cs
@@ -28,12 +28,6 @@ using System.IO;
 using JetBrains.Annotations;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Reads metadata stored within PSD file format data.</summary>
@@ -41,7 +35,7 @@ namespace MetadataExtractor.Formats.Photoshop
     public sealed class PsdReader
     {
         [NotNull]
-        public DirectoryList Extract([NotNull] SequentialReader reader)
+        public IReadOnlyList<Directory> Extract([NotNull] SequentialReader reader)
         {
             var directory = new PsdHeaderDirectory();
 

--- a/MetadataExtractor/Formats/Png/PngChunkReader.cs
+++ b/MetadataExtractor/Formats/Png/PngChunkReader.cs
@@ -30,14 +30,14 @@ using MetadataExtractor.IO;
 namespace MetadataExtractor.Formats.Png
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class PngChunkReader
+    public static class PngChunkReader
     {
         private static readonly byte[] _pngSignatureBytes = { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A };
 
         /// <exception cref="PngProcessingException"/>
         /// <exception cref="System.IO.IOException"/>
         [NotNull]
-        public IEnumerable<PngChunk> Extract([NotNull] SequentialReader reader, [CanBeNull] ICollection<PngChunkType> desiredChunkTypes)
+        public static IEnumerable<PngChunk> Extract([NotNull] SequentialReader reader, [CanBeNull] ICollection<PngChunkType> desiredChunkTypes)
         {
             //
             // PNG DATA STREAM

--- a/MetadataExtractor/Formats/Png/PngChunkReader.cs
+++ b/MetadataExtractor/Formats/Png/PngChunkReader.cs
@@ -22,8 +22,8 @@
 //
 #endregion
 
+using System;
 using System.Collections.Generic;
-using System.Linq;
 using JetBrains.Annotations;
 using MetadataExtractor.IO;
 
@@ -76,7 +76,7 @@ namespace MetadataExtractor.Formats.Png
             // network byte order
             reader = reader.WithByteOrder(isMotorolaByteOrder: true);
 
-            if (!_pngSignatureBytes.SequenceEqual(reader.GetBytes(_pngSignatureBytes.Length)))
+            if (!_pngSignatureBytes.AsSpan().SequenceEqual(reader.GetBytes(_pngSignatureBytes.Length)))
                 throw new PngProcessingException("PNG signature mismatch");
 
             var seenImageHeader = false;

--- a/MetadataExtractor/Formats/Png/PngChunkType.cs
+++ b/MetadataExtractor/Formats/Png/PngChunkType.cs
@@ -182,7 +182,7 @@ namespace MetadataExtractor.Formats.Png
 
         #region Equality and Hashing
 
-        private bool Equals([NotNull] PngChunkType other) => _bytes.SequenceEqual(other._bytes);
+        private bool Equals([NotNull] PngChunkType other) => _bytes.AsSpan().SequenceEqual(other._bytes);
 
         public override bool Equals(object obj)
         {

--- a/MetadataExtractor/Formats/Png/PngColorType.cs
+++ b/MetadataExtractor/Formats/Png/PngColorType.cs
@@ -22,18 +22,14 @@
 //
 #endregion
 
-#if !NETSTANDARD1_3
 using System;
-#endif
 using System.Linq;
 using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.Png
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public sealed class PngColorType
     {
         /// <summary>Each pixel is a greyscale sample.</summary>

--- a/MetadataExtractor/Formats/Png/PngDescriptor.cs
+++ b/MetadataExtractor/Formats/Png/PngDescriptor.cs
@@ -126,21 +126,16 @@ namespace MetadataExtractor.Formats.Png
         [CanBeNull]
         public string GetTextualDataDescription()
         {
-            var pairs = Directory.GetObject(PngDirectory.TagTextualData) as IList<KeyValuePair>;
-
-            return pairs == null
-                ? null
-                : string.Join(
-                    "\n",
-                    pairs.Select(kv => $"{kv.Key}: {kv.Value}")
-                    );
+            return Directory.GetObject(PngDirectory.TagTextualData) is IList<KeyValuePair> pairs    
+                ? string.Join("\n", pairs.Select(kv => $"{kv.Key}: {kv.Value}"))
+                : null;
         }
 
         [CanBeNull]
         public string GetBackgroundColorDescription()
         {
             var bytes = Directory.GetByteArray(PngDirectory.TagBackgroundColor);
-            if (bytes == null || !Directory.TryGetInt32(PngDirectory.TagColorType, out int colorType))
+            if (bytes is null || !Directory.TryGetInt32(PngDirectory.TagColorType, out int colorType))
                 return null;
 
             var reader = new SequentialByteArrayReader(bytes);

--- a/MetadataExtractor/Formats/Png/PngDescriptor.cs
+++ b/MetadataExtractor/Formats/Png/PngDescriptor.cs
@@ -133,9 +133,6 @@ namespace MetadataExtractor.Formats.Png
                 : string.Join(
                     "\n",
                     pairs.Select(kv => $"{kv.Key}: {kv.Value}")
-#if NET35
-                    .ToArray()
-#endif
                     );
         }
 

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -35,12 +35,6 @@ using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.IO;
 using MetadataExtractor.Util;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Png
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
@@ -65,9 +59,9 @@ namespace MetadataExtractor.Formats.Png
         };
 
         /// <exception cref="PngProcessingException"/>
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 
@@ -80,9 +74,9 @@ namespace MetadataExtractor.Formats.Png
         }
 
         /// <exception cref="PngProcessingException"/>
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             return new PngChunkReader()
                 .Extract(new SequentialStreamReader(stream), _desiredChunkTypes)
@@ -104,7 +98,7 @@ namespace MetadataExtractor.Formats.Png
         private static readonly Encoding _latin1Encoding = Encoding.GetEncoding("ISO-8859-1");
 
         /// <exception cref="PngProcessingException"/>
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         private static IEnumerable<Directory> ProcessChunk([NotNull] PngChunk chunk)
         {
             var chunkType = chunk.ChunkType;
@@ -381,14 +375,7 @@ namespace MetadataExtractor.Formats.Png
         {
             var ms = new MemoryStream();
 
-#if !NET35
             stream.CopyTo(ms);
-#else
-            var buffer = new byte[1024];
-            int count;
-            while ((count = stream.Read(buffer, 0, 256)) > 0)
-                ms.Write(buffer, 0, count);
-#endif
 
             return ms.ToArray();
         }

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -69,7 +69,7 @@ namespace MetadataExtractor.Formats.Png
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.AddRange(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -79,7 +79,7 @@ namespace MetadataExtractor.Formats.Png
         [NotNull]
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
-            return new PngChunkReader()
+            return PngChunkReader
                 .Extract(new SequentialStreamReader(stream), _desiredChunkTypes)
                 .SelectMany(ProcessChunk)
                 .ToList();

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -23,14 +23,15 @@
 #endregion
 
 using System;
+using System.Buffers.Binary;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
-using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.FileSystem;
+using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.IO;
 using MetadataExtractor.Util;
@@ -152,7 +153,7 @@ namespace MetadataExtractor.Formats.Png
             }
             else if (chunkType == PngChunkType.gAMA)
             {
-                var gammaInt = ByteConvert.ToInt32BigEndian(bytes);
+                int gammaInt = BinaryPrimitives.ReadInt32BigEndian(bytes);
                 var directory = new PngDirectory(PngChunkType.gAMA);
                 directory.Set(PngDirectory.TagGamma, gammaInt / 100000.0);
                 yield return directory;

--- a/MetadataExtractor/Formats/Png/PngProcessingException.cs
+++ b/MetadataExtractor/Formats/Png/PngProcessingException.cs
@@ -23,18 +23,15 @@
 #endregion
 
 using System;
-#if !NETSTANDARD1_3
 using System.Runtime.Serialization;
-#endif
+
 using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.Png
 {
     /// <summary>An exception class thrown upon unexpected and fatal conditions while processing a JPEG file.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public class PngProcessingException : ImageProcessingException
     {
         public PngProcessingException([CanBeNull] string message)
@@ -52,11 +49,9 @@ namespace MetadataExtractor.Formats.Png
         {
         }
 
-#if !NETSTANDARD1_3
         protected PngProcessingException([NotNull] SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -26,12 +26,6 @@ using System.Collections.Generic;
 using System.IO;
 using JetBrains.Annotations;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.QuickTime
 {
     public static class QuickTimeMetadataReader
@@ -39,7 +33,7 @@ namespace MetadataExtractor.Formats.QuickTime
         private static readonly DateTime _epoch = new DateTime(1904, 1, 1);
 
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
@@ -22,7 +22,6 @@
 #endregion
 
 using System;
-using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -88,11 +87,7 @@ namespace MetadataExtractor.Formats.QuickTime
             {
                 var bytes = BitConverter.GetBytes(Type);
                 bytes = bytes.Reverse().ToArray();
-#if NETSTANDARD1_3
-                return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
-#else
                 return Encoding.ASCII.GetString(bytes);
-#endif
             }
         }
 

--- a/MetadataExtractor/Formats/Raf/RafMetadataReader.cs
+++ b/MetadataExtractor/Formats/Raf/RafMetadataReader.cs
@@ -25,15 +25,10 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using System.IO;
 using JetBrains.Annotations;
 using MetadataExtractor.Formats.Jpeg;
-
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
 
 namespace MetadataExtractor.Formats.Raf
 {
@@ -43,7 +38,7 @@ namespace MetadataExtractor.Formats.Raf
     public static class RafMetadataReader
     {
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             if (!stream.CanSeek)
                 throw new ArgumentException("Must support seek", nameof(stream));

--- a/MetadataExtractor/Formats/Riff/RiffProcessingException.cs
+++ b/MetadataExtractor/Formats/Riff/RiffProcessingException.cs
@@ -23,18 +23,15 @@
 #endregion
 
 using System;
-#if !NETSTANDARD1_3
 using System.Runtime.Serialization;
-#endif
+
 using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.Riff
 {
     /// <summary>An exception class thrown upon unexpected and fatal conditions while processing a RIFF file.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public class RiffProcessingException : ImageProcessingException
     {
         public RiffProcessingException([CanBeNull] string message)
@@ -52,11 +49,9 @@ namespace MetadataExtractor.Formats.Riff
         {
         }
 
-#if !NETSTANDARD1_3
         protected RiffProcessingException([NotNull] SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -40,14 +40,14 @@ namespace MetadataExtractor.Formats.Riff
     /// </list>
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class RiffReader
+    public static class RiffReader
     {
         /// <summary>Processes a RIFF data sequence.</summary>
         /// <param name="reader">The <see cref="SequentialReader"/> from which the data should be read.</param>
         /// <param name="handler">The <see cref="IRiffHandler"/> that will coordinate processing and accept read values.</param>
         /// <exception cref="RiffProcessingException">An error occurred during the processing of RIFF data that could not be ignored or recovered from.</exception>
         /// <exception cref="System.IO.IOException">an error occurred while accessing the required data</exception>
-        public void ProcessRiff([NotNull] SequentialReader reader, [NotNull] IRiffHandler handler)
+        public static void ProcessRiff([NotNull] SequentialReader reader, [NotNull] IRiffHandler handler)
         {
             // RIFF files are always little-endian
             reader = reader.WithByteOrder(isMotorolaByteOrder: false);
@@ -71,7 +71,7 @@ namespace MetadataExtractor.Formats.Riff
         }
 
         // PROCESS CHUNKS
-        public void ProcessChunks([NotNull] SequentialReader reader, int sizeLeft, [NotNull] IRiffHandler handler)
+        public static void ProcessChunks([NotNull] SequentialReader reader, int sizeLeft, [NotNull] IRiffHandler handler)
         {
             // Processing chunks. Each chunk is 8 bytes header (4 bytes CC code + 4 bytes length of chunk) + data of the chunk
 

--- a/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
@@ -53,7 +53,7 @@ namespace MetadataExtractor.Formats.Tiff
                 TiffReader.ProcessTiff(new IndexedSeekingReader(stream), handler);
             }
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
@@ -29,12 +29,6 @@ using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Tiff
 {
     /// <summary>Obtains all available metadata from TIFF formatted files.</summary>
@@ -46,10 +40,10 @@ namespace MetadataExtractor.Formats.Tiff
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class TiffMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         /// <exception cref="TiffProcessingException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 
@@ -64,10 +58,10 @@ namespace MetadataExtractor.Formats.Tiff
             return directories;
         }
 
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         /// <exception cref="TiffProcessingException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             // TIFF processing requires random access, as directories can be scattered throughout the byte sequence.
             // Stream does not support seeking backwards, so we wrap it with IndexedCapturingReader, which

--- a/MetadataExtractor/Formats/Tiff/TiffProcessingException.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffProcessingException.cs
@@ -23,9 +23,8 @@
 #endregion
 
 using System;
-#if !NETSTANDARD1_3
 using System.Runtime.Serialization;
-#endif
+
 using JetBrains.Annotations;
 
 namespace MetadataExtractor.Formats.Tiff
@@ -33,9 +32,7 @@ namespace MetadataExtractor.Formats.Tiff
     /// <summary>An exception class thrown upon unexpected and fatal conditions while processing a TIFF file.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     /// <author>Darren Salomons</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public class TiffProcessingException : ImageProcessingException
     {
         public TiffProcessingException([CanBeNull] string message)
@@ -53,11 +50,9 @@ namespace MetadataExtractor.Formats.Tiff
         {
         }
 
-#if !NETSTANDARD1_3
         protected TiffProcessingException([NotNull] SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/MetadataExtractor/Formats/WebP/WebPMetadataReader.cs
+++ b/MetadataExtractor/Formats/WebP/WebPMetadataReader.cs
@@ -29,22 +29,16 @@ using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Riff;
 using MetadataExtractor.IO;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.WebP
 {
     /// <summary>Obtains metadata from WebP files.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class WebPMetadataReader
     {
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 
@@ -56,10 +50,10 @@ namespace MetadataExtractor.Formats.WebP
             return directories;
         }
 
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             var directories = new List<Directory>();
             new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new WebPRiffHandler(directories));

--- a/MetadataExtractor/Formats/WebP/WebPMetadataReader.cs
+++ b/MetadataExtractor/Formats/WebP/WebPMetadataReader.cs
@@ -45,7 +45,7 @@ namespace MetadataExtractor.Formats.WebP
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.AddRange(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }
@@ -56,7 +56,7 @@ namespace MetadataExtractor.Formats.WebP
         public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             var directories = new List<Directory>();
-            new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new WebPRiffHandler(directories));
+            RiffReader.ProcessRiff(new SequentialStreamReader(stream), new WebPRiffHandler(directories));
             return directories;
         }
     }

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -31,12 +31,6 @@ using MetadataExtractor.Util;
 using MetadataExtractor.Formats.Jpeg;
 using XmpCore;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Xmp
 {
     /// <summary>Extracts XMP data JPEG APP1 segments.</summary>
@@ -60,7 +54,7 @@ namespace MetadataExtractor.Formats.Xmp
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes => new [] { JpegSegmentType.App1 };
 
-        public DirectoryList ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        public IReadOnlyList<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // Ensure collection materialised (avoiding multiple lazy enumeration)
             segments = segments.ToList();

--- a/MetadataExtractor/GeoLocation.cs
+++ b/MetadataExtractor/GeoLocation.cs
@@ -89,7 +89,7 @@ namespace MetadataExtractor
         /// as a double.
         /// </summary>
         [CanBeNull, Pure]
-        public static double? DegreesMinutesSecondsToDecimal(Rational degs, Rational mins, Rational secs, bool isNegative)
+        public static double? DegreesMinutesSecondsToDecimal(in Rational degs, in  Rational mins, in Rational secs, bool isNegative)
         {
             var value = Math.Abs(degs.ToDouble()) + mins.ToDouble()/60.0d + secs.ToDouble()/3600.0d;
             if (double.IsNaN(value))

--- a/MetadataExtractor/IO/BufferBoundsException.cs
+++ b/MetadataExtractor/IO/BufferBoundsException.cs
@@ -22,12 +22,10 @@
 //
 #endregion
 
-using System.IO;
-using JetBrains.Annotations;
-#if !NETSTANDARD1_3
 using System;
+using System.IO;
 using System.Runtime.Serialization;
-#endif
+using JetBrains.Annotations;
 
 namespace MetadataExtractor.IO
 {
@@ -35,9 +33,7 @@ namespace MetadataExtractor.IO
     /// Thrown when the index provided to an <see cref="IndexedReader"/> is invalid.
     /// </summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public class BufferBoundsException : IOException
     {
         public BufferBoundsException(int index, int bytesRequested, long bufferLength)
@@ -65,11 +61,9 @@ namespace MetadataExtractor.IO
             return $"Attempt to read from beyond end of underlying data source (requested index: {index}, requested count: {bytesRequested}, max index: {bufferLength - 1})";
         }
 
-#if !NETSTANDARD1_3
         protected BufferBoundsException([NotNull] SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/MetadataExtractor/IO/ByteArrayReader.cs
+++ b/MetadataExtractor/IO/ByteArrayReader.cs
@@ -68,7 +68,16 @@ namespace MetadataExtractor.IO
         protected override void ValidateIndex(int index, int bytesRequested)
         {
             if (!IsValidIndex(index, bytesRequested))
+            {
                 throw new BufferBoundsException(ToUnshiftedOffset(index), bytesRequested, _buffer.Length);
+            }
+        }
+        
+        public override void GetBytes(int index, Span<byte> buffer)
+        {
+            ValidateIndex(index, buffer.Length);
+
+            _buffer.AsSpan(index + _baseOffset, buffer.Length).CopyTo(buffer);
         }
 
         protected override bool IsValidIndex(int index, int bytesRequested)
@@ -84,7 +93,9 @@ namespace MetadataExtractor.IO
             ValidateIndex(index, count);
 
             var bytes = new byte[count];
-            Array.Copy(_buffer, index + _baseOffset, bytes, 0, count);
+
+            _buffer.AsSpan(index + _baseOffset, count).CopyTo(bytes);
+
             return bytes;
         }
     }

--- a/MetadataExtractor/IO/ByteArrayReader.cs
+++ b/MetadataExtractor/IO/ByteArrayReader.cs
@@ -35,7 +35,7 @@ namespace MetadataExtractor.IO
     /// <see cref="IndexedReader.IsMotorolaByteOrder"/>.
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public class ByteArrayReader : IndexedReader
+    public sealed class ByteArrayReader : IndexedReader
     {
         [NotNull]
         private readonly byte[] _buffer;

--- a/MetadataExtractor/IO/IndexedCapturingReader.cs
+++ b/MetadataExtractor/IO/IndexedCapturingReader.cs
@@ -184,7 +184,9 @@ namespace MetadataExtractor.IO
                 var fromInnerIndex = fromIndex % _chunkLength;
                 var length = Math.Min(remaining, _chunkLength - fromInnerIndex);
                 var chunk = _chunks[fromChunkIndex];
-                Array.Copy(chunk, fromInnerIndex, bytes, toIndex, length);
+
+                chunk.AsSpan(fromInnerIndex, length).CopyTo(bytes.AsSpan(toIndex));
+
                 remaining -= length;
                 fromIndex += length;
                 toIndex += length;

--- a/MetadataExtractor/IO/IndexedCapturingReader.cs
+++ b/MetadataExtractor/IO/IndexedCapturingReader.cs
@@ -191,7 +191,30 @@ namespace MetadataExtractor.IO
                 fromIndex += length;
                 toIndex += length;
             }
+
             return bytes;
+        }
+
+        public override void GetBytes(int index, [NotNull] Span<byte> buffer)
+        {
+            ValidateIndex(index, buffer.Length);
+
+            var remaining = buffer.Length;
+            var fromIndex = index;
+            var toIndex = 0;
+            while (remaining != 0)
+            {
+                var fromChunkIndex = fromIndex / _chunkLength;
+                var fromInnerIndex = fromIndex % _chunkLength;
+                var length = Math.Min(remaining, _chunkLength - fromInnerIndex);
+                var chunk = _chunks[fromChunkIndex];
+
+                chunk.AsSpan(fromInnerIndex, length).CopyTo(buffer.Slice(toIndex));
+
+                remaining -= length;
+                fromIndex += length;
+                toIndex += length;
+            }
         }
 
         public override IndexedReader WithByteOrder(bool isMotorolaByteOrder) => isMotorolaByteOrder == IsMotorolaByteOrder ? (IndexedReader)this : new ShiftedIndexedCapturingReader(this, 0, isMotorolaByteOrder);
@@ -222,6 +245,11 @@ namespace MetadataExtractor.IO
             public override byte GetByte(int index) => _baseReader.GetByte(_baseOffset + index);
 
             public override byte[] GetBytes(int index, int count) => _baseReader.GetBytes(_baseOffset + index, count);
+
+            public override void GetBytes(int index, [NotNull] Span<byte> buffer)
+            {
+                _baseReader.GetBytes(_baseOffset + index, buffer);
+            }
 
             protected override void ValidateIndex(int index, int bytesRequested) => _baseReader.ValidateIndex(index + _baseOffset, bytesRequested);
 

--- a/MetadataExtractor/IO/IndexedReader.cs
+++ b/MetadataExtractor/IO/IndexedReader.cs
@@ -147,13 +147,13 @@ namespace MetadataExtractor.IO
             {
                 // Motorola - MSB first
                 return (ushort)
-                    (GetByte(index    ) << 8 |
+                    (GetByte(index) << 8 |
                      GetByte(index + 1));
             }
             // Intel ordering - LSB first
             return (ushort)
                 (GetByte(index + 1) << 8 |
-                 GetByte(index    ));
+                 GetByte(index));
         }
 
         /// <summary>Returns a signed 16-bit int calculated from two bytes of data at the specified index (MSB, LSB).</summary>
@@ -167,7 +167,7 @@ namespace MetadataExtractor.IO
             {
                 // Motorola - MSB first
                 return (short)
-                    (GetByte(index    ) << 8 |
+                    (GetByte(index) << 8 |
                      GetByte(index + 1));
             }
             // Intel ordering - LSB first
@@ -187,15 +187,15 @@ namespace MetadataExtractor.IO
             {
                 // Motorola - MSB first (big endian)
                 return
-                    GetByte(index    ) << 16 |
-                    GetByte(index + 1)  << 8 |
+                    GetByte(index) << 16 |
+                    GetByte(index + 1) << 8 |
                     GetByte(index + 2);
             }
             // Intel ordering - LSB first (little endian)
             return
                 GetByte(index + 2) << 16 |
-                GetByte(index + 1) <<  8 |
-                GetByte(index    );
+                GetByte(index + 1) << 8 |
+                GetByte(index);
         }
 
         /// <summary>Get a 32-bit unsigned integer from the buffer, returning it as a long.</summary>
@@ -205,21 +205,22 @@ namespace MetadataExtractor.IO
         public uint GetUInt32(int index)
         {
             ValidateIndex(index, 4);
+
             if (IsMotorolaByteOrder)
             {
                 // Motorola - MSB first (big endian)
                 return (uint)
-                    (GetByte(index    ) << 24 |
+                    (GetByte(index) << 24 |
                      GetByte(index + 1) << 16 |
-                     GetByte(index + 2) <<  8 |
+                     GetByte(index + 2) << 8 |
                      GetByte(index + 3));
             }
             // Intel ordering - LSB first (little endian)
             return (uint)
                 (GetByte(index + 3) << 24 |
                  GetByte(index + 2) << 16 |
-                 GetByte(index + 1) <<  8 |
-                 GetByte(index    ));
+                 GetByte(index + 1) << 8 |
+                 GetByte(index));
         }
 
         /// <summary>Returns a signed 32-bit integer from four bytes of data at the specified index the buffer.</summary>
@@ -233,17 +234,17 @@ namespace MetadataExtractor.IO
             {
                 // Motorola - MSB first (big endian)
                 return
-                    GetByte(index    ) << 24 |
+                    GetByte(index) << 24 |
                     GetByte(index + 1) << 16 |
-                    GetByte(index + 2) <<  8 |
+                    GetByte(index + 2) << 8 |
                     GetByte(index + 3);
             }
             // Intel ordering - LSB first (little endian)
             return
                 GetByte(index + 3) << 24 |
                 GetByte(index + 2) << 16 |
-                GetByte(index + 1) <<  8 |
-                GetByte(index    );
+                GetByte(index + 1) << 8 |
+                GetByte(index);
         }
 
         /// <summary>Get a signed 64-bit integer from the buffer.</summary>
@@ -257,13 +258,13 @@ namespace MetadataExtractor.IO
             {
                 // Motorola - MSB first
                 return
-                    (long)GetByte(index    ) << 56 |
+                    (long)GetByte(index) << 56 |
                     (long)GetByte(index + 1) << 48 |
                     (long)GetByte(index + 2) << 40 |
                     (long)GetByte(index + 3) << 32 |
                     (long)GetByte(index + 4) << 24 |
                     (long)GetByte(index + 5) << 16 |
-                    (long)GetByte(index + 6) <<  8 |
+                    (long)GetByte(index + 6) << 8 |
                           GetByte(index + 7);
             }
             // Intel ordering - LSB first
@@ -274,8 +275,8 @@ namespace MetadataExtractor.IO
                 (long)GetByte(index + 4) << 32 |
                 (long)GetByte(index + 3) << 24 |
                 (long)GetByte(index + 2) << 16 |
-                (long)GetByte(index + 1) <<  8 |
-                      GetByte(index    );
+                (long)GetByte(index + 1) << 8 |
+                      GetByte(index);
         }
 
         /// <summary>Gets a s15.16 fixed point float from the buffer.</summary>
@@ -378,9 +379,15 @@ namespace MetadataExtractor.IO
             if (length == maxLengthBytes)
                 return buffer;
 
-            var bytes = new byte[length];
-            if (length > 0)
-                Array.Copy(buffer, 0, bytes, 0, length);
+            if (length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
+            byte[] bytes = new byte[length];
+
+            buffer.AsSpan(0, length).CopyTo(bytes);
+
             return bytes;
         }
     }

--- a/MetadataExtractor/IO/IndexedSeekingReader.cs
+++ b/MetadataExtractor/IO/IndexedSeekingReader.cs
@@ -32,7 +32,7 @@ namespace MetadataExtractor.IO
     /// Provides methods to read data types from a <see cref="Stream"/> by indexing into the data.
     /// </summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public class IndexedSeekingReader : IndexedReader
+    public sealed class IndexedSeekingReader : IndexedReader
     {
         [NotNull]
         private readonly Stream _stream;

--- a/MetadataExtractor/IO/SequentialByteArrayReader.cs
+++ b/MetadataExtractor/IO/SequentialByteArrayReader.cs
@@ -29,7 +29,7 @@ using JetBrains.Annotations;
 namespace MetadataExtractor.IO
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public class SequentialByteArrayReader : SequentialReader
+    public sealed class SequentialByteArrayReader : SequentialReader
     {
         [NotNull]
         private readonly byte[] _bytes;

--- a/MetadataExtractor/IO/SequentialByteArrayReader.cs
+++ b/MetadataExtractor/IO/SequentialByteArrayReader.cs
@@ -61,7 +61,9 @@ namespace MetadataExtractor.IO
                 throw new IOException("End of data reached.");
 
             var bytes = new byte[count];
-            Array.Copy(_bytes, _index, bytes, 0, count);
+
+            _bytes.AsSpan(_index, count).CopyTo(bytes);
+
             _index += count;
             return bytes;
         }
@@ -71,7 +73,8 @@ namespace MetadataExtractor.IO
             if (_index + count > _bytes.Length)
                 throw new IOException("End of data reached.");
 
-            Array.Copy(_bytes, _index, buffer, offset, count);
+            _bytes.AsSpan(_index, count).CopyTo(buffer.AsSpan(offset));
+
             _index += count;
         }
 

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -23,6 +23,7 @@
 #endregion
 
 using System;
+using System.Buffers.Binary;
 using System.Text;
 using JetBrains.Annotations;
 
@@ -41,6 +42,8 @@ namespace MetadataExtractor.IO
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public abstract class SequentialReader
     {
+        private readonly byte[] temp = new byte[8];
+
         protected SequentialReader(bool isMotorolaByteOrder)
         {
             IsMotorolaByteOrder = isMotorolaByteOrder;
@@ -105,17 +108,11 @@ namespace MetadataExtractor.IO
         /// <exception cref="System.IO.IOException"/>
         public ushort GetUInt16()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return (ushort)
-                    (GetByte() << 8 |
-                     GetByte());
-            }
-            // Intel ordering - LSB first
-            return (ushort)
-                (GetByte() |
-                 GetByte() << 8);
+                        GetBytes(temp, 0, 2);
+
+            return IsMotorolaByteOrder
+                 ? BinaryPrimitives.ReadUInt16BigEndian(temp)
+                 : BinaryPrimitives.ReadUInt16LittleEndian(temp);
         }
 
         /// <summary>Returns a signed 16-bit int calculated from two bytes of data (MSB, LSB).</summary>
@@ -123,17 +120,11 @@ namespace MetadataExtractor.IO
         /// <exception cref="System.IO.IOException">the buffer does not contain enough bytes to service the request</exception>
         public short GetInt16()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return (short)
-                    (GetByte() << 8 |
-                     GetByte());
-            }
-            // Intel ordering - LSB first
-            return (short)
-                (GetByte() |
-                 GetByte() << 8);
+            GetBytes(temp, 0, 2);
+
+            return IsMotorolaByteOrder
+                 ? BinaryPrimitives.ReadInt16BigEndian(temp)
+                 : BinaryPrimitives.ReadInt16LittleEndian(temp);
         }
 
         /// <summary>Get a 32-bit unsigned integer from the buffer, returning it as a long.</summary>
@@ -141,21 +132,11 @@ namespace MetadataExtractor.IO
         /// <exception cref="System.IO.IOException">the buffer does not contain enough bytes to service the request</exception>
         public uint GetUInt32()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first (big endian)
-                return (uint)
-                    (GetByte() << 24 |
-                     GetByte() << 16 |
-                     GetByte() << 8  |
-                     GetByte());
-            }
-            // Intel ordering - LSB first (little endian)
-            return (uint)
-                (GetByte()       |
-                 GetByte() << 8  |
-                 GetByte() << 16 |
-                 GetByte() << 24);
+            GetBytes(temp, 0, 4);
+
+            return IsMotorolaByteOrder
+                 ? BinaryPrimitives.ReadUInt32BigEndian(temp)
+                 : BinaryPrimitives.ReadUInt32LittleEndian(temp);
         }
 
         /// <summary>Returns a signed 32-bit integer from four bytes of data.</summary>
@@ -163,21 +144,11 @@ namespace MetadataExtractor.IO
         /// <exception cref="System.IO.IOException">the buffer does not contain enough bytes to service the request</exception>
         public int GetInt32()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first (big endian)
-                return
-                    GetByte() << 24 |
-                    GetByte() << 16 |
-                    GetByte() << 8  |
-                    GetByte();
-            }
-            // Intel ordering - LSB first (little endian)
-            return
-                GetByte()       |
-                GetByte() <<  8 |
-                GetByte() << 16 |
-                GetByte() << 24;
+            GetBytes(temp, 0, 4);
+
+            return IsMotorolaByteOrder
+                 ? BinaryPrimitives.ReadInt32BigEndian(temp)
+                 : BinaryPrimitives.ReadInt32LittleEndian(temp);
         }
 
         /// <summary>Get a signed 64-bit integer from the buffer.</summary>
@@ -185,29 +156,11 @@ namespace MetadataExtractor.IO
         /// <exception cref="System.IO.IOException">the buffer does not contain enough bytes to service the request</exception>
         public long GetInt64()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return
-                    (long)GetByte() << 56 |
-                    (long)GetByte() << 48 |
-                    (long)GetByte() << 40 |
-                    (long)GetByte() << 32 |
-                    (long)GetByte() << 24 |
-                    (long)GetByte() << 16 |
-                    (long)GetByte() << 8  |
-                          GetByte();
-            }
-            // Intel ordering - LSB first
-            return
-                      GetByte()       |
-                (long)GetByte() << 8  |
-                (long)GetByte() << 16 |
-                (long)GetByte() << 24 |
-                (long)GetByte() << 32 |
-                (long)GetByte() << 40 |
-                (long)GetByte() << 48 |
-                (long)GetByte() << 56;
+            GetBytes(temp, 0, 8);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadInt64BigEndian(temp)
+                : BinaryPrimitives.ReadInt64LittleEndian(temp);
         }
 
         /// <summary>Get an usigned 64-bit integer from the buffer.</summary>
@@ -215,29 +168,11 @@ namespace MetadataExtractor.IO
         /// <exception cref="System.IO.IOException">the buffer does not contain enough bytes to service the request</exception>
         public ulong GetUInt64()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return
-                    (ulong)GetByte() << 56 |
-                    (ulong)GetByte() << 48 |
-                    (ulong)GetByte() << 40 |
-                    (ulong)GetByte() << 32 |
-                    (ulong)GetByte() << 24 |
-                    (ulong)GetByte() << 16 |
-                    (ulong)GetByte() << 8  |
-                           GetByte();
-            }
-            // Intel ordering - LSB first
-            return
-                       GetByte()       |
-                (ulong)GetByte() << 8  |
-                (ulong)GetByte() << 16 |
-                (ulong)GetByte() << 24 |
-                (ulong)GetByte() << 32 |
-                (ulong)GetByte() << 40 |
-                (ulong)GetByte() << 48 |
-                (ulong)GetByte() << 56;
+            GetBytes(temp, 0, 8);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadUInt64BigEndian(temp)
+                : BinaryPrimitives.ReadUInt64LittleEndian(temp);
         }
 
         /// <summary>Gets a s15.16 fixed point float from the buffer.</summary>

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -276,9 +276,15 @@ namespace MetadataExtractor.IO
             if (length == maxLengthBytes)
                 return buffer;
 
+            if (length == 0)
+            {
+                return Array.Empty<byte>();
+            }
+
             var bytes = new byte[length];
-            if (length > 0)
-                Array.Copy(buffer, bytes, length);
+
+            buffer.AsSpan(0, length).CopyTo(bytes);
+
             return bytes;
         }
 

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -108,7 +108,7 @@ namespace MetadataExtractor.IO
         /// <exception cref="System.IO.IOException"/>
         public ushort GetUInt16()
         {
-                        GetBytes(temp, 0, 2);
+            GetBytes(temp, 0, 2);
 
             return IsMotorolaByteOrder
                  ? BinaryPrimitives.ReadUInt16BigEndian(temp)

--- a/MetadataExtractor/IO/SequentialStreamReader.cs
+++ b/MetadataExtractor/IO/SequentialStreamReader.cs
@@ -30,7 +30,7 @@ using JetBrains.Annotations;
 namespace MetadataExtractor.IO
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public class SequentialStreamReader : SequentialReader
+    public sealed class SequentialStreamReader : SequentialReader
     {
         [NotNull]
         private readonly Stream _stream;
@@ -77,7 +77,7 @@ namespace MetadataExtractor.IO
         public override void Skip(long n)
         {
             if (n < 0)
-                throw new ArgumentException("n must be zero or greater.");
+                throw new ArgumentException("Must be zero or greater.", nameof(n));
 
             if (_stream.Position + n > _stream.Length)
                 throw new IOException("Unable to skip past of end of file");

--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -148,7 +148,7 @@ namespace MetadataExtractor
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
                 directories.AddRange(ReadMetadata(stream));
 
-            directories.Add(new FileMetadataReader().Read(filePath));
+            directories.Add(FileMetadataReader.Read(filePath));
 
             return directories;
         }

--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -42,12 +42,6 @@ using MetadataExtractor.Formats.WebP;
 using MetadataExtractor.Formats.Avi;
 using MetadataExtractor.Util;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 // ReSharper disable RedundantCaseLabel
 
 namespace MetadataExtractor
@@ -88,7 +82,7 @@ namespace MetadataExtractor
         /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
         /// <exception cref="System.IO.IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] Stream stream)
         {
             var fileType = FileTypeDetector.DetectFileType(stream);
 
@@ -136,7 +130,7 @@ namespace MetadataExtractor
                     throw new ImageProcessingException("File format is not supported");
             }
 
-            DirectoryList Append(IEnumerable<Directory> list, Directory directory) 
+            IReadOnlyList<Directory> Append(IEnumerable<Directory> list, Directory directory) 
                 => new List<Directory>(list) { directory };
         }
 
@@ -145,9 +139,9 @@ namespace MetadataExtractor
         /// <param name="filePath">Location of a file from which data should be read.</param>
         /// <returns>A list of <see cref="Directory"/> instances containing the various types of metadata found within the file's data.</returns>
         /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
-        /// <exception cref="System.IO.IOException"/>
+        /// <exception cref="IOException"/>
         [NotNull]
-        public static DirectoryList ReadMetadata([NotNull] string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata([NotNull] string filePath)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/ImageProcessingException.cs
+++ b/MetadataExtractor/ImageProcessingException.cs
@@ -23,18 +23,14 @@
 #endregion
 
 using System;
-#if !NETSTANDARD1_3
 using System.Runtime.Serialization;
-#endif
 using JetBrains.Annotations;
 
 namespace MetadataExtractor
 {
     /// <summary>An exception class thrown upon an unexpected condition that was fatal for the processing of an image.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public class ImageProcessingException : Exception
     {
         public ImageProcessingException([CanBeNull] string message)
@@ -52,11 +48,9 @@ namespace MetadataExtractor
         {
         }
 
-#if !NETSTANDARD1_3
         protected ImageProcessingException([NotNull] SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/MetadataExtractor/MetadataException.cs
+++ b/MetadataExtractor/MetadataException.cs
@@ -23,18 +23,14 @@
 #endregion
 
 using System;
-#if !NETSTANDARD1_3
 using System.Runtime.Serialization;
-#endif
 using JetBrains.Annotations;
 
 namespace MetadataExtractor
 {
     /// <summary>Base class for all metadata specific exceptions.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
-#endif
     public class MetadataException : Exception
     {
         public MetadataException([CanBeNull] string msg)
@@ -52,11 +48,9 @@ namespace MetadataExtractor
         {
         }
 
-#if !NETSTANDARD1_3
         protected MetadataException([NotNull] SerializationInfo info, StreamingContext context)
             : base(info, context)
         {
         }
-#endif
     }
 }

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -13,7 +13,7 @@
     <AssemblyTitle>Metadata Extractor</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Drew Noakes</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net461</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -41,13 +41,15 @@
     <PackageReference Include="XmpCore" Version="6.1.10" Condition=" '$(Signed)' != 'True' " />
     <PackageReference Include="XmpCore.StrongName" Version="5.1.3" Condition=" '$(Signed)' == 'True' " />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.5.1" />
+
   </ItemGroup>
 
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net451' ">
     <Reference Include="System" />
   </ItemGroup>
 

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -49,7 +49,6 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -13,7 +13,7 @@
     <AssemblyTitle>Metadata Extractor</AssemblyTitle>
     <VersionPrefix>2.0.0</VersionPrefix>
     <Authors>Drew Noakes</Authors>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net35;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <DebugType>portable</DebugType>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -43,12 +43,8 @@
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
-    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.3.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System" />
+  <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.0" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -39,7 +39,7 @@
 
   <ItemGroup>
     <PackageReference Include="XmpCore" Version="6.1.10" Condition=" '$(Signed)' != 'True' " />
-    <PackageReference Include="XmpCore.StrongName" Version="5.1.3" Condition=" '$(Signed)' == 'True' " />
+    <PackageReference Include="XmpCore.StrongName" Version="6.1.10" Condition=" '$(Signed)' == 'True' " />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
     <PackageReference Include="System.Memory" Version="4.5.1" />
 

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -38,7 +38,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="XmpCore" Version="5.1.3.1" Condition=" '$(Signed)' != 'True' " />
+    <PackageReference Include="XmpCore" Version="6.1.10" Condition=" '$(Signed)' != 'True' " />
     <PackageReference Include="XmpCore.StrongName" Version="5.1.3" Condition=" '$(Signed)' == 'True' " />
     <PackageReference Include="JetBrains.Annotations" Version="11.1.0" PrivateAssets="All" />
   </ItemGroup>

--- a/MetadataExtractor/Rational.cs
+++ b/MetadataExtractor/Rational.cs
@@ -23,11 +23,9 @@
 #endregion
 
 using System;
-using JetBrains.Annotations;
-#if !NETSTANDARD1_3
-using System.Globalization;
 using System.ComponentModel;
-#endif
+using System.Globalization;
+using JetBrains.Annotations;
 
 // TODO operator overloads
 
@@ -39,10 +37,8 @@ namespace MetadataExtractor
     /// Note that any <see cref="Rational"/> with a numerator of zero will be treated as zero, even if the denominator is also zero.
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-#if !NETSTANDARD1_3
     [Serializable]
     [TypeConverter(typeof(RationalConverter))]
-#endif
     public readonly struct Rational : IConvertible, IEquatable<Rational>
     {
         /// <summary>Gets the denominator.</summary>
@@ -322,7 +318,6 @@ namespace MetadataExtractor
 
         #region RationalConverter
 
-#if !NETSTANDARD1_3
         private sealed class RationalConverter : TypeConverter
         {
             public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
@@ -369,7 +364,6 @@ namespace MetadataExtractor
 
             public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType) => false;
         }
-#endif
 
         #endregion
     }

--- a/MetadataExtractor/Rational.cs
+++ b/MetadataExtractor/Rational.cs
@@ -43,7 +43,7 @@ namespace MetadataExtractor
     [Serializable]
     [TypeConverter(typeof(RationalConverter))]
 #endif
-    public struct Rational : IConvertible, IEquatable<Rational>
+    public readonly struct Rational : IConvertible, IEquatable<Rational>
     {
         /// <summary>Gets the denominator.</summary>
         public long Denominator { get; }
@@ -258,12 +258,10 @@ namespace MetadataExtractor
         /// </remarks>
         /// <param name="other"></param>
         /// <returns></returns>
-        public bool EqualsExact(Rational other) => Denominator == other.Denominator && Numerator == other.Numerator;
+        public bool EqualsExact(in Rational other) => Denominator == other.Denominator && Numerator == other.Numerator;
 
         public override bool Equals(object obj)
         {
-            if (ReferenceEquals(null, obj))
-                return false;
             return obj is Rational rational && Equals(rational);
         }
 

--- a/MetadataExtractor/StringValue.cs
+++ b/MetadataExtractor/StringValue.cs
@@ -16,7 +16,7 @@ namespace MetadataExtractor
     /// The introduction of this type allows full transparency and control over the use of string data extracted
     /// by the library during the read phase.
     /// </remarks>
-    public struct StringValue : IConvertible
+    public readonly struct StringValue : IConvertible
     {
         /// <summary>
         /// The encoding used when decoding a <see cref="StringValue"/> that does not specify its encoding.

--- a/MetadataExtractor/TagDescriptor.cs
+++ b/MetadataExtractor/TagDescriptor.cs
@@ -318,17 +318,10 @@ namespace MetadataExtractor
                     sb.Append(GetFStopDescription(values[2].ToDouble()));
                 else
                     sb.Append("f/")
-#if !NETSTANDARD1_3
                       .Append(Math.Round(values[2].ToDouble(), 1, MidpointRounding.AwayFromZero).ToString("0.0"))
-#else
-                      .Append(Math.Round(values[2].ToDouble(), 1).ToString("0.0"))
-#endif
                       .Append("-")
-#if !NETSTANDARD1_3
                       .Append(Math.Round(values[3].ToDouble(), 1, MidpointRounding.AwayFromZero).ToString("0.0"));
-#else
-                      .Append(Math.Round(values[3].ToDouble(), 1).ToString("0.0"));
-#endif
+
             }
 
             return sb.ToString();

--- a/MetadataExtractor/TagDescriptor.cs
+++ b/MetadataExtractor/TagDescriptor.cs
@@ -229,11 +229,8 @@ namespace MetadataExtractor
                 value >>= 1;
                 bitIndex++;
             }
-#if NET35
-            return string.Join(", ", parts.ToArray());
-#else
+
             return string.Join(", ", parts);
-#endif
         }
 
         [Pure]

--- a/MetadataExtractor/TagDescriptor.cs
+++ b/MetadataExtractor/TagDescriptor.cs
@@ -308,7 +308,7 @@ namespace MetadataExtractor
             if (values[0] == values[1])
                 sb.Append(values[0].ToSimpleString()).Append("mm");
             else
-                sb.Append(values[0].ToSimpleString()).Append("-").Append(values[1].ToSimpleString()).Append("mm");
+                sb.Append(values[0].ToSimpleString()).Append('-').Append(values[1].ToSimpleString()).Append("mm");
 
             if (!values[2].IsZero)
             {
@@ -319,7 +319,7 @@ namespace MetadataExtractor
                 else
                     sb.Append("f/")
                       .Append(Math.Round(values[2].ToDouble(), 1, MidpointRounding.AwayFromZero).ToString("0.0"))
-                      .Append("-")
+                      .Append('-')
                       .Append(Math.Round(values[3].ToDouble(), 1, MidpointRounding.AwayFromZero).ToString("0.0"));
 
             }

--- a/MetadataExtractor/Util/ByteArrayUtil.cs
+++ b/MetadataExtractor/Util/ByteArrayUtil.cs
@@ -1,4 +1,5 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using JetBrains.Annotations;
 
 namespace MetadataExtractor.Util
 {
@@ -10,12 +11,7 @@ namespace MetadataExtractor.Util
             if (source.Length < pattern.Length)
                 return false;
 
-            // ReSharper disable once LoopCanBeConvertedToQuery
-            for (var i = 0; i < pattern.Length; i++)
-                if (source[i] != pattern[i])
-                    return false;
-
-            return true;
+            return source.AsSpan().StartsWith(pattern);
         }
     }
 }

--- a/MetadataExtractor/Util/ByteConvert.cs
+++ b/MetadataExtractor/Util/ByteConvert.cs
@@ -1,6 +1,6 @@
-using JetBrains.Annotations;
 using System;
-
+using System.Buffers.Binary;
+using JetBrains.Annotations;
 namespace MetadataExtractor.Util
 {
     public static class ByteConvert
@@ -8,34 +8,25 @@ namespace MetadataExtractor.Util
         [Pure]
         public static uint FromBigEndianToNative(uint bigEndian)
         {
-            if (BitConverter.IsLittleEndian == false)
-                return bigEndian;
-
-            var bytes = BitConverter.GetBytes(bigEndian);
-            Array.Reverse(bytes);
-            return BitConverter.ToUInt32(bytes, startIndex: 0);
+            return BitConverter.IsLittleEndian
+               ? BinaryPrimitives.ReverseEndianness(bigEndian)
+               : bigEndian;
         }
 
         [Pure]
         public static ushort FromBigEndianToNative(ushort bigEndian)
         {
-            if (BitConverter.IsLittleEndian == false)
-                return bigEndian;
-
-            var bytes = BitConverter.GetBytes(bigEndian);
-            Array.Reverse(bytes);
-            return BitConverter.ToUInt16(bytes, startIndex: 0);
+            return BitConverter.IsLittleEndian
+              ? BinaryPrimitives.ReverseEndianness(bigEndian)
+              : bigEndian;
         }
 
         [Pure]
         public static short FromBigEndianToNative(short bigEndian)
         {
-            if (BitConverter.IsLittleEndian == false)
-                return bigEndian;
-
-            var bytes = BitConverter.GetBytes(bigEndian);
-            Array.Reverse(bytes);
-            return BitConverter.ToInt16(bytes, startIndex: 0);
+            return BitConverter.IsLittleEndian 
+                ? BinaryPrimitives.ReverseEndianness(bigEndian)
+                : bigEndian;
         }
     }
 }

--- a/MetadataExtractor/Util/ByteConvert.cs
+++ b/MetadataExtractor/Util/ByteConvert.cs
@@ -37,17 +37,5 @@ namespace MetadataExtractor.Util
             Array.Reverse(bytes);
             return BitConverter.ToInt16(bytes, startIndex: 0);
         }
-
-        [Pure]
-        public static int ToInt32BigEndian([NotNull] byte[] bytes) => bytes[0] << 24 |
-                                                                      bytes[1] << 16 |
-                                                                      bytes[2] << 8 |
-                                                                      bytes[3];
-
-        [Pure]
-        public static int ToInt32LittleEndian([NotNull] byte[] bytes) => bytes[0] |
-                                                                         bytes[1] << 8 |
-                                                                         bytes[2] << 16 |
-                                                                         bytes[3] << 24;
     }
 }

--- a/README.md
+++ b/README.md
@@ -116,16 +116,18 @@ Camera-specific "makernote" data is decoded for cameras manufactured by:
 
 This library targets:
 
-- .NET Framework 3.5 (`net35`)
-- .NET Framework 4.5 (`net45`)
-- .NET Standard 1.3 (`netstandard1.3`)
+- .NET Framework 4.6.1 (`net461`)
 - .NET Standard 2.0 (`netstandard2.0`)
 
 All target frameworks are provided via the [one NuGet package](https://www.nuget.org/packages/MetadataExtractor).
 
-`net35` and `net45` target the full .NET Framework. `net45` uses the newer `IReadOnlyList<>` on some public APIs where `net35` uses `IList<>`. Internally `net45` also uses some newer library features for slightly improved performance.
+`net46` target the full .NET Framework. 
 
-`netstandard1.3` implements version 1.3 of the [.NET Standard](https://docs.microsoft.com/en-us/dotnet/articles/standard/library) which covers .NET Core, Mono, Xamarin platforms, UWP, and future platforms. 
+`netstandard2.0` implements version 2.0 of the [.NET Standard](https://docs.microsoft.com/en-us/dotnet/articles/standard/library) which covers .NET Core, Mono, Xamarin platforms, UWP, and future platforms. 
+
+## Previously Supported Frameworks
+
+A .netstandard1.1 build was supported until [version 2.0.0](https://www.nuget.org/packages/MetadataExtractor/2.0.0).
 
 A PCL build was supported until [version 1.5.3](https://www.nuget.org/packages/MetadataExtractor/1.5.3) which supported Silverlight 5.0, Windows 8.0, Windows Phone 8.1 and Windows Phone Silverlight 8.0. PCL versions did not support file-system metadata due to restricted IO APIs.
 

--- a/README.md
+++ b/README.md
@@ -121,8 +121,6 @@ This library targets:
 
 All target frameworks are provided via the [one NuGet package](https://www.nuget.org/packages/MetadataExtractor).
 
-`net46` target the full .NET Framework. 
-
 `netstandard2.0` implements version 2.0 of the [.NET Standard](https://docs.microsoft.com/en-us/dotnet/articles/standard/library) which covers .NET Core, Mono, Xamarin platforms, UWP, and future platforms. 
 
 ## Previously Supported Frameworks


### PR DESCRIPTION
This PR retargets the library to platforms supporting System.Memory and implements an initial set of refactoring to improve performance and bring down memory usage.

This PR also:

- Updates deps to their latest versions
- Updates test to run on .NETSTANDARD2.1
- Ensure that the code pages are registered on .NETSTANDARD2.0
- Makes readers with single Extract method static (eliminating per use allocations) 
 