### PR TITLE
Java port - Process only leafnodes for XMP data

### DIFF
--- a/MetadataExtractor.Tests/Formats/Xmp/XmpReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Xmp/XmpReaderTest.cs
@@ -33,7 +33,7 @@ namespace MetadataExtractor.Tests.Formats.Xmp
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class XmpReaderTest
     {
-        private const int expectedPropertyCount = 178;
+        private const int expectedPropertyCount = 167;
 
         private readonly XmpDirectory _directory;
 

--- a/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
+++ b/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
@@ -111,18 +111,15 @@ namespace MetadataExtractor.Tools.FileProcessor
                                 while (iterator.HasNext())
                                 {
                                     var prop = (IXmpPropertyInfo)iterator.Next();
-                                    var ns = prop.Namespace;
                                     var path = prop.Path;
-                                    var value = prop.Value;
 
                                     if (path == null)
                                         continue;
-                                    if (ns == null)
-                                        ns = "";
 
-                                    if (value == null)
-                                        value = "";
-                                    else if (value.Length > 512)
+                                    var ns = prop.Namespace ?? "";
+                                    var value = prop.Value ?? "";
+
+                                    if (value.Length > 512)
                                         value = value.Substring(0, 512) + $" <truncated from {value.Length} characters>";
                                     writer.Write($"[XMPMeta - {ns}] {path} = {value}{NEW_LINE}");
                                     wrote = true;

--- a/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
+++ b/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
@@ -32,6 +32,10 @@ using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.Util;
 
+using XmpCore;
+using XmpCore.Impl;
+using XmpCore.Options;
+
 namespace MetadataExtractor.Tools.FileProcessor
 {
     /// <summary>
@@ -39,6 +43,8 @@ namespace MetadataExtractor.Tools.FileProcessor
     /// </summary>
     internal class TextFileOutputHandler : FileHandlerBase
     {
+        private static string NEW_LINE = "\n";
+
         public override void OnStartingDirectory(string directoryPath)
         {
             base.OnStartingDirectory(directoryPath);
@@ -49,7 +55,7 @@ namespace MetadataExtractor.Tools.FileProcessor
         {
             base.OnBeforeExtraction(filePath, relativePath, log);
             log.Write(filePath);
-            log.Write('\n');
+            log.Write(NEW_LINE);
         }
 
         public override void OnExtractionSuccess(string filePath, IList<Directory> directories, string relativePath, TextWriter log, long streamPosition)
@@ -72,7 +78,7 @@ namespace MetadataExtractor.Tools.FileProcessor
                                 foreach (var error in directory.Errors)
                                     writer.Write("[ERROR: {0}] {1}\n", directory.Name, error);
                             }
-                            writer.Write('\n');
+                            writer.Write(NEW_LINE);
                         }
 
                         // Write tag values for each directory
@@ -87,27 +93,42 @@ namespace MetadataExtractor.Tools.FileProcessor
                                 if (directory is FileMetadataDirectory && tag.Type == FileMetadataDirectory.TagFileModifiedDate)
                                     description = "<omitted for regression testing as checkout dependent>";
 
-                                writer.Write("[{0} - 0x{1:x4}] {2} = {3}\n",
-                                    directoryName, tag.Type, tagName, description);
+                                writer.Write("[{0} - 0x{1:x4}] {2} = {3}{4}",
+                                    directoryName, tag.Type, tagName, description, NEW_LINE);
                             }
 
                             if (directory.TagCount != 0)
-                                writer.Write('\n');
+                                writer.Write(NEW_LINE);
 
+                            // Special handling for XMP directory data
                             var xmpDirectory = directory as XmpDirectory;
                             if (xmpDirectory?.XmpMeta != null)
                             {
                                 var wrote = false;
-                                foreach (var prop in xmpDirectory.XmpMeta.Properties)
+
+                                XmpIterator iterator = new XmpIterator((XmpMeta)xmpDirectory.XmpMeta, null, null, new IteratorOptions() { IsJustLeafNodes = true });
+
+                                while (iterator.HasNext())
                                 {
+                                    var prop = (IXmpPropertyInfo)iterator.Next();
+                                    var ns = prop.Namespace;
+                                    var path = prop.Path;
                                     var value = prop.Value;
-                                    if (value?.Length > 512)
+
+                                    if (path == null)
+                                        continue;
+                                    if (ns == null)
+                                        ns = "";
+
+                                    if (value == null)
+                                        value = "";
+                                    else if (value.Length > 512)
                                         value = value.Substring(0, 512) + $" <truncated from {value.Length} characters>";
-                                    writer.WriteLine($"[XMPMeta - {prop.Namespace}] {prop.Path} = {value}");
+                                    writer.Write($"[XMPMeta - {ns}] {path} = {value}{NEW_LINE}");
                                     wrote = true;
                                 }
                                 if (wrote)
-                                    writer.Write('\n');
+                                    writer.Write(NEW_LINE);
                             }
                         }
 
@@ -128,7 +149,7 @@ namespace MetadataExtractor.Tools.FileProcessor
 
                         WriteLevel(null, 0);
 
-                        writer.Write('\n');
+                        writer.Write(NEW_LINE);
                     }
                     finally
                     {

--- a/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
@@ -24,7 +24,6 @@
 
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
-using System.Linq;
 using JetBrains.Annotations;
 using XmpCore;
 using XmpCore.Impl;
@@ -70,6 +69,9 @@ namespace MetadataExtractor.Formats.Xmp
             return _tagNameMap.TryGetValue(tagType, out tagName);
         }
 
+        // set only once to save some allocations
+        private static readonly IteratorOptions _iteratorOptions = new IteratorOptions() { IsJustLeafNodes = true };
+
         /// <summary>Gets a map of all XMP properties in this directory, not just the known ones.</summary>
         /// <remarks>
         /// This is required because XMP properties are represented as strings, whereas the rest of this library
@@ -83,7 +85,7 @@ namespace MetadataExtractor.Formats.Xmp
             {
                 try
                 {
-                    XmpIterator i = new XmpIterator((XmpMeta)XmpMeta, null, null, new IteratorOptions() { IsJustLeafNodes = true });
+                    XmpIterator i = new XmpIterator((XmpMeta)XmpMeta, null, null, _iteratorOptions);
                     while (i.HasNext())
                     {
                         var prop = (IXmpPropertyInfo)i.Next();
@@ -104,7 +106,7 @@ namespace MetadataExtractor.Formats.Xmp
             XmpMeta = xmpMeta;
 
             int valueCount = 0;
-            XmpIterator i = new XmpIterator((XmpMeta)XmpMeta, null, null, new IteratorOptions() { IsJustLeafNodes = true });
+            XmpIterator i = new XmpIterator((XmpMeta)XmpMeta, null, null, _iteratorOptions);
 
             while (i.HasNext())
             {


### PR DESCRIPTION
- process only leafnodes for XMP data both in XmpDirectory and text file output
- use consistent new lines in TextFileOuputHandler

Before this change, .NET would go directly through XmpDirectory.XmpMeta for normal processing and display. Namespace nodes are also present in this collection and output lines with blank values. This isn't an error, but they're always like this and Java ignores them by setting an iterator option. With the change, text file output is consistent with Java and removes scores of discrepancies.

Note that XmpMeta is using an Iterator instance with a null IteratorOptions parameter internally for the Properties property, meaning there is no more of a performance hit for this than calling Properties.