### PR TITLE
Replaced rawgit.com urls with combinatronics.com urls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![metadata-extractor logo](https://cdn.rawgit.com/drewnoakes/metadata-extractor/master/Resources/metadata-extractor-logo.svg)
+![metadata-extractor logo](https://cdn.combinatronics.com/drewnoakes/metadata-extractor/master/Resources/metadata-extractor-logo.svg)
 
 [![Build status](https://ci.appveyor.com/api/projects/status/90hfuleg8wj8r956?svg=true)](https://ci.appveyor.com/project/drewnoakes/metadata-extractor-dotnet)
 [![MetadataExtractor NuGet version](https://img.shields.io/nuget/v/MetadataExtractor.svg)](https://www.nuget.org/packages/MetadataExtractor/)


### PR DESCRIPTION
Combinatronics.com is a drop in replacement for rawgit.com which is EOL.