### PR TITLE
Port extended BMP support from Java

### DIFF
--- a/MetadataExtractor.Tests/Formats/Bmp/BmpReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Bmp/BmpReaderTest.cs
@@ -22,6 +22,7 @@
 //
 #endregion
 
+using System.Linq;
 using JetBrains.Annotations;
 using MetadataExtractor.Formats.Bmp;
 using MetadataExtractor.IO;
@@ -37,7 +38,7 @@ namespace MetadataExtractor.Tests.Formats.Bmp
         private static BmpHeaderDirectory ProcessBytes([NotNull] string filePath)
         {
             using (var stream = TestDataUtil.OpenRead(filePath))
-                return new BmpReader().Extract(new SequentialStreamReader(stream));
+                return new BmpReader().Extract(new SequentialStreamReader(stream)).OfType<BmpHeaderDirectory>().First();
         }
 
         [Fact]

--- a/MetadataExtractor/Formats/Bmp/BmpHeaderDescriptor.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpHeaderDescriptor.cs
@@ -28,6 +28,7 @@ using JetBrains.Annotations;
 namespace MetadataExtractor.Formats.Bmp
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public sealed class BmpHeaderDescriptor : TagDescriptor<BmpHeaderDirectory>
     {
@@ -40,10 +41,55 @@ namespace MetadataExtractor.Formats.Bmp
         {
             switch (tagType)
             {
+                case BmpHeaderDirectory.TagBitmapType:
+                    return GetBitmapTypeDescription();
                 case BmpHeaderDirectory.TagCompression:
                     return GetCompressionDescription();
+                case BmpHeaderDirectory.TagRendering:
+                    return GetRenderingDescription();
+                case BmpHeaderDirectory.TagColorEncoding:
+                    return GetColorEncodingDescription();
+                case BmpHeaderDirectory.TagRedMask:
+                case BmpHeaderDirectory.TagGreenMask:
+                case BmpHeaderDirectory.TagBlueMask:
+                case BmpHeaderDirectory.TagAlphaMask:
+                    return string.Format("0x{0}", Directory.GetInt64(tagType).ToString("X" + 8.ToString()));
+                case BmpHeaderDirectory.TagColorSpaceType:
+                    return GetColorSpaceTypeDescription();
+                case BmpHeaderDirectory.TagGammaRed:
+                case BmpHeaderDirectory.TagGammaGreen:
+                case BmpHeaderDirectory.TagGammaBlue:
+                    return $"{((double)Directory.GetInt64(tagType) / 0x10000):0.###}";
+                //return FormatFixed1616(Directory.GetInt64(tagType));
+                case BmpHeaderDirectory.TagIntent:
+                    return GetRenderingIntentDescription();
                 default:
                     return base.GetDescription(tagType);
+            }
+        }
+
+        [CanBeNull]
+        public string GetBitmapTypeDescription()
+        {
+            if (!Directory.TryGetInt32(BmpHeaderDirectory.TagBitmapType, out int value))
+                return null;
+
+            switch (value)
+            {
+                case (int)BmpHeaderDirectory.BitmapType.Bitmap:
+                    return "Standard";
+                case (int)BmpHeaderDirectory.BitmapType.OS2BitmapArray:
+                    return "Bitmap Array";
+                case (int)BmpHeaderDirectory.BitmapType.OS2ColorIcon:
+                    return "Color Icon";
+                case (int)BmpHeaderDirectory.BitmapType.OS2ColorPointer:
+                    return "Color Pointer";
+                case (int)BmpHeaderDirectory.BitmapType.OS2Icon:
+                    return "Monochrome Icon";
+                case (int)BmpHeaderDirectory.BitmapType.OS2Pointer:
+                    return "Monochrome Pointer";
+                default:
+                    return "Unimplemented bitmap type " + value.ToString();
             }
         }
 
@@ -53,10 +99,14 @@ namespace MetadataExtractor.Formats.Bmp
             // 0 = None
             // 1 = RLE 8-bit/pixel
             // 2 = RLE 4-bit/pixel
-            // 3 = Bit field (or Huffman 1D if BITMAPCOREHEADER2 (size 64))
-            // 4 = JPEG (or RLE-24 if BITMAPCOREHEADER2 (size 64))
+            // 3 = Bit fields (not OS22XBITMAPHEADER (size 64))
+            // 3 = Huffman 1D (if OS22XBITMAPHEADER (size 64))
+            // 4 = JPEG (not OS22XBITMAPHEADER (size 64))
             // 5 = PNG
-            // 6 = Bit field
+            // 6 = RGBA bit fields
+            // 11 = CMYK
+            // 12 = CMYK RLE-8
+            // 13 = CMYK RLE-4
 
             if (!Directory.TryGetInt32(BmpHeaderDirectory.TagCompression, out int value) ||
                 !Directory.TryGetInt32(BmpHeaderDirectory.TagHeaderSize, out int headerSize))
@@ -64,23 +114,109 @@ namespace MetadataExtractor.Formats.Bmp
 
             switch (value)
             {
-                case 0:
+                case (int)BmpHeaderDirectory.Compression.Rgb:
                     return "None";
-                case 1:
+                case (int)BmpHeaderDirectory.Compression.Rle8:
                     return "RLE 8-bit/pixel";
-                case 2:
+                case (int)BmpHeaderDirectory.Compression.Rle4:
                     return "RLE 4-bit/pixel";
-                case 3:
-                    return headerSize == 64 ? "Bit field" : "Huffman 1D";
-                case 4:
-                    return headerSize == 64 ? "JPEG" : "RLE-24";
-                case 5:
+                case (int)BmpHeaderDirectory.Compression.BitFields:
+                    return headerSize == 64 ? "Huffman 1D" : "Bit Fields";
+                case (int)BmpHeaderDirectory.Compression.Jpeg:
+                    return headerSize == 64 ? "RLE 24-bit/pixel" : "JPEG";
+                case (int)BmpHeaderDirectory.Compression.Png:
                     return "PNG";
-                case 6:
-                    return "Bit field";
+                case (int)BmpHeaderDirectory.Compression.AlphaBitFields:
+                    return "RGBA Bit Fields";
+                case (int)BmpHeaderDirectory.Compression.Cmyk:
+                    return "CMYK Uncompressed";
+                case (int)BmpHeaderDirectory.Compression.CmykRle8:
+                    return "CMYK RLE-8";
+                case (int)BmpHeaderDirectory.Compression.CmykRle4:
+                    return "CMYK RLE-4";
+                default:
+                    return "Unimplemented compression type " + value.ToString();
             }
+        }
 
