### PR TITLE
Uniform QuickTime and RIFF checkers

### DIFF
--- a/MetadataExtractor/Util/FileTypeDetector.cs
+++ b/MetadataExtractor/Util/FileTypeDetector.cs
@@ -81,11 +81,9 @@ namespace MetadataExtractor.Util
         {
             if (!bytes.RegionEquals(4, 4, Encoding.UTF8.GetBytes("ftyp")))
                 return FileType.Unknown;
-            if (bytes.RegionEquals(8, 4, Encoding.UTF8.GetBytes("qt  ")))
-                return FileType.QuickTime;
             if (bytes.RegionEquals(8, 4, Encoding.UTF8.GetBytes("crx ")))
                 return FileType.Crx;
-            return FileType.Unknown;
+            return FileType.QuickTime;
         }
 
         private static readonly IEnumerable<Func<byte[], FileType>> _fixedCheckers = new Func<byte[], FileType>[]

--- a/MetadataExtractor/Util/FileTypeDetector.cs
+++ b/MetadataExtractor/Util/FileTypeDetector.cs
@@ -77,18 +77,20 @@ namespace MetadataExtractor.Util
             { FileType.Rw2, Encoding.UTF8.GetBytes("II"), new byte[] { 0x55, 0x00 } },
         };
 
+        private static FileType CheckQuickTime(byte[] bytes)
+        {
+            if (!bytes.RegionEquals(4, 4, Encoding.UTF8.GetBytes("ftyp")))
+                return FileType.Unknown;
+            if (bytes.RegionEquals(8, 4, Encoding.UTF8.GetBytes("qt  ")))
+                return FileType.QuickTime;
+            if (bytes.RegionEquals(8, 4, Encoding.UTF8.GetBytes("crx ")))
+                return FileType.Crx;
+            return FileType.Unknown;
+        }
+
         private static readonly IEnumerable<Func<byte[], FileType>> _fixedCheckers = new Func<byte[], FileType>[]
         {
-            bytes =>
-            {
-                if (!bytes.RegionEquals(4, 4, Encoding.UTF8.GetBytes("ftyp")))
-                    return FileType.Unknown;
-                if (bytes.RegionEquals(8, 4, Encoding.UTF8.GetBytes("qt  ")))
-                    return FileType.QuickTime;
-                if (bytes.RegionEquals(8, 4, Encoding.UTF8.GetBytes("crx ")))
-                    return FileType.Crx;
-                return FileType.Unknown;
-            }
+            CheckQuickTime
         };
 
         /// <summary>Examines the a file's first bytes and estimates the file's type.</summary>


### PR DESCRIPTION
This also restores backwards compatibility (FileType.QuickTime for unknown major brands)