### PR TITLE
Port GifControlDirectory additions from Java

### DIFF
--- a/MetadataExtractor/Formats/Gif/GifControlDescriptor.cs
+++ b/MetadataExtractor/Formats/Gif/GifControlDescriptor.cs
@@ -33,5 +33,41 @@ namespace MetadataExtractor.Formats.Gif
             : base(directory)
         {
         }
+
+        public override string GetDescription(int tagType)
+        {
+            switch (tagType)
+            {
+                case GifControlDirectory.TagDisposalMethod:
+                    return GetDisposalMethodDescription();
+                default:
+                    return base.GetDescription(tagType);
+            }
+        }
+
+        public string GetDisposalMethodDescription()
+        {
+            if (!Directory.TryGetInt32(GifControlDirectory.TagDisposalMethod, out int value))
+                return null;
+
+            switch (value)
+            {
+                case 0:
+                    return "Not Specified";
+                case 1:
+                    return "Don't Dispose";
+                case 2:
+                    return "Restore to Background Color";
+                case 3:
+                    return "Restore to Previous";
+                case 4:
+                case 5:
+                case 6:
+                case 7:
+                    return "To Be Defined";
+                default:
+                    return $"Invalid value ({value})";
+            }
+        }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifControlDirectory.cs
+++ b/MetadataExtractor/Formats/Gif/GifControlDirectory.cs
@@ -32,10 +32,18 @@ namespace MetadataExtractor.Formats.Gif
     public class GifControlDirectory : Directory
     {
         public const int TagDelay = 1;
+        public const int TagDisposalMethod = 2;
+        public const int TagUserInputFlag = 3;
+        public const int TagTransparentColorFlag = 4;
+        public const int TagTransparentColorIndex = 5;
 
         private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
         {
-            { TagDelay, "Delay" }
+            { TagDelay, "Delay" },
+            { TagDisposalMethod, "Disposal Method" },
+            { TagUserInputFlag, "User Input Flag" },
+            { TagTransparentColorFlag, "Transparent Color Flag" },
+            { TagTransparentColorIndex, "Transparent Color Index" }
         };
 
         public GifControlDirectory()

--- a/MetadataExtractor/Formats/Gif/GifReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifReader.cs
@@ -329,12 +329,12 @@ namespace MetadataExtractor.Formats.Gif
 
             var directory = new GifControlDirectory();
 
-            reader.Skip(1);
-
+            byte packedFields = reader.GetByte();
+            directory.Set(GifControlDirectory.TagDisposalMethod, (packedFields >> 2) & 7);
+            directory.Set(GifControlDirectory.TagUserInputFlag, (packedFields & 2) == 2);
+            directory.Set(GifControlDirectory.TagTransparentColorFlag, (packedFields & 1) == 1);
             directory.Set(GifControlDirectory.TagDelay, reader.GetUInt16());
-
-            if (blockSizeBytes > 3)
-                reader.Skip(blockSizeBytes - 3);
+            directory.Set(GifControlDirectory.TagTransparentColorIndex, reader.GetByte());
 
             // skip 0x0 block terminator
             reader.GetByte();


### PR DESCRIPTION
Todo: backport GifControlDescriptor "{value}" addition to Java
Todo: backport to Java GifReader --  directory.Set(GifControlDirectory.TagUserInputFlag, (packedFields & 2) == 2);