### PR TITLE
Use default compiler

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -21,9 +21,4 @@
     <PackageReference Include="JetBrains.Annotations" Version="2019.1.3" PrivateAssets="All" />
   </ItemGroup>
 
-  <!-- Opt in to a newer compiler -->
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Net.Compilers.Toolset" Version="3.3.0-beta2-final" />
-  </ItemGroup>
-
 </Project>


### PR DESCRIPTION
Now that VS2019 16.3 has gone GA, we don't need to opt in to a specific compiler version.

This PR will also validate that CI has a sufficient default compiler.