### PR TITLE
Add crude CR3 support

### DIFF
--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -25,7 +25,11 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using JetBrains.Annotations;
+using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.Exif.Makernotes;
+using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.IO;
+using MetadataExtractor.Util;
 #if NET35
 using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
 #else
@@ -91,6 +95,35 @@ namespace MetadataExtractor.Formats.QuickTime
                 }
             }
 
+            void UuidHandler(AtomCallbackArgs a)
+            {
+                switch (a.TypeString)
+                {
+                    case "CMT1":
+                    case "CMT2":
+                    {
+                        var handler = new QuickTimeTiffHandler<ExifIfd0Directory>(directories);
+                        var reader = new IndexedSeekingReader(a.Stream, (int)a.Reader.Position);
+                        TiffReader.ProcessTiff(reader, handler);
+                        break;
+                    }
+                    case "CMT3":
+                    {
+                        var handler = new QuickTimeTiffHandler<CanonMakernoteDirectory>(directories);
+                        var reader = new IndexedSeekingReader(a.Stream, (int)a.Reader.Position);
+                        TiffReader.ProcessTiff(reader, handler);
+                        break;
+                    }
+                    case "CMT4":
+                    {
+                        var handler = new QuickTimeTiffHandler<GpsDirectory>(directories);
+                        var reader = new IndexedSeekingReader(a.Stream, (int)a.Reader.Position);
+                        TiffReader.ProcessTiff(reader, handler);
+                        break;
+                    }
+                }
+            }
+
             void MoovHandler(AtomCallbackArgs a)
             {
                 switch (a.TypeString)
@@ -117,6 +150,16 @@ namespace MetadataExtractor.Formats.QuickTime
                         directory.Set(QuickTimeMovieHeaderDirectory.TagCurrentTime, a.Reader.GetUInt32());
                         directory.Set(QuickTimeMovieHeaderDirectory.TagNextTrackId, a.Reader.GetUInt32());
                         directories.Add(directory);
+                        break;
+                    }
+                    case "uuid":
+                    {
+                        var CR3 = new byte[] { 0x85, 0xc0, 0xb6, 0x87, 0x82, 0x0f, 0x11, 0xe0, 0x81, 0x11, 0xf4, 0xce, 0x46, 0x2b, 0x6a, 0x48 };
+                        var uuid = a.Reader.GetBytes(CR3.Length);
+                        if (CR3.RegionEquals(0, CR3.Length, uuid))
+                        {
+                            QuickTimeReader.ProcessAtoms(stream, UuidHandler, a.BytesLeft);
+                        }
                         break;
                     }
                     case "trak":

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -100,9 +100,15 @@ namespace MetadataExtractor.Formats.QuickTime
                 switch (a.TypeString)
                 {
                     case "CMT1":
-                    case "CMT2":
                     {
                         var handler = new QuickTimeTiffHandler<ExifIfd0Directory>(directories);
+                        var reader = new IndexedSeekingReader(a.Stream, (int)a.Reader.Position);
+                        TiffReader.ProcessTiff(reader, handler);
+                        break;
+                    }
+                    case "CMT2":
+                    {
+                        var handler = new QuickTimeTiffHandler<ExifSubIfdDirectory>(directories);
                         var reader = new IndexedSeekingReader(a.Stream, (int)a.Reader.Position);
                         TiffReader.ProcessTiff(reader, handler);
                         break;

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
@@ -26,7 +26,6 @@ using JetBrains.Annotations;
 using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.Tiff;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace MetadataExtractor.Formats.QuickTime
 {
@@ -45,8 +44,7 @@ namespace MetadataExtractor.Formats.QuickTime
             {
                 throw new TiffProcessingException($"Unexpected TIFF marker: 0x{marker:X}");
             }
-            var directory = Directories.OfType<T>().FirstOrDefault() ?? new T();
-            PushDirectory(directory);
+            PushDirectory(new T());
         }
     }
 }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
@@ -1,0 +1,52 @@
+﻿#region License
+//
+// Copyright 2002-2019 Drew Noakes
+// Ported from Java to C# by Yakov Danilov for Imazen LLC in 2014
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+// More information about this project is available at:
+//
+//    https://github.com/drewnoakes/metadata-extractor-dotnet
+//    https://drewnoakes.com/code/exif/
+//
+#endregion
+
+using JetBrains.Annotations;
+using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.Tiff;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MetadataExtractor.Formats.QuickTime
+{
+    public sealed class QuickTimeTiffHandler<T> : ExifTiffHandler
+        where T : Directory, new()
+    {
+        public QuickTimeTiffHandler([NotNull] List<Directory> directories)
+            : base(directories)
+        {
+        }
+
+        public override void SetTiffMarker(int marker)
+        {
+            const int standardTiffMarker = 0x002A;
+            if (marker != standardTiffMarker)
+            {
+                throw new TiffProcessingException($"Unexpected TIFF marker: 0x{marker:X}");
+            }
+            var directory = Directories.OfType<T>().FirstOrDefault() ?? new T();
+            PushDirectory(directory);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -61,10 +61,7 @@ namespace MetadataExtractor.Formats.Tiff
                 directory.Parent = CurrentDirectory;
             }
             CurrentDirectory = directory;
-            if (!Directories.Contains(CurrentDirectory))
-            {
-                Directories.Add(CurrentDirectory);
-            }
+            Directories.Add(CurrentDirectory);
         }
 
         public void Warn(string message)  => GetCurrentOrErrorDirectory().AddError(message);

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -61,7 +61,10 @@ namespace MetadataExtractor.Formats.Tiff
                 directory.Parent = CurrentDirectory;
             }
             CurrentDirectory = directory;
-            Directories.Add(CurrentDirectory);
+            if (!Directories.Contains(CurrentDirectory))
+            {
+                Directories.Add(CurrentDirectory);
+            }
         }
 
         public void Warn(string message)  => GetCurrentOrErrorDirectory().AddError(message);


### PR DESCRIPTION
This is my stab at a minimal CR3 support.

CR3 is based on ISO/IEC 14496-12, ~~which means it is detected as QuickTime~~. The moov container wraps 4 TIFF IFDs (and other data, which will be ignored).

**Edit:** Added CRX file type; see below.
**Edit 2:** Fixed CMT2 directory type.