### PR TITLE
Catch PNG chunk processing errors

### DIFF
--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -29,6 +29,11 @@ using System.Diagnostics;
 using System.Text;
 #endif
 using JetBrains.Annotations;
+#if NET35
+using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
+#else
+using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
+#endif
 
 namespace MetadataExtractor
 {
@@ -45,6 +50,7 @@ namespace MetadataExtractor
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 #endif
+        internal static readonly DirectoryList EmptyList = new Directory[0];
 
         /// <summary>Map of values hashed by type identifiers.</summary>
         [NotNull]

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -84,10 +84,26 @@ namespace MetadataExtractor.Formats.Png
         [NotNull]
         public static DirectoryList ReadMetadata([NotNull] Stream stream)
         {
-            return new PngChunkReader()
-                .Extract(new SequentialStreamReader(stream), _desiredChunkTypes)
-                .SelectMany(ProcessChunk)
-                .ToList();
+            List<Directory> directories = null;
+
+            var chunks = new PngChunkReader().Extract(new SequentialStreamReader(stream), _desiredChunkTypes);
+
+            foreach (var chunk in chunks)
+            {
+                if(directories == null)
+                    directories = new List<Directory>();
+
+                try
+                {
+                    directories.AddRange(ProcessChunk(chunk));
+                }
+                catch (Exception ex)
+                {
+                    directories.Add(new ErrorDirectory("Exception reading PNG chunk: " + ex.Message));
+                }
+            }
+
+            return directories ?? Directory.EmptyList;
         }
 
         /// <summary>


### PR DESCRIPTION
Good metadata is lost when PNG chunks encounter processing errors. Refactor so errors can be recorded while preserving this good metadata.