-            return base.GetDescription(BmpHeaderDirectory.TagCompression);
+        [CanBeNull]
+        public string GetRenderingDescription()
+        {
+            if (!Directory.TryGetInt32(BmpHeaderDirectory.TagRendering, out int value))
+                return null;
+
+            switch (value)
+            {
+                case (int)BmpHeaderDirectory.RenderingHalftoningAlgorithm.None:
+                    return "No Halftoning Algorithm";
+                case (int)BmpHeaderDirectory.RenderingHalftoningAlgorithm.ErrorDiffusion:
+                    return "Error Diffusion Halftoning";
+                case (int)BmpHeaderDirectory.RenderingHalftoningAlgorithm.Panda:
+                    return "Processing Algorithm for Noncoded Document Acquisition";
+                case (int)BmpHeaderDirectory.RenderingHalftoningAlgorithm.SuperCircle:
+                    return "Super-circle Halftoning";
+                default:
+                    return "Unimplemented rendering halftoning algorithm type " + value.ToString();
+            }
+        }
+
+        [CanBeNull]
+        public string GetColorEncodingDescription()
+        {
+            if (!Directory.TryGetInt32(BmpHeaderDirectory.TagColorEncoding, out int value))
+                return null;
+
+            switch (value)
+            {
+                case (int)BmpHeaderDirectory.ColorEncoding.Rgb:
+                    return "RGB";
+                default:
+                    return "Unimplemented color encoding type " + value.ToString();
+            }
+        }
+
+        [CanBeNull]
+        public string GetColorSpaceTypeDescription()
+        {
+            if (!Directory.TryGetInt64(BmpHeaderDirectory.TagColorSpaceType, out long value))
+                return null;
+
+            switch (value)
+            {
+                case (long)BmpHeaderDirectory.ColorSpaceType.LcsCalibratedRgb:
+                    return "Calibrated RGB";
+                case (long)BmpHeaderDirectory.ColorSpaceType.LcsSRgb:
+                    return "sRGB Color Space";
+                case (long)BmpHeaderDirectory.ColorSpaceType.LcsWindowsColorSpace:
+                    return "System Default Color Space, sRGB";
+                case (long)BmpHeaderDirectory.ColorSpaceType.ProfileLinked:
+                    return "Linked Profile";
+                case (long)BmpHeaderDirectory.ColorSpaceType.ProfileEmbedded:
+                    return "Embedded Profile";
+                default:
+                    return "Unimplemented color space type " + value.ToString();
+            }
+        }
+
+        [CanBeNull]
+        public string GetRenderingIntentDescription()
+        {
+            if (!Directory.TryGetInt64(BmpHeaderDirectory.TagIntent, out long value))
+                return null;
+
+            switch (value)
+            {
+                case (long)BmpHeaderDirectory.RenderingIntent.LcsGmBusiness:
+                    return "Graphic, Saturation";
+                case (long)BmpHeaderDirectory.RenderingIntent.LcsGmGraphics:
+                    return "Proof, Relative Colorimetric";
+                case (long)BmpHeaderDirectory.RenderingIntent.LcsGmImages:
+                    return "Picture, Perceptual";
+                case (long)BmpHeaderDirectory.RenderingIntent.LcsGmAbsColorimetric:
+                    return "Match, Absolute Colorimetric";
+                default:
+                    return "Unimplemented rendering intent type " + value.ToString();
+            }
         }
     }
 }

