### PR TITLE
QuickTime Compatible Brands value correction

### DIFF
--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -184,7 +184,7 @@ namespace MetadataExtractor.Formats.QuickTime
                         var compatibleBrands = new List<string>();
                         while (a.BytesLeft >= 4)
                             compatibleBrands.Add(a.Reader.Get4ccString());
-                        directory.Set(QuickTimeFileTypeDirectory.TagCompatibleBrands, compatibleBrands);
+                        directory.Set(QuickTimeFileTypeDirectory.TagCompatibleBrands, String.Join(", ", compatibleBrands));
                         directories.Add(directory);
                         break;
                     }


### PR DESCRIPTION
The Description of the Tag QuickTime Compatible Brands is not a string, but a list. This results in  a description of "System.Collections.Generic.List`1[System.String]}"
In order to get the values of the compatible brands, you could use a string join.

[My PR did not compile, sorry about that. I should have opened an issue instead of a PR without testing]

