### PR TITLE
Prevent negative length in "Ducky" data

### DIFF
--- a/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
@@ -67,7 +67,13 @@ namespace MetadataExtractor.Formats.Photoshop
                         case DuckyDirectory.TagCopyright:
                         {
                             reader.Skip(4);
-                            directory.Set(tag, reader.GetString(length - 4, Encoding.BigEndianUnicode));
+                            length -= 4;
+                            if (length < 0)
+                            {
+                                directory.AddError("Unexpected length for a text tag");
+                                return directory;
+                            }
+                            directory.Set(tag, reader.GetString(length, Encoding.BigEndianUnicode));
                             break;
                         }
                         default:


### PR DESCRIPTION
Fixes the problem with [`jpg/NegativeArraySizeException.DuckyReader.extract.mp3`](https://github.com/drewnoakes/metadata-extractor-images/commit/4244161122711b3cfdc0a317b2c699cfd94ba867#diff-ed6cbf568225fbeb5fb842e85094e967) from #196