--- a/MetadataExtractor/Formats/Bmp/BmpHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpHeaderDirectory.cs
@@ -28,9 +28,11 @@ using System.Diagnostics.CodeAnalysis;
 namespace MetadataExtractor.Formats.Bmp
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public class BmpHeaderDirectory : Directory
     {
+        public const int TagBitmapType = -2;
         public const int TagHeaderSize = -1;
         public const int TagImageHeight = 1;
         public const int TagImageWidth = 2;
@@ -41,9 +43,22 @@ namespace MetadataExtractor.Formats.Bmp
         public const int TagYPixelsPerMeter = 7;
         public const int TagPaletteColourCount = 8;
         public const int TagImportantColourCount = 9;
+        public const int TagRendering = 10;
+        public const int TagColorEncoding = 11;
+        public const int TagRedMask = 12;
+        public const int TagGreenMask = 13;
+        public const int TagBlueMask = 14;
+        public const int TagAlphaMask = 15;
+        public const int TagColorSpaceType = 16;
+        public const int TagGammaRed = 17;
+        public const int TagGammaGreen = 18;
+        public const int TagGammaBlue = 19;
+        public const int TagIntent = 20;
+        public const int TagLinkedProfile = 21;
 
         private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
         {
+            { TagBitmapType, "Bitmap type" },
             { TagHeaderSize, "Header Size" },
             { TagImageHeight, "Image Height" },
             { TagImageWidth, "Image Width" },
@@ -53,7 +68,19 @@ namespace MetadataExtractor.Formats.Bmp
             { TagXPixelsPerMeter, "X Pixels per Meter" },
             { TagYPixelsPerMeter, "Y Pixels per Meter" },
             { TagPaletteColourCount, "Palette Colour Count" },
-            { TagImportantColourCount, "Important Colour Count" }
+            { TagImportantColourCount, "Important Colour Count" },
+            { TagRendering, "Rendering" },
+            { TagColorEncoding, "Color Encoding" },
+            { TagRedMask, "Red Mask" },
+            { TagGreenMask, "Green Mask" },
+            { TagBlueMask, "Blue Mask" },
+            { TagAlphaMask, "Alpha Mask" },
+            { TagColorSpaceType, "Color Space Type" },
+            { TagGammaRed, "Red Gamma Curve" },
+            { TagGammaGreen, "Green Gamma Curve" },
+            { TagGammaBlue, "Blue Gamma Curve" },
+            { TagIntent, "Rendering Intent" },
+            { TagLinkedProfile, "Linked Profile File Name" }
         };
 
         public BmpHeaderDirectory()
@@ -66,6 +93,122 @@ namespace MetadataExtractor.Formats.Bmp
         protected override bool TryGetTagName(int tagType, out string tagName)
         {
             return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+
+        /// <summary>
+        /// Possible "magic bytes" indicating bitmap type
+        /// </summary>
+        public enum BitmapType : int
+        {
+            /** "BM" - Windows or OS/2 bitmap */
+            Bitmap = 0x4D42,
+
+            /** "BA" - OS/2 Bitmap array (multiple bitmaps) */
+            OS2BitmapArray = 0x4142,
+
+            /** "IC" - OS/2 Icon */
+            OS2Icon = 0x4349,
+
+            /** "CI" - OS/2 Color icon */
+            OS2ColorIcon = 0x4943,
+
+            /** "CP" - OS/2 Color pointer */
+            OS2ColorPointer = 0x5043,
+
+            /** "PT" - OS/2 Pointer */
+            OS2Pointer = 0x5450
+        }
+
+        public enum Compression : int
+        {
+            /** 0 = None */
+            Rgb = 0,
+
+            /** 1 = RLE 8-bit/pixel */
+            Rle8 = 1,
+
+            /** 2 = RLE 4-bit/pixel */
+            Rle4 = 2,
+
+            /** 3 = Bit fields (not OS22XBITMAPHEADER (size 64)) */
+            BitFields = 3,
+
+            /** 3 = Huffman 1D (if OS22XBITMAPHEADER (size 64)) */
+            Huffman1D = 3,
+
+            /** 4 = JPEG (not OS22XBITMAPHEADER (size 64)) */
+            Jpeg = 4,
+
+            /** 4 = RLE 24-bit/pixel (if OS22XBITMAPHEADER (size 64)) */
+            Rle24 = 4,
+
+            /** 5 = PNG */
+            Png = 5,
+
+            /** 6 = RGBA bit fields */
+            AlphaBitFields = 6,
+
+            /** 11 = CMYK */
+            Cmyk = 11,
+
+            /** 12 = CMYK RLE-8 */
+            CmykRle8 = 12,
+
+            /** 13 = CMYK RLE-4 */
+            CmykRle4 = 13
+        }
+
+        public enum RenderingHalftoningAlgorithm : int
+        {
+            /** No halftoning algorithm */
+            None = 0,
+
+            /** Error Diffusion Halftoning */
+            ErrorDiffusion = 1,
+
+            /** Processing Algorithm for Noncoded Document Acquisition */
+            Panda = 2,
+
+            /** Super-circle Halftoning */
+            SuperCircle = 3
+        }
+
+        public enum ColorEncoding : int
+        {
+            Rgb = 0
+        }
+
+        public enum ColorSpaceType : long
+        {
+            /** 0 = Calibrated RGB */
+            LcsCalibratedRgb = 0L,
+
+            /** "sRGB" = sRGB Color Space */
+            LcsSRgb = 0x73524742L,
+
+            /** "Win " = System Default Color Space, sRGB */
+            LcsWindowsColorSpace = 0x57696E20L,
+
+            /** "LINK" = Linked Profile */
+            ProfileLinked = 0x4C494E4BL,
+
+            /** "MBED" = Embedded Profile */
+            ProfileEmbedded = 0x4D424544L
+        }
+
+        public enum RenderingIntent : long
+        {
+            /** Graphic, Saturation */
+            LcsGmBusiness = 1,
+
+            /** Proof, Relative Colorimetric */
+            LcsGmGraphics = 2,
+
+            /** Picture, Perceptual */
+            LcsGmImages = 4,
+
+            /** Match, Absolute Colorimetric */
+            LcsGmAbsColorimetric = 8
         }
     }
 }

