### PR TITLE
Added DJI to ExifTiffHandler.cs, so DJI makernotes are parsed

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -578,6 +578,11 @@ namespace MetadataExtractor.Formats.Exif
                 PushDirectory(new SamsungType2MakernoteDirectory());
                 TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
             }
+            else if (string.Equals("DJI", cameraMake, StringComparison.Ordinal))
+            {
+                PushDirectory(new DJIMakernoteDirectory());
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+            }
             else
             {
                 // The makernote is not comprehended by this library.


### PR DESCRIPTION
First: Thanks for the work you put into this library!

DJI Makernote parsing was already in the code base, but wasn't called from ExifTiffHandler.cs. If I understand the code correctly :)
Added the model check & tested with photos from DJI FC6520, FC6310 and FC330, and works great.

And an unrelated questions: looks like there is activity in this repo, but there hasn't been a release since 2.0.0. Am I missing something? Anything I could help?