### PR TITLE
Remove redundant annotation

### DIFF
--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
@@ -1,6 +1,5 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using JetBrains.Annotations;
 using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.Tiff;
 using System.Collections.Generic;
@@ -10,7 +9,7 @@ namespace MetadataExtractor.Formats.QuickTime
     public sealed class QuickTimeTiffHandler<T> : ExifTiffHandler
         where T : Directory, new()
     {
-        public QuickTimeTiffHandler([NotNull] List<Directory> directories)
+        public QuickTimeTiffHandler(List<Directory> directories)
             : base(directories)
         {
         }


### PR DESCRIPTION
We use C# 8 nullable reference types now.