--- a/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
@@ -23,6 +23,7 @@
 #endregion
 
 using System.IO;
+using System.Linq;
 using JetBrains.Annotations;
 using System.Collections.Generic;
 using MetadataExtractor.Formats.FileSystem;
@@ -38,6 +39,7 @@ namespace MetadataExtractor.Formats.Bmp
 {
     /// <summary>Obtains metadata from BMP files.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
+    /// <author>Kevin Mott https://github.com/kwhopper</author>
     public static class BmpMetadataReader
     {
         /// <exception cref="System.IO.IOException"/>
@@ -47,7 +49,7 @@ namespace MetadataExtractor.Formats.Bmp
             var directories = new List<Directory>(2);
 
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                directories.Add(ReadMetadata(stream));
+                directories.AddRange(ReadMetadata(stream));
 
             directories.Add(new FileMetadataReader().Read(filePath));
 
@@ -55,9 +57,9 @@ namespace MetadataExtractor.Formats.Bmp
         }
 
         [NotNull]
-        public static BmpHeaderDirectory ReadMetadata([NotNull] Stream stream)
+        public static DirectoryList ReadMetadata([NotNull] Stream stream)
         {
-            return new BmpReader().Extract(new SequentialStreamReader(stream));
+            return new BmpReader().Extract(new SequentialStreamReader(stream)).ToList();
         }
     }
 }

--- a/MetadataExtractor/Formats/Bmp/BmpReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpReader.cs
@@ -22,91 +22,311 @@
 //
 #endregion
 
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
+using System.Text;
 using JetBrains.Annotations;
 using MetadataExtractor.IO;
