### PR TITLE
Add Support for Quicktime metadata incl GPS and CreationDate

### DIFF
--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataHeaderDirectory.cs
@@ -41,7 +41,7 @@ namespace MetadataExtractor.Formats.QuickTime
             { TagAuthor,            "Author"},
             { TagComment,           "Comment"},
             { TagCopyright,         "Copyright"},
-            { TagCreationDate,      "Creationdate"},
+            { TagCreationDate,      "Creation Date"},
             { TagDescription,       "Description"},
             { TagDirector,          "Director"},
             { TagTitle,             "Title"},

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataHeaderDirectory.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Linq;
+
+namespace MetadataExtractor.Formats.QuickTime
+{
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public sealed class QuickTimeMetadataHeaderDirectory : Directory
+    {
+        public const int TagAlbum = 1;
+        public const int TagArtist = 2;
+        public const int TagArtwork = 3;
+        public const int TagAuthor = 4;
+        public const int TagComment = 5;
+        public const int TagCopyright = 6;
+        public const int TagCreationDate = 7;
+        public const int TagDescription = 8;
+        public const int TagDirector = 9;
+        public const int TagTitle = 10;
+        public const int TagGenre = 11;
+        public const int TagInformation = 12;
+        public const int TagKeywords = 13;
+        public const int TagGpsLocation = 14;
+        public const int TagProducer = 15;
+        public const int TagPublisher = 16;
+        public const int TagSoftware = 17;
+        public const int TagYear = 18;
+        public const int TagCollection = 19;
+        public const int TagRating = 20;
+
+
+        public override string Name { get; } = "QuickTime Metadata Header";
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>
+        {
+            { TagAlbum,             "Album"},
+            { TagArtist,            "Artist"},
+            { TagArtwork,           "Artwork"},
+            { TagAuthor,            "Author"},
+            { TagComment,           "Comment"},
+            { TagCopyright,         "Copyright"},
+            { TagCreationDate,      "Creationdate"},
+            { TagDescription,       "Description"},
+            { TagDirector,          "Director"},
+            { TagTitle,             "Title"},
+            { TagGenre,             "Genre"},
+            { TagInformation,       "Information"},
+            { TagKeywords,          "Keywords"},
+            { TagGpsLocation,       "GPS Location"},
+            { TagProducer,          "Producer"},
+            { TagPublisher,         "Publisher"},
+            { TagSoftware,          "Software"},
+            { TagYear,              "Year"},
+            { TagCollection,        "Collection"},
+            { TagRating,            "Rating"}
+        };
+
+        private static readonly Dictionary<string, int> _nameTagMap = new Dictionary<string, int>
+        {
+            { "com.apple.quicktime.album",              TagAlbum},
+            { "com.apple.quicktime.artist",             TagArtist},
+            { "com.apple.quicktime.artwork",            TagArtwork},
+            { "com.apple.quicktime.author",             TagAuthor},
+            { "com.apple.quicktime.comment",            TagComment},
+            { "com.apple.quicktime.copyright",          TagCopyright},
+            { "com.apple.quicktime.creationdate",       TagCreationDate},
+            { "com.apple.quicktime.description",        TagDescription},
+            { "com.apple.quicktime.director",           TagDirector},
+            { "com.apple.quicktime.title",              TagTitle},
+            { "com.apple.quicktime.genre",              TagGenre},
+            { "com.apple.quicktime.information",        TagInformation},
+            { "com.apple.quicktime.keywords",           TagKeywords},
+            { "com.apple.quicktime.location.ISO6709",   TagGpsLocation},
+            { "com.apple.quicktime.producer",           TagProducer},
+            { "com.apple.quicktime.publisher",          TagPublisher},
+            { "com.apple.quicktime.software",           TagSoftware},
+            { "com.apple.quicktime.year",               TagYear},
+            { "com.apple.quicktime.collection.user",    TagCollection},
+            { "com.apple.quicktime.rating.user",        TagRating}
+        };
+
+        public QuickTimeMetadataHeaderDirectory()
+        {
+            SetDescriptor(new TagDescriptor<QuickTimeMetadataHeaderDirectory>(this));
+        }
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+
+        public bool TryGetTag(string name, out int tagType)
+        {
+            return _nameTagMap.TryGetValue(name, out tagType);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Text;
 using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.Exif.Makernotes;
 using MetadataExtractor.Formats.Tiff;
@@ -25,6 +26,7 @@ namespace MetadataExtractor.Formats.QuickTime
         public static DirectoryList ReadMetadata(Stream stream)
         {
             var directories = new List<Directory>();
+            var metaDataKeys = new List<string>();
 
             QuickTimeReader.ProcessAtoms(stream, Handler);
 
@@ -113,6 +115,59 @@ namespace MetadataExtractor.Formats.QuickTime
                 }
             }
 
+            void MetaDataHandler(AtomCallbackArgs a)
+            {
+                // see https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/Metadata/Metadata.html
+                switch (a.TypeString)
+                {
+                    case "keys":
+                    {
+                        var version = a.Reader.GetByte();
+                        var flags = a.Reader.GetBytes(3);
+                        var entryCount = a.Reader.GetUInt32();
+                        for (int i = 1; i <= entryCount; i++)
+                        {
+                            var keySize = a.Reader.GetUInt32();
+                            var keyValueSize = (int)keySize - 8;
+                            var keyNamespace = a.Reader.GetUInt32();
+                            var keyValue = a.Reader.GetBytes(keyValueSize);
+                            metaDataKeys.Add(Encoding.UTF8.GetString(keyValue));
+                        }
+                        break;
+                    }
+                    case "ilst":
+                    {
+                        var directory = new QuickTimeMetadataHeaderDirectory();
+                        // Iterate over the list of Metadata Item Atoms.
+                        for (int i = 0; i < metaDataKeys.Count; i++)
+                        {
+                            long atomSize = a.Reader.GetUInt32();
+                            var atomType = a.Reader.GetUInt32();
+
+                            // Indexes into the metadata item keys atom are 1-based (1…entry_count).
+                            // atom type for each metadata item atom should be set equal to the index of the key
+                            var key = metaDataKeys[(int)atomType - 1];
+
+                            // Value Atom
+                            var typeIndicator = a.Reader.GetBytes(4);
+                            var localeIndicator = a.Reader.GetBytes(4);
+
+                            // Data Atom
+                            var dataTypeIndicator = a.Reader.GetBytes(4);
+                            var dataLocaleIndicator = a.Reader.GetBytes(4);
+                            var data = a.Reader.GetBytes((int)atomSize - 24);
+                            var dataStr = Encoding.UTF8.GetString(data);
+                            if (directory.TryGetTag(key, out int tag))
+                            {
+                                directory.Set(tag, dataStr);
+                            }
+                        }
+                        directories.Add(directory);
+                        break;
+                }
+            }
+            }
+
             void MoovHandler(AtomCallbackArgs a)
             {
                 switch (a.TypeString)
@@ -156,6 +211,12 @@ namespace MetadataExtractor.Formats.QuickTime
                         QuickTimeReader.ProcessAtoms(stream, TrakHandler, a.BytesLeft);
                         break;
                     }
+                    case "meta":
+                    {
+                        QuickTimeReader.ProcessAtoms(stream, MetaDataHandler, a.BytesLeft);
+                        break;
+                    }
+
 //                    case "clip":
 //                    {
 //                        QuickTimeReader.ProcessAtoms(stream, clipHandler, a.BytesLeft);

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -142,10 +142,22 @@ namespace MetadataExtractor.Formats.QuickTime
                         for (int i = 0; i < metaDataKeys.Count; i++)
                         {
                             long atomSize = a.Reader.GetUInt32();
+                            if (atomSize < 24)
+                            {
+                                directory.AddError("Invalid ilist AtomSize");
+                                directories.Add(directory);
+                                break;
+                            }
                             var atomType = a.Reader.GetUInt32();
 
                             // Indexes into the metadata item keys atom are 1-based (1…entry_count).
-                            // atom type for each metadata item atom should be set equal to the index of the key
+                            // atom type for each metadata item atom is the index of the key
+                            if (atomType < 1 || atomType > metaDataKeys.Count)
+                            {
+                                directory.AddError("Invalid ilist AtomType");
+                                directories.Add(directory);
+                                break;
+                            }
                             var key = metaDataKeys[(int)atomType - 1];
 
                             // Value Atom
@@ -164,8 +176,8 @@ namespace MetadataExtractor.Formats.QuickTime
                         }
                         directories.Add(directory);
                         break;
+                    }
                 }
