### PR TITLE
Register encodings under netstandard2.0 as well

### DIFF
--- a/MetadataExtractor.Tests/Formats/Iptc/IptcReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Iptc/IptcReaderTest.cs
@@ -23,7 +23,6 @@
 #endregion
 
 using System.Linq;
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.Iptc;
 using MetadataExtractor.IO;
 using Xunit;

--- a/MetadataExtractor.Tests/Formats/Photoshop/PsdReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Photoshop/PsdReaderTest.cs
@@ -23,7 +23,6 @@
 #endregion
 
 using System.Linq;
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.Photoshop;
 using MetadataExtractor.IO;
 using Xunit;

--- a/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Png/PngMetadataReaderTest.cs
@@ -25,7 +25,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.Png;
 using Xunit;
 

--- a/MetadataExtractor.Tools.FileProcessor/Program.cs
+++ b/MetadataExtractor.Tools.FileProcessor/Program.cs
@@ -28,7 +28,6 @@ using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Text;
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Xmp;

--- a/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
+++ b/MetadataExtractor.Tools.FileProcessor/TextFileOutputHandler.cs
@@ -27,7 +27,6 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text;
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.Util;

--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -171,7 +171,7 @@ namespace MetadataExtractor
         /// <summary>Gets whether the specified tag is known by the directory and has a name.</summary>
         /// <param name="tagType">the tag type identifier</param>
         /// <returns>whether this directory has a name for the specified tag</returns>
-        public bool HasTagName(int tagType) => TryGetTagName(tagType, out string? _);
+        public bool HasTagName(int tagType) => TryGetTagName(tagType, out _);
 
         /// <summary>
         /// Provides a description of a tag's value using the descriptor set by <see cref="SetDescriptor"/>.

--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -26,7 +26,7 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || NETSTANDARD2_0
 using System.Text;
 #endif
 #if NET35
@@ -44,7 +44,7 @@ namespace MetadataExtractor
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public abstract class Directory
     {
-#if NETSTANDARD1_3
+#if NETSTANDARD1_3 || NETSTANDARD2_0
         static Directory()
         {
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -34,7 +34,7 @@
     <PackageReference Include="XmpCore.StrongName" Version="6.1.10" Condition=" '$(Signed)' == 'True' " />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' ">
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
 


### PR DESCRIPTION
Without this, callers using `netstandard2.0` builds see execptions for certain files that need `windows-1252` encoding.