+using MetadataExtractor.Formats.Icc;
+
+#if NET35
+using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
+#else
+using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
+#endif
 
 namespace MetadataExtractor.Formats.Bmp
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class BmpReader
     {
         [NotNull]
-        public BmpHeaderDirectory Extract([NotNull] SequentialReader reader)
+        public DirectoryList Extract([NotNull] SequentialReader reader)
         {
-            var directory = new BmpHeaderDirectory();
+            var directories = new List<Directory>();
+            reader = reader.WithByteOrder(isMotorolaByteOrder: false);
 
-            // FILE HEADER
-            //
-            // 2 - magic number (0x42 0x4D = "BM")
-            // 4 - size of BMP file in bytes
-            // 2 - reserved
-            // 2 - reserved
-            // 4 - the offset of the pixel array
-            //
             // BITMAP INFORMATION HEADER
             //
             // The first four bytes of the header give the size, which is a discriminator of the actual header format.
             // See this for more information http://en.wikipedia.org/wiki/BMP_file_format
-            //
-            // BITMAPINFOHEADER (size = 40)
-            //
-            // 4 - size of header
-            // 4 - pixel width (signed)
-            // 4 - pixel height (signed)
-            // 2 - number of colour planes (must be set to 1)
-            // 2 - number of bits per pixel
-            // 4 - compression being used (needs decoding)
-            // 4 - pixel data length (not total file size, just pixel array)
-            // 4 - horizontal resolution, pixels/meter (signed)
-            // 4 - vertical resolution, pixels/meter (signed)
-            // 4 - number of colours in the palette (0 means no palette)
-            // 4 - number of important colours (generally ignored)
-            //
-            // BITMAPCOREHEADER (size = 12)
-            //
-            // 4 - size of header
-            // 2 - pixel width
-            // 2 - pixel height
-            // 2 - number of colour planes (must be set to 1)
-            // 2 - number of bits per pixel
-            //
-            // COMPRESSION VALUES
-            //
-            // 0 = None
-            // 1 = RLE 8-bit/pixel
-            // 2 = RLE 4-bit/pixel
-            // 3 = Bit field (or Huffman 1D if BITMAPCOREHEADER2 (size 64))
-            // 4 = JPEG (or RLE-24 if BITMAPCOREHEADER2 (size 64))
-            // 5 = PNG
-            // 6 = Bit field
+            try
+            {
+                ReadFileHeader(reader, true, directories);
+            }
+            catch (IOException)
+            {
+                directories.Add(new ErrorDirectory("IOException processing BMP data"));
+            }
 
-            reader = reader.WithByteOrder(isMotorolaByteOrder: false);
+            return directories;
+        }
+
+        private static void ReadFileHeader([NotNull] SequentialReader reader, bool allowArray, List<Directory> directories)
+        {
+            /*
+             * There are two possible headers a file can start with. If the magic
+             * number is OS/2 Bitmap Array (0x4142) the OS/2 Bitmap Array Header
+             * will follow. In all other cases the file header will follow, which
+             * is identical for Windows and OS/2.
+             *
+             * File header:
+             *
+             *    WORD   FileType;      - File type identifier
+             *    DWORD  FileSize;      - Size of the file in bytes
+             *    WORD   XHotSpot;      - X coordinate of hotspot for pointers
+             *    WORD   YHotSpot;      - Y coordinate of hotspot for pointers
+             *    DWORD  BitmapOffset;  - Starting position of image data in bytes
+             *
+             * OS/2 Bitmap Array Header:
+             *
+             *     WORD  Type;          - Header type, always 4142h ("BA")
+             *     DWORD Size;          - Size of this header
+             *     DWORD OffsetToNext;  - Offset to next OS2BMPARRAYFILEHEADER
+             *     WORD  ScreenWidth;   - Width of the image display in pixels
+             *     WORD  ScreenHeight;  - Height of the image display in pixels
+             *
+             */
+
+            Directory directory = null;
+            int magicNumber;
+            try
+            {
+                magicNumber = reader.GetUInt16();
+            }
+            catch (IOException e)
+            {
+                directories.Add(new ErrorDirectory("Couldn't determine bitmap type: " + e.ToString()));
+                return;
+            }
 
             try
             {
-                var magicNumber = reader.GetUInt16();
-
-                if (magicNumber != 0x4D42)
+                switch (magicNumber)
                 {
-                    directory.AddError("Invalid BMP magic number");
-                    return directory;
+                    case (int)BmpHeaderDirectory.BitmapType.OS2BitmapArray:
+                        if (!allowArray)
+                        {
+                            //directories.Add(new ErrorDirectory("Invalid bitmap file - nested arrays not allowed"));
+                            AddError("Invalid bitmap file - nested arrays not allowed", directories);
+                            return;
+                        }
+                        reader.Skip(4); // Size
+                        long nextHeaderOffset = reader.GetUInt32();
+                        reader.Skip(2 + 2); // Screen Resolution
+                        ReadFileHeader(reader, false, directories);
+                        if (nextHeaderOffset == 0)
+                        {
+                            return; // No more bitmaps
+                        }
+                        if (reader.Position > nextHeaderOffset)
+                        {
+                            AddError("Invalid next header offset", directories);
+                            return;
+                        }
+                        reader.Skip(nextHeaderOffset - reader.Position);
+                        ReadFileHeader(reader, true, directories);
+                        break;
+                    case (int)BmpHeaderDirectory.BitmapType.Bitmap:
+                    case (int)BmpHeaderDirectory.BitmapType.OS2Icon:
+                    case (int)BmpHeaderDirectory.BitmapType.OS2ColorIcon:
+                    case (int)BmpHeaderDirectory.BitmapType.OS2ColorPointer:
+                    case (int)BmpHeaderDirectory.BitmapType.OS2Pointer:
+                        directory = new BmpHeaderDirectory();
+                        directories.Add(directory);
+                        directory.Set(BmpHeaderDirectory.TagBitmapType, magicNumber);
+                        // skip past the rest of the file header
+                        reader.Skip(4 + 2 + 2 + 4);
+                        ReadBitmapHeader(reader, (BmpHeaderDirectory)directory, directories);
+                        break;
+                    default:
+                        directories.Add(new ErrorDirectory("Invalid BMP magic number 0x" + magicNumber.ToString("X4")));
+                        return;
                 }
+            }
+            catch (IOException)
+            {
+                if (directory == null)
+                    AddError("Unable to read BMP file header", directories);
+                else
+                    directory.AddError("Unable to read BMP file header");
+            }
 
-                // skip past the rest of the file header
-                reader.Skip(4 + 2 + 2 + 4);
+            return;
+        }
 
-                var headerSize = reader.GetInt32();
+        private static void ReadBitmapHeader([NotNull] SequentialReader reader, [NotNull] BmpHeaderDirectory directory, [NotNull]List<Directory> directories)
+        {
+            /*
+             * BITMAPCOREHEADER (12 bytes):
+             *
+             *    DWORD Size              - Size of this header in bytes
+             *    SHORT Width             - Image width in pixels
+             *    SHORT Height            - Image height in pixels
+             *    WORD  Planes            - Number of color planes
+             *    WORD  BitsPerPixel      - Number of bits per pixel
+             *
+             * OS21XBITMAPHEADER (12 bytes):
+             *
+             *    DWORD  Size             - Size of this structure in bytes
+             *    WORD   Width            - Bitmap width in pixels
+             *    WORD   Height           - Bitmap height in pixel
+             *    WORD   NumPlanes        - Number of bit planes (color depth)
+             *    WORD   BitsPerPixel     - Number of bits per pixel per plane
+             *
+             * OS22XBITMAPHEADER (16/64 bytes):
+             *
+             *    DWORD  Size             - Size of this structure in bytes
+             *    DWORD  Width            - Bitmap width in pixels
+             *    DWORD  Height           - Bitmap height in pixel
+             *    WORD   NumPlanes        - Number of bit planes (color depth)
+             *    WORD   BitsPerPixel     - Number of bits per pixel per plane
+             *
+             *    - Short version ends here -
+             *
+             *    DWORD  Compression      - Bitmap compression scheme
+             *    DWORD  ImageDataSize    - Size of bitmap data in bytes
+             *    DWORD  XResolution      - X resolution of display device
+             *    DWORD  YResolution      - Y resolution of display device
+             *    DWORD  ColorsUsed       - Number of color table indices used
+             *    DWORD  ColorsImportant  - Number of important color indices
+             *    WORD   Units            - Type of units used to measure resolution
+             *    WORD   Reserved         - Pad structure to 4-byte boundary
+             *    WORD   Recording        - Recording algorithm
+             *    WORD   Rendering        - Halftoning algorithm used
+             *    DWORD  Size1            - Reserved for halftoning algorithm use
+             *    DWORD  Size2            - Reserved for halftoning algorithm use
+             *    DWORD  ColorEncoding    - Color model used in bitmap
+             *    DWORD  Identifier       - Reserved for application use
+             *
+             * BITMAPINFOHEADER (40 bytes), BITMAPV2INFOHEADER (52 bytes), BITMAPV3INFOHEADER (56 bytes),
+             * BITMAPV4HEADER (108 bytes) and BITMAPV5HEADER (124 bytes):
+             *
+             *    DWORD Size              - Size of this header in bytes
+             *    LONG  Width             - Image width in pixels
+             *    LONG  Height            - Image height in pixels
+             *    WORD  Planes            - Number of color planes
+             *    WORD  BitsPerPixel      - Number of bits per pixel
+             *    DWORD Compression       - Compression methods used
+             *    DWORD SizeOfBitmap      - Size of bitmap in bytes
+             *    LONG  HorzResolution    - Horizontal resolution in pixels per meter
+             *    LONG  VertResolution    - Vertical resolution in pixels per meter
+             *    DWORD ColorsUsed        - Number of colors in the image
+             *    DWORD ColorsImportant   - Minimum number of important colors
+             *
+             *    - BITMAPINFOHEADER ends here -
+             *
+             *    DWORD RedMask           - Mask identifying bits of red component
+             *    DWORD GreenMask         - Mask identifying bits of green component
+             *    DWORD BlueMask          - Mask identifying bits of blue component
+             *
+             *    - BITMAPV2INFOHEADER ends here -
+             *
+             *    DWORD AlphaMask         - Mask identifying bits of alpha component
+             *
+             *    - BITMAPV3INFOHEADER ends here -
+             *
+             *    DWORD CSType            - Color space type
+             *    LONG  RedX              - X coordinate of red endpoint
+             *    LONG  RedY              - Y coordinate of red endpoint
+             *    LONG  RedZ              - Z coordinate of red endpoint
+             *    LONG  GreenX            - X coordinate of green endpoint
+             *    LONG  GreenY            - Y coordinate of green endpoint
+             *    LONG  GreenZ            - Z coordinate of green endpoint
+             *    LONG  BlueX             - X coordinate of blue endpoint
+             *    LONG  BlueY             - Y coordinate of blue endpoint
+             *    LONG  BlueZ             - Z coordinate of blue endpoint
+             *    DWORD GammaRed          - Gamma red coordinate scale value
+             *    DWORD GammaGreen        - Gamma green coordinate scale value
+             *    DWORD GammaBlue         - Gamma blue coordinate scale value
+             *
+             *    - BITMAPV4HEADER ends here -
+             *
+             *    DWORD Intent            - Rendering intent for bitmap
+             *    DWORD ProfileData       - Offset of the profile data relative to BITMAPV5HEADER
+             *    DWORD ProfileSize       - Size, in bytes, of embedded profile data
+             *    DWORD Reserved          - Shall be zero
+             *
+             */
+
+            try
+            {
+                int bitmapType = directory.GetInt32(BmpHeaderDirectory.TagBitmapType);
+                long headerOffset = reader.Position;
+                int headerSize = reader.GetInt32();
+
                 directory.Set(BmpHeaderDirectory.TagHeaderSize, headerSize);
 
-                // We expect the header size to be either 40 (BITMAPINFOHEADER) or 12 (BITMAPCOREHEADER)
-                if (headerSize == 40)
-                {
-                    // BITMAPINFOHEADER
+                /*
+                 * Known header type sizes:
+                 *
+                 *  12 - BITMAPCOREHEADER or OS21XBITMAPHEADER
+                 *  16 - OS22XBITMAPHEADER (short)
+                 *  40 - BITMAPINFOHEADER
+                 *  52 - BITMAPV2INFOHEADER
+                 *  56 - BITMAPV3INFOHEADER
+                 *  64 - OS22XBITMAPHEADER (full)
+                 * 108 - BITMAPV4HEADER
+                 * 124 - BITMAPV5HEADER
+                 *
+                 */
+
+                if (headerSize == 12 && bitmapType == (int)BmpHeaderDirectory.BitmapType.Bitmap)
+                { //BITMAPCOREHEADER
+                  /*
+                   * There's no way to tell BITMAPCOREHEADER and OS21XBITMAPHEADER
+                   * apart for the "standard" bitmap type. The difference is only
+                   * that BITMAPCOREHEADER has signed width and height while
+                   * in OS21XBITMAPHEADER they are unsigned. Since BITMAPCOREHEADER,
+                   * the Windows version, is most common, read them as signed.
+                   */
+                    directory.Set(BmpHeaderDirectory.TagImageWidth, reader.GetInt16());
+                    directory.Set(BmpHeaderDirectory.TagImageHeight, reader.GetInt16());
+                    directory.Set(BmpHeaderDirectory.TagColourPlanes, reader.GetUInt16());
+                    directory.Set(BmpHeaderDirectory.TagBitsPerPixel, reader.GetUInt16());
+                }
+                else if (headerSize == 12)
+                { // OS21XBITMAPHEADER
+                    directory.Set(BmpHeaderDirectory.TagImageWidth, reader.GetUInt16());
+                    directory.Set(BmpHeaderDirectory.TagImageHeight, reader.GetUInt16());
+                    directory.Set(BmpHeaderDirectory.TagColourPlanes, reader.GetUInt16());
+                    directory.Set(BmpHeaderDirectory.TagBitsPerPixel, reader.GetUInt16());
+                }
+                else if (headerSize == 16 || headerSize == 64)
+                { // OS22XBITMAPHEADER
                     directory.Set(BmpHeaderDirectory.TagImageWidth, reader.GetInt32());
                     directory.Set(BmpHeaderDirectory.TagImageHeight, reader.GetInt32());
-                    directory.Set(BmpHeaderDirectory.TagColourPlanes, reader.GetInt16());
-                    directory.Set(BmpHeaderDirectory.TagBitsPerPixel, reader.GetInt16());
+                    directory.Set(BmpHeaderDirectory.TagColourPlanes, reader.GetUInt16());
+                    directory.Set(BmpHeaderDirectory.TagBitsPerPixel, reader.GetUInt16());
+                    if (headerSize > 16)
+                    {
+                        directory.Set(BmpHeaderDirectory.TagCompression, reader.GetInt32());
+                        reader.Skip(4); // skip the pixel data length
+                        directory.Set(BmpHeaderDirectory.TagXPixelsPerMeter, reader.GetInt32());
+                        directory.Set(BmpHeaderDirectory.TagYPixelsPerMeter, reader.GetInt32());
+                        directory.Set(BmpHeaderDirectory.TagPaletteColourCount, reader.GetInt32());
+                        directory.Set(BmpHeaderDirectory.TagImportantColourCount, reader.GetInt32());
+                        reader.Skip(
+                            2 + // Skip Units, can only be 0 (pixels per meter)
+                            2 + // Skip padding
+                            2   // Skip Recording, can only be 0 (left to right, bottom to top)
+                        );
+                        directory.Set(BmpHeaderDirectory.TagRendering, reader.GetUInt16());
+                        reader.Skip(4 + 4); // Skip Size1 and Size2
+                        directory.Set(BmpHeaderDirectory.TagColorEncoding, reader.GetInt32());
+                        reader.Skip(4); // Skip Identifier
+                    }
+                }
+                else if (
+                  headerSize == 40 || headerSize == 52 || headerSize == 56 ||
+                  headerSize == 108 || headerSize == 124)
+                { // BITMAPINFOHEADER V1-5
+                    directory.Set(BmpHeaderDirectory.TagImageWidth, reader.GetInt32());
+                    directory.Set(BmpHeaderDirectory.TagImageHeight, reader.GetInt32());
+                    directory.Set(BmpHeaderDirectory.TagColourPlanes, reader.GetUInt16());
+                    directory.Set(BmpHeaderDirectory.TagBitsPerPixel, reader.GetUInt16());
                     directory.Set(BmpHeaderDirectory.TagCompression, reader.GetInt32());
                     // skip the pixel data length
                     reader.Skip(4);
@@ -114,13 +334,63 @@ namespace MetadataExtractor.Formats.Bmp
                     directory.Set(BmpHeaderDirectory.TagYPixelsPerMeter, reader.GetInt32());
                     directory.Set(BmpHeaderDirectory.TagPaletteColourCount, reader.GetInt32());
                     directory.Set(BmpHeaderDirectory.TagImportantColourCount, reader.GetInt32());
-                }
-                else if (headerSize == 12)
-                {
-                    directory.Set(BmpHeaderDirectory.TagImageWidth, reader.GetInt16());
-                    directory.Set(BmpHeaderDirectory.TagImageHeight, reader.GetInt16());
-                    directory.Set(BmpHeaderDirectory.TagColourPlanes, reader.GetInt16());
-                    directory.Set(BmpHeaderDirectory.TagBitsPerPixel, reader.GetInt16());
+                    if (headerSize == 40)
+                    { // BITMAPINFOHEADER end
+                        return;
+                    }
+                    directory.Set(BmpHeaderDirectory.TagRedMask, reader.GetUInt32());
+                    directory.Set(BmpHeaderDirectory.TagGreenMask, reader.GetUInt32());
+                    directory.Set(BmpHeaderDirectory.TagBlueMask, reader.GetUInt32());
+                    if (headerSize == 52)
+                    { // BITMAPV2INFOHEADER end
+                        return;
+                    }
+                    directory.Set(BmpHeaderDirectory.TagAlphaMask, reader.GetUInt32());
+                    if (headerSize == 56)
+                    { // BITMAPV3INFOHEADER end
+                        return;
+                    }
+                    long csType = reader.GetUInt32();
+                    directory.Set(BmpHeaderDirectory.TagColorSpaceType, csType);
+                    reader.Skip(36); // Skip color endpoint coordinates
+                    directory.Set(BmpHeaderDirectory.TagGammaRed, reader.GetUInt32());
+                    directory.Set(BmpHeaderDirectory.TagGammaGreen, reader.GetUInt32());
+                    directory.Set(BmpHeaderDirectory.TagGammaBlue, reader.GetUInt32());
+                    if (headerSize == 108)
+                    { // BITMAPV4HEADER end
+                        return;
+                    }
+                    directory.Set(BmpHeaderDirectory.TagIntent, reader.GetInt32());
+                    if (csType == (long)BmpHeaderDirectory.ColorSpaceType.ProfileEmbedded || csType == (long)BmpHeaderDirectory.ColorSpaceType.ProfileLinked)
+                    {
+                        long profileOffset = reader.GetUInt32();
+                        int profileSize = reader.GetInt32();
+                        if (reader.Position > headerOffset + profileOffset)
+                        {
+                            directory.AddError("Invalid profile data offset 0x" + (headerOffset + profileOffset).ToString("X8"));
+                            return;
+                        }
+                        reader.Skip(headerOffset + profileOffset - reader.Position);
+                        if (csType == (long)BmpHeaderDirectory.ColorSpaceType.ProfileLinked)
+                        {
+                            directory.Set(BmpHeaderDirectory.TagLinkedProfile, reader.GetNullTerminatedString(profileSize, Encoding.GetEncoding(1252)));
+                        }
+                        else
+                        {
+                            var iccReader = new ByteArrayReader(reader.GetBytes(profileSize));
+                            var iccDirectory = new IccReader().Extract(iccReader);
+                            iccDirectory.Parent = directory;
+                            directories.Add(iccDirectory);
+                        }
+                    }
+                    else
+                    {
+                        reader.Skip(
+                            4 + // Skip ProfileData offset
+                            4 + // Skip ProfileSize
+                            4   // Skip Reserved
+                        );
+                    }
                 }
                 else
                 {
@@ -131,8 +401,19 @@ namespace MetadataExtractor.Formats.Bmp
             {
                 directory.AddError("Unable to read BMP header");
             }
+            catch (MetadataException)
+            {
+                directory.AddError("Internal error");
+            }
+        }
 
-            return directory;
+        private static void AddError([NotNull] string errorMessage, [NotNull] List<Directory> directories)
+        {
+            ErrorDirectory directory = directories.OfType<ErrorDirectory>().FirstOrDefault();
+            if (directory == null)
+                directories.Add(new ErrorDirectory(errorMessage));
+            else
+                directory.AddError(errorMessage);
         }
     }
 }

--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -110,7 +110,7 @@ namespace MetadataExtractor
                 case FileType.Png:
                     return Append(PngMetadataReader.ReadMetadata(stream), fileTypeDirectory);
                 case FileType.Bmp:
-                    return new Directory[] { BmpMetadataReader.ReadMetadata(stream), fileTypeDirectory };
+                    return Append(BmpMetadataReader.ReadMetadata(stream), fileTypeDirectory);
                 case FileType.Gif:
                     return Append(GifMetadataReader.ReadMetadata(stream), fileTypeDirectory);
                 case FileType.Ico:

--- a/MetadataExtractor/Util/FileTypeDetector.cs
+++ b/MetadataExtractor/Util/FileTypeDetector.cs
@@ -44,8 +44,12 @@ namespace MetadataExtractor.Util
             { FileType.Tiff, Encoding.UTF8.GetBytes("MM"), new byte[] { 0x00, 0x2a } },
             { FileType.Psd, Encoding.UTF8.GetBytes("8BPS") },
             { FileType.Png, new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52 } },
-            { FileType.Bmp, Encoding.UTF8.GetBytes("BM") },
-            // TODO technically there are other very rare magic numbers for OS/2 BMP files
+            { FileType.Bmp, Encoding.UTF8.GetBytes("BM") }, // Standard Bitmap Windows and OS/2
+            { FileType.Bmp, Encoding.UTF8.GetBytes("BA") }, // OS/2 Bitmap Array
+            { FileType.Bmp, Encoding.UTF8.GetBytes("CI") }, // OS/2 Color Icon
+            { FileType.Bmp, Encoding.UTF8.GetBytes("CP") }, // OS/2 Color Pointer
+            { FileType.Bmp, Encoding.UTF8.GetBytes("IC") }, // OS/2 Icon
+            { FileType.Bmp, Encoding.UTF8.GetBytes("PT") }, // OS/2 Pointer
             { FileType.Gif, Encoding.UTF8.GetBytes("GIF87a") },
             { FileType.Gif, Encoding.UTF8.GetBytes("GIF89a") },
             { FileType.Ico, new byte[] { 0x00, 0x00, 0x01, 0x00 } },


### PR DESCRIPTION
I'm not really impressed with how the enums + description worked in the Java implementation, but it is what it is. Maybe that should be reviewed a little. Using the special enum methods that Java supports kind of breaks the mold for how the library stores and returns descriptions.