-            }
             }
 
             void MoovHandler(AtomCallbackArgs a)

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -315,16 +315,17 @@ namespace MetadataExtractor.Formats.QuickTime
                     directory.Set(tagType, new StringValue(data, Encoding.UTF8));
                     break;
                 }
-            case 13: // JPEG
-            case 14: // PNG
-            case 27: // BMP
-                {
-                    directory.Set(tagType, data);
-                    break;
-                }
-            case 23: // BE Float32 (used for User Rating)
+                case 23: // BE Float32 (used for User Rating)
                 {
                     directory.Set(tagType, BitConverter.ToSingle(BitConverter.IsLittleEndian ? data.Reverse().ToArray() : data, 0));
+                    break;
+                }
+                case 13: // JPEG
+                case 14: // PNG
+                case 27: // BMP
+                default:
+                {
+                    directory.Set(tagType, data);
                     break;
                 }
             }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -177,7 +177,7 @@ namespace MetadataExtractor.Formats.QuickTime
                             var dataLocaleIndicator = a.Reader.GetUInt32();
                             if (dataLocaleIndicator != 0)
                             {
-                                directory.AddError("Unsupported Metadata Locale Indicator: " + dataLocaleIndicator);
+                                directory.AddError($"Unsupported Metadata Locale Indicator: {dataLocaleIndicator} for key: {key}");
                                 a.Reader.Skip(atomSize - 24);
                                 continue;
                             }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -145,7 +145,6 @@ namespace MetadataExtractor.Formats.QuickTime
                             if (atomSize < 24)
                             {
                                 directory.AddError("Invalid ilist AtomSize");
-                                directories.Add(directory);
                                 break;
                             }
                             var atomType = a.Reader.GetUInt32();
@@ -155,7 +154,6 @@ namespace MetadataExtractor.Formats.QuickTime
                             if (atomType < 1 || atomType > metaDataKeys.Count)
                             {
                                 directory.AddError("Invalid ilist AtomType");
-                                directories.Add(directory);
                                 break;
                             }
                             var key = metaDataKeys[(int)atomType - 1];


### PR DESCRIPTION
Does not support Optional Item_info atom or Optional name atom inside the the Value Atom as described in the spec as none of the sample data I had access to had these attributes.