### PR TITLE
Parse Apple HEIC files, including EXIF and other metadate.

### DIFF
--- a/MetadataExtractor.Tests/Formats/Heif/Iso14496Parser/BitsReaderTest.cs
+++ b/MetadataExtractor.Tests/Formats/Heif/Iso14496Parser/BitsReaderTest.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using MetadataExtractor.Formats.Heif.Iso14496Parser;
+using MetadataExtractor.IO;
+using Xunit;
+
+namespace MetadataExtractor.Tests.Formats.Heif.Iso14496Parser
+{
+    public class BitsReaderTest
+    {
+        public BitsReader CreateReader(params byte[] sourceData)
+        {
+            var sr = new SequentialByteArrayReader(sourceData);
+            return new BitsReader(sr);
+        }
+        [Theory]
+        [InlineData(1,1)]
+        [InlineData(2,3)]
+        [InlineData(3,7)]
+        [InlineData(4,15)]
+        [InlineData(5,31)]
+        [InlineData(6,63)]
+        [InlineData(7,127)]
+        [InlineData(8,255)]
+        [InlineData(9,511)]
+        public void GetOneBit(int bits, UInt32 result)
+        {
+            var reader = CreateReader(0xFF, 0xFF);
+            Assert.Equal(result, reader.GetUInt32(bits));
+
+            var reader2 = CreateReader(0, 0);
+            Assert.Equal(0u, reader2.GetUInt32(bits));
+        }
+
+        [Fact]
+        public void ReadNibbles()
+        {
+            var reader = CreateReader(0x12, 0x34);
+            for (int i = 0; i < 4; i++)
+            {
+                Assert.Equal(i+1, reader.GetByte(4));
+
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace MetadataExtractor.Formats.Heif
 {
@@ -14,11 +15,44 @@ namespace MetadataExtractor.Formats.Heif
 
         public const int ImageWidth = 1;
         public const int ImageHeight = 2;
-
+        public const int Rotation = 3;
+        public const int PixelDepths = 4;
+        public const int ConfigurationVersion = 5;
+        public const int GeneralProfileSpace = 6;
+        public const int GeneralTierTag = 7;
+        public const int GeneralProfileIdc = 8;
+        public const int GeneralProfileCompatibilityTag = 9;
+        public const int GeneralLevelIdc = 10;
+        public const int MinSpacialSegmentationIdc = 11;
+        public const int ParallelismType = 12;
+        public const int ChromaFormat = 13;
+        public const int BitDepthLuma = 14;
+        public const int BitDepthChroma = 15;
+        public const int AverageFrameRate = 16;
+        public const int ConstantFrameRate = 17;
+        public const int NumTemporalLayers=18;
+        public const int LengthSize = 19;
         private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>()
         {
             { ImageHeight, "Image Height" },
-            { ImageWidth, "Image Width" }
+            { ImageWidth, "Image Width" },
+            { Rotation, "Default Rotation"},
+            { PixelDepths, "Pixel Depth in Bits"},
+            { ConfigurationVersion, "HEVC Configuration Version"},
+            { GeneralProfileSpace, "General Profile Space"},
+            { GeneralTierTag, "General Tiler Tag"},
+            { GeneralProfileIdc, "General Profile"},
+            { GeneralProfileCompatibilityTag, "General Profile Compatibility"},
+            { GeneralLevelIdc, "General Level"},
+            { MinSpacialSegmentationIdc, "Minimum Spacial Segmentation"},
+            { ParallelismType, "Parallelism Type"},
+            { ChromaFormat, "Chroma Format"},
+            { BitDepthLuma, "Luma Bit Depth"},
+            { BitDepthChroma, "Chroma Bit Depth"},
+            { AverageFrameRate, "Average Frame Rate"},
+            { ConstantFrameRate, "Constant Frame Rate"},
+            { NumTemporalLayers, "Number of Temporal Layers"},
+            { LengthSize, "Length or Size"}
         };
 
 
@@ -37,6 +71,12 @@ namespace MetadataExtractor.Formats.Heif
             this.dir = dir;
         }
 
-        public string? GetDescription(int tagType) => dir.GetString(tagType);
+        public string? GetDescription(int tagType) => tagType switch {
+            HeicImagePropertiesDirectory.Rotation => dir.GetString(tagType) + " degrees",
+            HeicImagePropertiesDirectory.PixelDepths =>
+                string.Join(" ", ((byte[])dir.GetObject(HeicImagePropertiesDirectory.PixelDepths))
+                    .Select(i=>i.ToString()).ToArray()),
+            _=>dir.GetString(tagType)
+        };
     }
 }

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
@@ -1,0 +1,42 @@
+﻿using System.Collections.Generic;
+
+namespace MetadataExtractor.Formats.Heif
+{
+    public class HeicImagePropertiesDirectory: Directory
+    {
+        public override string Name { get; }
+
+        public HeicImagePropertiesDirectory(string name)
+        {
+            Name = name;
+            SetDescriptor(new HeicImagePropertyDescriptor(this));
+        }
+
+        public const int ImageWidth = 1;
+        public const int ImageHeight = 2;
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>()
+        {
+            { ImageHeight, "Image Height" },
+            { ImageWidth, "Image Width" }
+        };
+
+
+        protected override bool TryGetTagName(int tagType, out string? tagName) =>
+            _tagNameMap.TryGetValue(tagType, out tagName);
+
+        string? GetDescription(int tagType) => null;
+    }
+
+    public class HeicImagePropertyDescriptor: ITagDescriptor
+    {
+        private readonly HeicImagePropertiesDirectory dir;
+
+        public HeicImagePropertyDescriptor(HeicImagePropertiesDirectory dir)
+        {
+            this.dir = dir;
+        }
+
+        public string? GetDescription(int tagType) => dir.GetString(tagType);
+    }
+}

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using MetadataExtractor.Formats.Heif.Iso14496Parser;
 
 namespace MetadataExtractor.Formats.Heif
 {
@@ -32,6 +33,11 @@ namespace MetadataExtractor.Formats.Heif
         public const int ConstantFrameRate = 17;
         public const int NumTemporalLayers=18;
         public const int LengthSize = 19;
+        public const int ColorPrimaries = 20;
+        public const int ColorTransferCharacteristics = 21;
+        public const int ColorMatrixCharacteristicis = 22;
+        public const int FullRangeColor = 23;
+        public const int ColorFormat = 24;
         private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>()
         {
             { ImageHeight, "Image Height" },
@@ -52,14 +58,17 @@ namespace MetadataExtractor.Formats.Heif
             { AverageFrameRate, "Average Frame Rate"},
             { ConstantFrameRate, "Constant Frame Rate"},
             { NumTemporalLayers, "Number of Temporal Layers"},
-            { LengthSize, "Length or Size"}
+            { LengthSize, "Length or Size"},
+            { ColorPrimaries, "Primary Color Definitions"},
+            { ColorTransferCharacteristics, "Optical Color Transfer Characteristic"},
+            { ColorMatrixCharacteristicis, "Color Deviation Matrix Characteristics"},
+            { FullRangeColor, "Full-Range Color"},
+            { ColorFormat, "Color Data Format"}
         };
 
 
         protected override bool TryGetTagName(int tagType, out string? tagName) =>
             _tagNameMap.TryGetValue(tagType, out tagName);
-
-        string? GetDescription(int tagType) => null;
     }
 
     public class HeicImagePropertyDescriptor: ITagDescriptor
@@ -76,7 +85,57 @@ namespace MetadataExtractor.Formats.Heif
             HeicImagePropertiesDirectory.PixelDepths =>
                 string.Join(" ", ((byte[])dir.GetObject(HeicImagePropertiesDirectory.PixelDepths))
                     .Select(i=>i.ToString()).ToArray()),
+            HeicImagePropertiesDirectory.ColorFormat =>
+               TypeStringConverter.ToTypeString(dir.GetUInt32(HeicImagePropertiesDirectory.ColorFormat)),
+            HeicImagePropertiesDirectory.ColorPrimaries =>
+               ColorPrimary(dir.GetUInt16(HeicImagePropertiesDirectory.ColorPrimaries)),
+            HeicImagePropertiesDirectory.ColorTransferCharacteristics =>
+               ColorTransfer(dir.GetUInt16(HeicImagePropertiesDirectory.ColorTransferCharacteristics)),
+            HeicImagePropertiesDirectory.ColorMatrixCharacteristicis =>
+               ColorMatricCoeffs(dir.GetUInt16(HeicImagePropertiesDirectory.ColorMatrixCharacteristicis)),
             _=>dir.GetString(tagType)
         };
+
+        private string? ColorMatricCoeffs(ushort value) =>
+            value switch
+            {
+                0 => "RGB, GBR",
+                1 => "vKr = 0.2126 vKb = 0.0722",
+                2 => "Unspecified",
+                4 => "vKr = 0.299, vKb - 0.11",
+                5 => "vKr = 0.299, vKb - 0.114",
+                6 => "vKr = 0.299, vKb - 0.114",
+                7 => "vKr = 0.212, vKb - 0.087",
+                8 => "YCgCo",
+                _ => "Reserved"
+            };
+
+        private string? ColorTransfer(ushort value) =>
+            value switch
+            {
+                1 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc otherwise.",
+                2 => "Unspecified",
+                4 => "Assumed display gamma 2.2",
+                5 => "Assumed display gamma 2.9",
+                6 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc otherwise.",
+                7 => "vV - 1.1115 * vLc^0.45 - 0.1115 for 1 >= vLc >= 0.0.0288 or vV = 4.0 * vLc otherwise.",
+                8 => "vV = vLC",
+                11 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc for 0.018 > vLC > -0.018 or vV - 1.009 * (-vLc)^0.45 - 0.099 otherwise",
+                12 => "vV - 1.009 * vLc^0.45 - 0.099 for 1.33 >= vLc >= 0.018 or vV = 4.500 * vLc for 0.018 > vLC > -0.045 or vV - 1.009 * (-4vLc)^0.45 - 0.099 + 4 otherwise",
+                13 => "vV - 1.055 * vLc^(1/2.4) - 0.055 for 1 >= vLc >= 0.031308 or vV = 12.92 * vLc otherwise.",
+                _ => "Reserved"
+            };
+
+        private string? ColorPrimary(ushort value) =>
+            value switch
+            {
+                1=> "G(0.3, 0.6) B(0.15, 0.06) R(0.64, 0.33) W(.3127, .329)",
+                2=> "Unspecified",
+                4=> "G(0.21, 0.72) B(0.14, 0.08), R(0.67, 0.33) W(0.31, 0.316)",
+                5=> "G(0.29, 0.70) B(0.15, 0.06), R(0.64, 0.33) W(0.3127, 0.3290)",
+                6=> "G(0.31, 0.595) B(0.155, 0.07), R(0.63, 0.34) W(0.3127, 0.3290)",
+                7=> "G(0.31, 0.595) B(0.155, 0.07), R(0.63, 0.34) W (0.3127, 0.3290)",
+                _=> "Reserved"
+            };
     }
 }

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
@@ -1,6 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Linq;
-using MetadataExtractor.Formats.Heif.Iso14496Parser;
 
 namespace MetadataExtractor.Formats.Heif
 {
@@ -69,73 +67,5 @@ namespace MetadataExtractor.Formats.Heif
 
         protected override bool TryGetTagName(int tagType, out string? tagName) =>
             _tagNameMap.TryGetValue(tagType, out tagName);
-    }
-
-    public class HeicImagePropertyDescriptor: ITagDescriptor
-    {
-        private readonly HeicImagePropertiesDirectory dir;
-
-        public HeicImagePropertyDescriptor(HeicImagePropertiesDirectory dir)
-        {
-            this.dir = dir;
-        }
-
-        public string? GetDescription(int tagType) => tagType switch {
-            HeicImagePropertiesDirectory.Rotation => dir.GetString(tagType) + " degrees",
-            HeicImagePropertiesDirectory.PixelDepths =>
-                string.Join(" ", ((byte[])dir.GetObject(HeicImagePropertiesDirectory.PixelDepths))
-                    .Select(i=>i.ToString()).ToArray()),
-            HeicImagePropertiesDirectory.ColorFormat =>
-               TypeStringConverter.ToTypeString(dir.GetUInt32(HeicImagePropertiesDirectory.ColorFormat)),
-            HeicImagePropertiesDirectory.ColorPrimaries =>
-               ColorPrimary(dir.GetUInt16(HeicImagePropertiesDirectory.ColorPrimaries)),
-            HeicImagePropertiesDirectory.ColorTransferCharacteristics =>
-               ColorTransfer(dir.GetUInt16(HeicImagePropertiesDirectory.ColorTransferCharacteristics)),
-            HeicImagePropertiesDirectory.ColorMatrixCharacteristicis =>
-               ColorMatricCoeffs(dir.GetUInt16(HeicImagePropertiesDirectory.ColorMatrixCharacteristicis)),
-            _=>dir.GetString(tagType)
-        };
-
-        private string? ColorMatricCoeffs(ushort value) =>
-            value switch
-            {
-                0 => "RGB, GBR",
-                1 => "vKr = 0.2126 vKb = 0.0722",
-                2 => "Unspecified",
-                4 => "vKr = 0.299, vKb - 0.11",
-                5 => "vKr = 0.299, vKb - 0.114",
-                6 => "vKr = 0.299, vKb - 0.114",
-                7 => "vKr = 0.212, vKb - 0.087",
-                8 => "YCgCo",
-                _ => "Reserved"
-            };
-
-        private string? ColorTransfer(ushort value) =>
-            value switch
-            {
-                1 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc otherwise.",
-                2 => "Unspecified",
-                4 => "Assumed display gamma 2.2",
-                5 => "Assumed display gamma 2.9",
-                6 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc otherwise.",
-                7 => "vV - 1.1115 * vLc^0.45 - 0.1115 for 1 >= vLc >= 0.0.0288 or vV = 4.0 * vLc otherwise.",
-                8 => "vV = vLC",
-                11 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc for 0.018 > vLC > -0.018 or vV - 1.009 * (-vLc)^0.45 - 0.099 otherwise",
-                12 => "vV - 1.009 * vLc^0.45 - 0.099 for 1.33 >= vLc >= 0.018 or vV = 4.500 * vLc for 0.018 > vLC > -0.045 or vV - 1.009 * (-4vLc)^0.45 - 0.099 + 4 otherwise",
-                13 => "vV - 1.055 * vLc^(1/2.4) - 0.055 for 1 >= vLc >= 0.031308 or vV = 12.92 * vLc otherwise.",
-                _ => "Reserved"
-            };
-
-        private string? ColorPrimary(ushort value) =>
-            value switch
-            {
-                1=> "G(0.3, 0.6) B(0.15, 0.06) R(0.64, 0.33) W(.3127, .329)",
-                2=> "Unspecified",
-                4=> "G(0.21, 0.72) B(0.14, 0.08), R(0.67, 0.33) W(0.31, 0.316)",
-                5=> "G(0.29, 0.70) B(0.15, 0.06), R(0.64, 0.33) W(0.3127, 0.3290)",
-                6=> "G(0.31, 0.595) B(0.155, 0.07), R(0.63, 0.34) W(0.3127, 0.3290)",
-                7=> "G(0.31, 0.595) B(0.155, 0.07), R(0.63, 0.34) W (0.3127, 0.3290)",
-                _=> "Reserved"
-            };
     }
 }

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertyDescriptor.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertyDescriptor.cs
@@ -1,0 +1,73 @@
+﻿using System.Linq;
+using MetadataExtractor.Formats.Heif.Iso14496Parser;
+
+namespace MetadataExtractor.Formats.Heif
+{
+    public class HeicImagePropertyDescriptor: ITagDescriptor
+    {
+        private readonly HeicImagePropertiesDirectory dir;
+
+        public HeicImagePropertyDescriptor(HeicImagePropertiesDirectory dir)
+        {
+            this.dir = dir;
+        }
+
+        public string? GetDescription(int tagType) => tagType switch {
+            HeicImagePropertiesDirectory.Rotation => dir.GetString(tagType) + " degrees",
+            HeicImagePropertiesDirectory.PixelDepths =>
+            string.Join(" ", ((byte[])dir.GetObject(HeicImagePropertiesDirectory.PixelDepths))
+                .Select(i=>i.ToString()).ToArray()),
+            HeicImagePropertiesDirectory.ColorFormat =>
+            TypeStringConverter.ToTypeString(dir.GetUInt32(HeicImagePropertiesDirectory.ColorFormat)),
+            HeicImagePropertiesDirectory.ColorPrimaries =>
+            ColorPrimary(dir.GetUInt16(HeicImagePropertiesDirectory.ColorPrimaries)),
+            HeicImagePropertiesDirectory.ColorTransferCharacteristics =>
+            ColorTransfer(dir.GetUInt16(HeicImagePropertiesDirectory.ColorTransferCharacteristics)),
+            HeicImagePropertiesDirectory.ColorMatrixCharacteristicis =>
+            ColorMatricCoeffs(dir.GetUInt16(HeicImagePropertiesDirectory.ColorMatrixCharacteristicis)),
+            _=>dir.GetString(tagType)
+        };
+
+        private string? ColorMatricCoeffs(ushort value) =>
+            value switch
+            {
+                0 => "RGB, GBR",
+                1 => "vKr = 0.2126 vKb = 0.0722",
+                2 => "Unspecified",
+                4 => "vKr = 0.299, vKb - 0.11",
+                5 => "vKr = 0.299, vKb - 0.114",
+                6 => "vKr = 0.299, vKb - 0.114",
+                7 => "vKr = 0.212, vKb - 0.087",
+                8 => "YCgCo",
+                _ => "Reserved"
+            };
+
+        private string? ColorTransfer(ushort value) =>
+            value switch
+            {
+                1 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc otherwise.",
+                2 => "Unspecified",
+                4 => "Assumed display gamma 2.2",
+                5 => "Assumed display gamma 2.9",
+                6 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc otherwise.",
+                7 => "vV - 1.1115 * vLc^0.45 - 0.1115 for 1 >= vLc >= 0.0.0288 or vV = 4.0 * vLc otherwise.",
+                8 => "vV = vLC",
+                11 => "vV - 1.009 * vLc^0.45 - 0.099 for 1 >= vLc >= 0.018 or vV = 4.500 * vLc for 0.018 > vLC > -0.018 or vV - 1.009 * (-vLc)^0.45 - 0.099 otherwise",
+                12 => "vV - 1.009 * vLc^0.45 - 0.099 for 1.33 >= vLc >= 0.018 or vV = 4.500 * vLc for 0.018 > vLC > -0.045 or vV - 1.009 * (-4vLc)^0.45 - 0.099 + 4 otherwise",
+                13 => "vV - 1.055 * vLc^(1/2.4) - 0.055 for 1 >= vLc >= 0.031308 or vV = 12.92 * vLc otherwise.",
+                _ => "Reserved"
+            };
+
+        private string? ColorPrimary(ushort value) =>
+            value switch
+            {
+                1=> "G(0.3, 0.6) B(0.15, 0.06) R(0.64, 0.33) W(.3127, .329)",
+                2=> "Unspecified",
+                4=> "G(0.21, 0.72) B(0.14, 0.08), R(0.67, 0.33) W(0.31, 0.316)",
+                5=> "G(0.29, 0.70) B(0.15, 0.06), R(0.64, 0.33) W(0.3127, 0.3290)",
+                6=> "G(0.31, 0.595) B(0.155, 0.07), R(0.63, 0.34) W(0.3127, 0.3290)",
+                7=> "G(0.31, 0.595) B(0.155, 0.07), R(0.63, 0.34) W (0.3127, 0.3290)",
+                _=> "Reserved"
+            };
+    }
+}

--- a/MetadataExtractor/Formats/Heif/HeicThumbnailDirectory.cs
+++ b/MetadataExtractor/Formats/Heif/HeicThumbnailDirectory.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+
+namespace MetadataExtractor.Formats.Heif
+{
+    public class HeicThumbnailDirectory: Directory
+    {
+        public override string Name => "HEIC Thumbnail Data";
+
+        public HeicThumbnailDirectory()
+        {
+            SetDescriptor(new HeicThumbnailTagDescriptor(this));
+        }
+
+        public const int FileOffset = 1;
+        public const int Length = 2;
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>()
+        {
+            {FileOffset, "Offset From Beginning of File"},
+            {Length, "Data Length"}
+        };
+
+        protected override bool TryGetTagName(int tagType, out string? tagName) =>
+            _tagNameMap.TryGetValue(tagType, out tagName);
+    }
+
+    public class HeicThumbnailTagDescriptor : ITagDescriptor
+    {
+        private readonly HeicThumbnailDirectory _heicThumbnailDirectory;
+
+        public HeicThumbnailTagDescriptor(HeicThumbnailDirectory heicThumbnailDirectory)
+        {
+            _heicThumbnailDirectory = heicThumbnailDirectory;
+        }
+
+        public string? GetDescription(int tagType) =>
+            _heicThumbnailDirectory.GetObject(tagType)?.ToString()??"";
+    }
+}

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Linq.Expressions;
 using MetadataExtractor.Formats.FileType;
 using MetadataExtractor.Formats.Heif.Iso14496Parser;
 using MetadataExtractor.Formats.QuickTime;
@@ -36,38 +37,106 @@ namespace MetadataExtractor.Formats.Heif
             uint primaryItem = _sourceBoxes.Descendant<PrimaryItemBox>()?.PrimaryItem ?? uint.MaxValue;
             var itemRefs = _sourceBoxes.Descendant<ItemReferenceBox>().Boxes
                 .Where(i=>i.Type == BoxTypes.ThmbTag || i.Type == BoxTypes.CdscTag).ToList();
+            uint[] allPrimaryTiles = _sourceBoxes.Descendant<ItemReferenceBox>().Boxes
+                .SelectMany(i=>i.FromItemId == primaryItem && i.Type == BoxTypes.DimgTag?
+                  i.ToItemIds:new uint[0]).ToArray();
             var itemPropertyBox = _sourceBoxes.Descendant<ItemPropertyBox>();
             var props = itemPropertyBox.Boxes.Descendant<ItemPropertyContainerBox>().Boxes;
-            foreach (var pbox in InterestingPropertyBoxes(itemPropertyBox, primaryItem, itemRefs))
+            var associations = itemPropertyBox.Boxes.Descendant<ItemPropertyAssociationBox>();
+            ParsePropertyBoxes("HEIC Primary Item Properties", ImageProperties(primaryItem, allPrimaryTiles,
+                associations, props));
+            foreach (var itemRef in itemRefs)
             {
-                var dir = new HeicImagePropertiesDirectory(pbox.ItemId == primaryItem?"HEIC Primary Item Properties":
-                    "HEIC Thumbnal Properties");
-                foreach (var prop in pbox.Properties.Select(i=>props.ElementAt(i.Index-1)))
-                {
-                    switch (prop)
-                    {
-                        case ImageSpatialExtentsBox ipse:
-                            dir.Set(HeicImagePropertiesDirectory.ImageWidth, ipse.X);
-                            dir.Set(HeicImagePropertiesDirectory.ImageHeight, ipse.Y);
-                            break;
-                    }
-                }
-                _directories.Add(dir);
+                ParsePropertyBoxes("HEIC Thumbnail Properties", ImageProperties(itemRef.FromItemId, new uint[0],
+                    associations, props));
             }
-            /*
-            var propGroups = InterestingPropertyBoxes(itemPropertyBox, primaryItem, itemRefs)
-                .Select(i=>new { i.ItemId, Props = i.Properties.Select(j=>props.ElementAt(j.Index-1)).ToList()})
-                .ToList();
-                */
+            // foreach (var pbox in InterestingPropertyBoxes(itemPropertyBox, allPrimaryTiles, itemRefs).Distinct())
+            // {
+            //     var propertyBoxTitle = pbox.ItemId == primaryItem
+            //         ? "HEIC Primary Item Properties"
+            //         : "HEIC Thumbnal Properties";
+            //     ParsePropertyBoxes(propertyBoxTitle, pbox, props);
+            // }
 
             return _directories;
         }
 
-        private static IEnumerable<ItemPropertyAssociationEntry> InterestingPropertyBoxes(
-            ItemPropertyBox itemPropertyBox, uint primaryItem, List<SingleItemTypeReferenceBox> itemRefs)
+        private IEnumerable<Box> ImageProperties(uint primaryId, uint[] secondary,
+            ItemPropertyAssociationBox associations, IList<Box> props)
         {
-            return itemPropertyBox.Boxes.Descendant<ItemPropertyAssociationBox>().Entries
-                .Where(i => i.ItemId == primaryItem || itemRefs.Any(j => j.FromItemId == i.ItemId));
+            return DirectProperties(primaryId, associations, props). Concat(
+                (from associationBox in associations.Entries.Where(i=>secondary.Contains(i.ItemId))
+                from propIndex in associationBox.Properties
+                select props.ElementAt(propIndex.Index - 1))
+                .Where(i=>i is DecoderConfigurationBox || i is ColorInformationBox)
+                .Distinct()
+                );
+        }
+
+        private static IEnumerable<Box> DirectProperties(uint primaryId, ItemPropertyAssociationBox associations, IList<Box> props)
+        {
+            return from associationBox in associations.Entries.Where(i=>i.ItemId == primaryId)
+                from propIndex in associationBox.Properties
+                select props.ElementAt(propIndex.Index - 1);
+        }
+
+        private void ParsePropertyBoxes(string propertyBoxTitle, IEnumerable<Box> props)
+        {
+            var dir = new HeicImagePropertiesDirectory(propertyBoxTitle);
+            bool hasProp = false;
+            foreach (var prop in props)
+            {
+                switch (prop)
+                {
+                    case ImageSpatialExtentsBox ipse: ParseImageSize(dir, ipse); break;
+                    case ImageRotationBox irot: ParseImageRotation(dir, irot); break;
+                    case PixelInformationBox pixi : ParsePixelDepth(dir, pixi); break;
+                    case DecoderConfigurationBox hvcC : ParseDecoderInformation(dir, hvcC); break;
+                    default: continue;
+                }
+
+                hasProp = true;
+            }
+
+            if (hasProp)
+            {
+                _directories.Add(dir);
+            }
+        }
+
+        private void ParseDecoderInformation(HeicImagePropertiesDirectory dir, DecoderConfigurationBox hvcC)
+        {
+            dir.Set(HeicImagePropertiesDirectory.ConfigurationVersion, hvcC.ConfigurationVersion);
+            dir.Set(HeicImagePropertiesDirectory.GeneralProfileSpace, hvcC.GeneralProfileSpace);
+            dir.Set(HeicImagePropertiesDirectory.GeneralTierTag, hvcC.GeneralTierTag);
+            dir.Set(HeicImagePropertiesDirectory.GeneralProfileIdc, hvcC.GeneralProfileIdc);
+            dir.Set(HeicImagePropertiesDirectory.GeneralProfileCompatibilityTag, hvcC.GeneralProfileCompatibilityFlags);
+            dir.Set(HeicImagePropertiesDirectory.GeneralLevelIdc, hvcC.GeneralLevelIdc);
+            dir.Set(HeicImagePropertiesDirectory.MinSpacialSegmentationIdc, hvcC.MinSpacialSegmentationIdc);
+            dir.Set(HeicImagePropertiesDirectory.ParallelismType, hvcC.ParallelismType);
+            dir.Set(HeicImagePropertiesDirectory.ChromaFormat, hvcC.ChromaFormat);
+            dir.Set(HeicImagePropertiesDirectory.BitDepthLuma, hvcC.BitDepthLumaMinus8+8);
+            dir.Set(HeicImagePropertiesDirectory.BitDepthChroma, hvcC.BitDepthChromaMinus8+8);
+            dir.Set(HeicImagePropertiesDirectory.AverageFrameRate, hvcC.AvgFrameRate);
+            dir.Set(HeicImagePropertiesDirectory.ConstantFrameRate, hvcC.ConstantFrameRate);
+            dir.Set(HeicImagePropertiesDirectory.NumTemporalLayers, hvcC.NumTemporalLayers);
+            dir.Set(HeicImagePropertiesDirectory.LengthSize, hvcC.LengthSizeMinus1 + 1);
+        }
+
+        private void ParsePixelDepth(HeicImagePropertiesDirectory dir, PixelInformationBox pixi)
+        {
+            dir.Set(HeicImagePropertiesDirectory.PixelDepths, pixi.BitsPerChannel);
+        }
+
+        private void ParseImageRotation(HeicImagePropertiesDirectory dir, ImageRotationBox irot)
+        {
+            dir.Set(HeicImagePropertiesDirectory.Rotation, irot.Rotation);
+        }
+
+        private static void ParseImageSize(HeicImagePropertiesDirectory dir, ImageSpatialExtentsBox ipse)
+        {
+            dir.Set(HeicImagePropertiesDirectory.ImageWidth, ipse.X);
+            dir.Set(HeicImagePropertiesDirectory.ImageHeight, ipse.Y);
         }
 
         private void ParseQuickTimeTest()

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using MetadataExtractor.Formats.FileType;
+using MetadataExtractor.Formats.QuickTime;
+#if NET35
+using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
+#else
+using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
+#endif
+
+
+namespace MetadataExtractor.Formats.Heif
+{
+    public class HeifMetadataReader
+    {
+        public static DirectoryList ReadMetadata(Stream stream) => new HeifMetadataReader(stream).Process();
+
+        private readonly Stream _stream;
+        private HeifMetadataReader(Stream stream)
+        {
+            _stream = stream;
+        }
+
+        List<Directory> _directories = new List<Directory>();
+        private DirectoryList Process()
+        {
+            return _directories;
+        }
+
+    }
+
+    public class DataReferenceDirectory : Directory
+    {
+        public const int Version = 1;
+        public const int Flags = 2;
+        public const int Items = 3;
+
+        public static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>()
+        {
+            { Version, "Data Reference Version" },
+            { Flags, "Flags" },
+            { Items, "Numeber of Entries" }
+        };
+
+        public override string Name { get; } = "Hief Metadata";
+        protected override bool TryGetTagName(int tagType, out string? tagName)
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -1,8 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using MetadataExtractor.Formats.FileType;
+using MetadataExtractor.Formats.Heif.Iso14496Parser;
 using MetadataExtractor.Formats.QuickTime;
+using MetadataExtractor.IO;
 #if NET35
 using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
 #else
@@ -15,6 +18,7 @@ namespace MetadataExtractor.Formats.Heif
     public class HeifMetadataReader
     {
         public static DirectoryList ReadMetadata(Stream stream) => new HeifMetadataReader(stream).Process();
+        private List<Box> _sourceBoxes = new List<Box>();
 
         private readonly Stream _stream;
         private HeifMetadataReader(Stream stream)
@@ -23,30 +27,79 @@ namespace MetadataExtractor.Formats.Heif
         }
 
         List<Directory> _directories = new List<Directory>();
+
         private DirectoryList Process()
         {
+            var reader = new SequentialStreamReader(_stream);
+            ReadBoxes(reader);
+            ParseQuickTimeTest();
+            uint primaryItem = _sourceBoxes.Descendant<PrimaryItemBox>()?.PrimaryItem ?? uint.MaxValue;
+            var itemRefs = _sourceBoxes.Descendant<ItemReferenceBox>().Boxes
+                .Where(i=>i.Type == BoxTypes.ThmbTag || i.Type == BoxTypes.CdscTag).ToList();
+            var itemPropertyBox = _sourceBoxes.Descendant<ItemPropertyBox>();
+            var props = itemPropertyBox.Boxes.Descendant<ItemPropertyContainerBox>().Boxes;
+            foreach (var pbox in InterestingPropertyBoxes(itemPropertyBox, primaryItem, itemRefs))
+            {
+                var dir = new HeicImagePropertiesDirectory(pbox.ItemId == primaryItem?"HEIC Primary Item Properties":
+                    "HEIC Thumbnal Properties");
+                foreach (var prop in pbox.Properties.Select(i=>props.ElementAt(i.Index-1)))
+                {
+                    switch (prop)
+                    {
+                        case ImageSpatialExtentsBox ipse:
+                            dir.Set(HeicImagePropertiesDirectory.ImageWidth, ipse.X);
+                            dir.Set(HeicImagePropertiesDirectory.ImageHeight, ipse.Y);
+                            break;
+                    }
+                }
+                _directories.Add(dir);
+            }
+            /*
+            var propGroups = InterestingPropertyBoxes(itemPropertyBox, primaryItem, itemRefs)
+                .Select(i=>new { i.ItemId, Props = i.Properties.Select(j=>props.ElementAt(j.Index-1)).ToList()})
+                .ToList();
+                */
+
             return _directories;
         }
 
-    }
-
-    public class DataReferenceDirectory : Directory
-    {
-        public const int Version = 1;
-        public const int Flags = 2;
-        public const int Items = 3;
-
-        public static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>()
+        private static IEnumerable<ItemPropertyAssociationEntry> InterestingPropertyBoxes(
+            ItemPropertyBox itemPropertyBox, uint primaryItem, List<SingleItemTypeReferenceBox> itemRefs)
         {
-            { Version, "Data Reference Version" },
-            { Flags, "Flags" },
-            { Items, "Numeber of Entries" }
-        };
+            return itemPropertyBox.Boxes.Descendant<ItemPropertyAssociationBox>().Entries
+                .Where(i => i.ItemId == primaryItem || itemRefs.Any(j => j.FromItemId == i.ItemId));
+        }
 
-        public override string Name { get; } = "Hief Metadata";
-        protected override bool TryGetTagName(int tagType, out string? tagName)
+        private void ParseQuickTimeTest()
         {
-            throw new NotImplementedException();
+            if (_sourceBoxes.Descendant<FileTypeBox>() is {} ftype)
+            {
+                var dir = new QuickTimeFileTypeDirectory();
+                if (ftype.MajorBrand > 0)
+                {
+                    dir.Set(QuickTimeFileTypeDirectory.TagMajorBrand, ftype.MajorBrandString);
+                }
+                if (ftype.MinorBrand > 0)
+                {
+                    dir.Set(QuickTimeFileTypeDirectory.TagMinorVersion, ftype.MinorBrandString);
+                }
+
+                if (ftype.CompatibleBrands.Count > 0)
+                {
+                    dir.Set(QuickTimeFileTypeDirectory.TagCompatibleBrands,
+                        String.Join(", ", ftype.CompatibleBrandStrings.ToArray()));
+                }
+                _directories.Add(dir);
+            }
+        }
+
+        private void ReadBoxes(SequentialStreamReader reader)
+        {
+            Box? item = null;
+            while ((item = BoxReader.ReadBox(reader)) != null)
+            {
+                _sourceBoxes.Add(item);
+            }
         }
     }
 }

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using MetadataExtractor.Formats.FileType;
 using MetadataExtractor.Formats.Heif.Iso14496Parser;
+using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.QuickTime;
 using MetadataExtractor.IO;
 #if NET35
@@ -78,6 +79,7 @@ namespace MetadataExtractor.Formats.Heif
         {
             var dir = new HeicImagePropertiesDirectory(propertyBoxTitle);
             bool hasProp = false;
+            _directories.Add(dir); // add now so it will preceed the ICC profile directory
             foreach (var prop in props)
             {
                 switch (prop)
@@ -93,9 +95,9 @@ namespace MetadataExtractor.Formats.Heif
                 hasProp = true;
             }
 
-            if (hasProp)
+            if (!hasProp)
             {
-                _directories.Add(dir);
+                _directories.Remove(dir);
             }
         }
 
@@ -111,7 +113,9 @@ namespace MetadataExtractor.Formats.Heif
             }
             else
             {
-                // parse ICC
+                var iccDirectory = new IccReader().Extract(new ByteArrayReader(colr.IccProfile));
+                iccDirectory.Parent = dir;
+                _directories.Add(iccDirectory);
             }
         }
 

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BitsReader.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BitsReader.cs
@@ -1,0 +1,62 @@
+﻿using System.Diagnostics;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class BitsReader
+    {
+        private readonly SequentialReader source;
+
+        public BitsReader(SequentialReader source)
+        {
+            this.source = source;
+        }
+
+        public ulong GetUInt64(int bits)
+        {
+            Debug.Assert(bits <=64);
+            ulong ret = 0;
+            for (int i = 0; i < bits; i++)
+            {
+                ret <<= 1;
+                if (GetBit())
+                {
+                    ret |= 1;
+                }
+            }
+
+            return ret;
+        }
+        public uint GetUInt32(int bits)
+        {
+            Debug.Assert(bits <=32);
+            return (uint) (GetUInt64(bits));
+        }
+        public ushort GetUInt16(int bits)
+        {
+            Debug.Assert(bits <=32);
+            return (ushort) (GetUInt64(bits));
+        }
+        public byte GetByte(int bits)
+        {
+            Debug.Assert(bits <=8);
+            return (byte) (GetUInt64(bits));
+        }
+
+        private byte mask = 0;
+        private byte currentByte = 0;
+        public bool GetBit()
+        {
+            if (mask == 0) ReadWholeByteFromSource();
+            var ret = (mask & currentByte) == mask;
+            mask >>= 1;
+            return ret;
+        }
+
+        private void ReadWholeByteFromSource()
+        {
+            currentByte = source.GetByte();
+            mask = 128;
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/Box.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/Box.cs
@@ -1,4 +1,6 @@
-﻿using MetadataExtractor.IO;
+﻿using System.Collections.Generic;
+using System.Net.Sockets;
+using MetadataExtractor.IO;
 
 namespace MetadataExtractor.Formats.Heif.Iso14496Parser
 {
@@ -17,5 +19,8 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
             sr.Skip((long) NextPosition - sr.Position);
         }
         public byte[] ReadRemainingData(SequentialReader sr) => sr.GetBytes((int) ((long) NextPosition - sr.Position));
+        public virtual IEnumerable<Box> Children() => EmptyChildren;
+
+        private static Box[] EmptyChildren = new Box[0];
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/Box.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/Box.cs
@@ -1,0 +1,21 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class Box
+    {
+        private BoxLocation location;
+        public uint Type => location.Type;
+        public ulong Origin => location.Origin;
+        public ulong Length => location.Length;
+        public ulong NextPosition => location.NextPosition;
+
+        public Box(BoxLocation location) => this.location = location;
+        public string TypeString => TypeStringConverter.ToTypeString(Type);
+        public void SkipRemainingData(SequentialReader sr)
+        {
+            sr.Skip((long) NextPosition - sr.Position);
+        }
+        public byte[] ReadRemainingData(SequentialReader sr) => sr.GetBytes((int) ((long) NextPosition - sr.Position));
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxLocation.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxLocation.cs
@@ -1,0 +1,26 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class BoxLocation
+    {
+        public uint Type { get; }
+        public ulong Origin { get; }
+        public ulong Length { get; }
+        public ulong NextPosition => Origin + Length;
+        public ulong BytesLeft (SequentialReader sr) => NextPosition - (ulong)sr.Position;
+        public bool DoneReading(SequentialReader sr) => (ulong)sr.Position >= NextPosition;
+
+        public BoxLocation(SequentialReader reader)
+        {
+            Origin = (ulong)reader.Position;
+            Length = reader.GetUInt32();
+            Type = reader.GetUInt32();
+            Length = Length switch {
+                1 => reader.GetUInt64(),
+                0 => (ulong)(reader.Available()+8), // 8 is for the two words already consumed.
+                _=> Length
+            };
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxQuery.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxQuery.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public static class BoxQuery
+    {
+        public static IEnumerable<T> Descendants<T>(this IEnumerable<Box> source) where T:Box =>
+            source.Traverse(b=>b.Children()).OfType<T>();
+        public static T Descendant<T>(this IEnumerable<Box> source) where T:Box =>
+            source.Descendants<T>().FirstOrDefault();
+
+        public static IEnumerable<T> Traverse<T>(this IEnumerable<T> roots, Func<T,IEnumerable<T>> children)
+        {
+            var queue = new Queue<T>();
+            EnqueAll(roots);
+            while(queue.Count > 0)
+            {
+                var current = queue.Dequeue();
+                yield return current;
+                EnqueAll(children(current));
+            }
+            void EnqueAll(IEnumerable<T> all)
+            {
+                foreach (var item in all)
+                {
+                    queue.Enqueue(item);
+                }
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
@@ -8,15 +8,18 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
     {
         public static Box ReadBox(SequentialReader sr) => ReadBox(sr, LoadFinalType);
 
-        public static Box ReadBox(SequentialReader sr, Func<BoxLocation, SequentialReader, Box> reader)
+        public static Box? ReadBox(SequentialReader sr, Func<BoxLocation, SequentialReader, Box> reader)
         {
+            if (sr.Available() < 8) return null;
             var location = new BoxLocation(sr);
+            if (location.Type == MdatTag) return null;
             var ret = reader(location, sr);
             ret.SkipRemainingData(sr);
             return ret;
 
         }
 
+        private const uint MdatTag = 0x6D646174; // mdat
         private const uint MetaTag = 0x6D657461; // meta
         private const uint FTypTag = 0x66747970; // ftyp
         private const uint HdlrTag = 0x68646C72; // hdlr
@@ -37,6 +40,7 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         private const uint PixiTag = 0x70697869; // pixi
         private const uint IdatTag = 0x69646174; // idat
         private const uint IlocTag = 0x696C6F63; // iloc
+        private const uint IpmaTag = 0x69706D61; // ipma
         private static Box LoadFinalType(BoxLocation location, SequentialReader sr)
         {
             return location.Type switch
@@ -61,6 +65,7 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
                 PixiTag => new PixelInformationBox(location, sr),
                 IdatTag => new ItemDataBox(location, sr),
                 IlocTag => new ItemLocationBox(location, sr),
+                IpmaTag => new ItemPropertyAssociationBox(location, sr),
                 _=> new Box(location)
             };
         }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
@@ -34,6 +34,9 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         private const uint HvcCTag = 0x68766343; // hvcC
         private const uint ColrTag = 0x636F6C72; // colr
         private const uint IrotTag = 0x69726f74; // irot
+        private const uint PixiTag = 0x70697869; // pixi
+        private const uint IdatTag = 0x69646174; // idat
+        private const uint IlocTag = 0x696C6F63; // iloc
         private static Box LoadFinalType(BoxLocation location, SequentialReader sr)
         {
             return location.Type switch
@@ -55,6 +58,9 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
                 HvcCTag => new DecoderConfigurationBox(location, sr),
                 ColrTag => new ColorInformationBox(location, sr),
                 IrotTag => new ImageRotationBox(location, sr),
+                PixiTag => new PixelInformationBox(location, sr),
+                IdatTag => new ItemDataBox(location, sr),
+                IlocTag => new ItemLocationBox(location, sr),
                 _=> new Box(location)
             };
         }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public static class BoxReader
+    {
+        public static Box ReadBox(SequentialReader sr) => ReadBox(sr, LoadFinalType);
+
+        public static Box ReadBox(SequentialReader sr, Func<BoxLocation, SequentialReader, Box> reader)
+        {
+            var location = new BoxLocation(sr);
+            var ret = reader(location, sr);
+            ret.SkipRemainingData(sr);
+            return ret;
+
+        }
+
+        private const uint MetaTag = 0x6D657461; // meta
+        private const uint FTypTag = 0x66747970; // ftyp
+        private const uint HdlrTag = 0x68646C72; // hdlr
+        private const uint DinfTag = 0x64696E66; // dinf
+        private const uint DrefTag = 0x64726566; // dref
+        private const uint UrlTag  = 0x75726C20; // 'url '
+        private const uint UrnTag  = 0x75726E20; // 'urn '
+        private const uint PitmTag = 0x7069746D; // pitm
+        private const uint Iinftag = 0x69696E66; // iinf
+        private const uint InfeTag = 0x696E6665; // infe
+        private const uint IrefTag = 0x69726566; // iref
+        private const uint IprpTag = 0x69707270; // iprp
+        private const uint IpcoTag = 0x6970636F; // ipco
+        private const uint IspeTag = 0x69737065; // ipse
+        private const uint HvcCTag = 0x68766343; // hvcC
+        private const uint ColrTag = 0x636F6C72; // colr
+        private const uint IrotTag = 0x69726f74; // irot
+        private static Box LoadFinalType(BoxLocation location, SequentialReader sr)
+        {
+            return location.Type switch
+            {
+                FTypTag => new FileTypeBox(location, sr),
+                MetaTag => new MetaBox(location, sr),
+                HdlrTag => new HandlerBox(location, sr),
+                DinfTag => new DataInformationBox(location, sr),
+                DrefTag => new DataReferenceBox(location, sr),
+                UrlTag  => new DataEntryLocationBox(location, sr, false),
+                UrnTag  => new DataEntryLocationBox(location, sr, true),
+                PitmTag => new PrimaryItemBox(location, sr),
+                Iinftag => new ItemInformationBox(location, sr),
+                InfeTag => new ItemInfoEntryBox(location, sr),
+                IrefTag => new ItemReferenceBox(location, sr),
+                IprpTag => new ItemPropertyBox(location, sr),
+                IpcoTag => new ItemPropertyContainerBox(location, sr),
+                IspeTag => new ImageSpatialExtentsBox(location, sr),
+                HvcCTag => new DecoderConfigurationBox(location, sr),
+                ColrTag => new ColorInformationBox(location, sr),
+                IrotTag => new ImageRotationBox(location, sr),
+                _=> new Box(location)
+            };
+        }
+
+        public static IList<Box> BoxList(BoxLocation loc, SequentialReader sr) {
+            var ret = new List<Box>();
+            while (!loc.DoneReading(sr)){
+                ret.Add(ReadBox(sr));
+            }
+            return ret;
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
@@ -12,7 +12,8 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         {
             if (sr.Available() < 8) return null;
             var location = new BoxLocation(sr);
-            if (location.Type == BoxTypes.MdatTag) return null;
+            if ((long)location.NextPosition - sr.Position >= sr.Available()) return null; // skip the last box of the file.
+           // if (location.Type == BoxTypes.MdatTag) return null;
             var ret = reader(location, sr);
             ret.SkipRemainingData(sr);
             return ret;

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxReader.cs
@@ -6,66 +6,43 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
 {
     public static class BoxReader
     {
-        public static Box ReadBox(SequentialReader sr) => ReadBox(sr, LoadFinalType);
+        public static Box? ReadBox(SequentialReader sr) => ReadBox(sr, LoadFinalType);
 
         public static Box? ReadBox(SequentialReader sr, Func<BoxLocation, SequentialReader, Box> reader)
         {
             if (sr.Available() < 8) return null;
             var location = new BoxLocation(sr);
-            if (location.Type == MdatTag) return null;
+            if (location.Type == BoxTypes.MdatTag) return null;
             var ret = reader(location, sr);
             ret.SkipRemainingData(sr);
             return ret;
-
         }
 
-        private const uint MdatTag = 0x6D646174; // mdat
-        private const uint MetaTag = 0x6D657461; // meta
-        private const uint FTypTag = 0x66747970; // ftyp
-        private const uint HdlrTag = 0x68646C72; // hdlr
-        private const uint DinfTag = 0x64696E66; // dinf
-        private const uint DrefTag = 0x64726566; // dref
-        private const uint UrlTag  = 0x75726C20; // 'url '
-        private const uint UrnTag  = 0x75726E20; // 'urn '
-        private const uint PitmTag = 0x7069746D; // pitm
-        private const uint Iinftag = 0x69696E66; // iinf
-        private const uint InfeTag = 0x696E6665; // infe
-        private const uint IrefTag = 0x69726566; // iref
-        private const uint IprpTag = 0x69707270; // iprp
-        private const uint IpcoTag = 0x6970636F; // ipco
-        private const uint IspeTag = 0x69737065; // ipse
-        private const uint HvcCTag = 0x68766343; // hvcC
-        private const uint ColrTag = 0x636F6C72; // colr
-        private const uint IrotTag = 0x69726f74; // irot
-        private const uint PixiTag = 0x70697869; // pixi
-        private const uint IdatTag = 0x69646174; // idat
-        private const uint IlocTag = 0x696C6F63; // iloc
-        private const uint IpmaTag = 0x69706D61; // ipma
         private static Box LoadFinalType(BoxLocation location, SequentialReader sr)
         {
             return location.Type switch
             {
-                FTypTag => new FileTypeBox(location, sr),
-                MetaTag => new MetaBox(location, sr),
-                HdlrTag => new HandlerBox(location, sr),
-                DinfTag => new DataInformationBox(location, sr),
-                DrefTag => new DataReferenceBox(location, sr),
-                UrlTag  => new DataEntryLocationBox(location, sr, false),
-                UrnTag  => new DataEntryLocationBox(location, sr, true),
-                PitmTag => new PrimaryItemBox(location, sr),
-                Iinftag => new ItemInformationBox(location, sr),
-                InfeTag => new ItemInfoEntryBox(location, sr),
-                IrefTag => new ItemReferenceBox(location, sr),
-                IprpTag => new ItemPropertyBox(location, sr),
-                IpcoTag => new ItemPropertyContainerBox(location, sr),
-                IspeTag => new ImageSpatialExtentsBox(location, sr),
-                HvcCTag => new DecoderConfigurationBox(location, sr),
-                ColrTag => new ColorInformationBox(location, sr),
-                IrotTag => new ImageRotationBox(location, sr),
-                PixiTag => new PixelInformationBox(location, sr),
-                IdatTag => new ItemDataBox(location, sr),
-                IlocTag => new ItemLocationBox(location, sr),
-                IpmaTag => new ItemPropertyAssociationBox(location, sr),
+                BoxTypes.FTypTag => new FileTypeBox(location, sr),
+                BoxTypes.MetaTag => new MetaBox(location, sr),
+                BoxTypes.HdlrTag => new HandlerBox(location, sr),
+                BoxTypes.DinfTag => new DataInformationBox(location, sr),
+                BoxTypes.DrefTag => new DataReferenceBox(location, sr),
+                BoxTypes.UrlTag  => new DataEntryLocationBox(location, sr, false),
+                BoxTypes.UrnTag  => new DataEntryLocationBox(location, sr, true),
+                BoxTypes.PitmTag => new PrimaryItemBox(location, sr),
+                BoxTypes.Iinftag => new ItemInformationBox(location, sr),
+                BoxTypes.InfeTag => new ItemInfoEntryBox(location, sr),
+                BoxTypes.IrefTag => new ItemReferenceBox(location, sr),
+                BoxTypes.IprpTag => new ItemPropertyBox(location, sr),
+                BoxTypes.IpcoTag => new ItemPropertyContainerBox(location, sr),
+                BoxTypes.IspeTag => new ImageSpatialExtentsBox(location, sr),
+                BoxTypes.HvcCTag => new DecoderConfigurationBox(location, sr),
+                BoxTypes.ColrTag => new ColorInformationBox(location, sr),
+                BoxTypes.IrotTag => new ImageRotationBox(location, sr),
+                BoxTypes.PixiTag => new PixelInformationBox(location, sr),
+                BoxTypes.IdatTag => new ItemDataBox(location, sr),
+                BoxTypes.IlocTag => new ItemLocationBox(location, sr),
+                BoxTypes.IpmaTag => new ItemPropertyAssociationBox(location, sr),
                 _=> new Box(location)
             };
         }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxTypes.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxTypes.cs
@@ -26,6 +26,6 @@
         public const uint IpmaTag = 0x69706D61; // ipma
         public const uint ThmbTag = 0x74686D62; // thmb
         public const uint CdscTag = 0x63647363; // cdsc
-
+        public const uint DimgTag = 0x64696D67; // dimg
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxTypes.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/BoxTypes.cs
@@ -1,0 +1,31 @@
+﻿namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public static class BoxTypes
+    {
+        public const uint MdatTag = 0x6D646174; // mdat
+        public const uint MetaTag = 0x6D657461; // meta
+        public const uint FTypTag = 0x66747970; // ftyp
+        public const uint HdlrTag = 0x68646C72; // hdlr
+        public const uint DinfTag = 0x64696E66; // dinf
+        public const uint DrefTag = 0x64726566; // dref
+        public const uint UrlTag  = 0x75726C20; // 'url '
+        public const uint UrnTag  = 0x75726E20; // 'urn '
+        public const uint PitmTag = 0x7069746D; // pitm
+        public const uint Iinftag = 0x69696E66; // iinf
+        public const uint InfeTag = 0x696E6665; // infe
+        public const uint IrefTag = 0x69726566; // iref
+        public const uint IprpTag = 0x69707270; // iprp
+        public const uint IpcoTag = 0x6970636F; // ipco
+        public const uint IspeTag = 0x69737065; // ipse
+        public const uint HvcCTag = 0x68766343; // hvcC
+        public const uint ColrTag = 0x636F6C72; // colr
+        public const uint IrotTag = 0x69726f74; // irot
+        public const uint PixiTag = 0x70697869; // pixi
+        public const uint IdatTag = 0x69646174; // idat
+        public const uint IlocTag = 0x696C6F63; // iloc
+        public const uint IpmaTag = 0x69706D61; // ipma
+        public const uint ThmbTag = 0x74686D62; // thmb
+        public const uint CdscTag = 0x63647363; // cdsc
+
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ColorInformationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ColorInformationBox.cs
@@ -1,0 +1,38 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ColorInformationBox : Box
+    {
+        public uint ColorType { get; }
+        public ushort ColorPrimaries { get; }
+        public ushort TransferCharacteristics { get; }
+        public ushort MatrixCharacteristics { get; }
+        public bool FullRangeFlag { get; }
+        public byte[] IccProfile { get; }
+        private const uint NclxTag = 0x6E636C78; // nclx
+        private const uint RICCTag = 0x72494343; // rICC
+        private const uint ProfTag = 0x70726F66; // prof
+        public ColorInformationBox(BoxLocation location, SequentialReader sr) : base(location)
+        {
+            ColorType = sr.GetUInt32();
+            switch (ColorType)
+            {
+                case NclxTag:
+                    ColorPrimaries = sr.GetUInt16();
+                    TransferCharacteristics = sr.GetUInt16();
+                    MatrixCharacteristics = sr.GetUInt16();
+                    FullRangeFlag = (sr.GetByte() & 128) == 128;
+                    IccProfile = new byte[0];
+                    break;
+                case RICCTag:
+                case ProfTag:
+                    IccProfile = ReadRemainingData(sr);
+                    break;
+                default:
+                    IccProfile = new byte[0];
+                    break;
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ColorInformationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ColorInformationBox.cs
@@ -10,9 +10,9 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         public ushort MatrixCharacteristics { get; }
         public bool FullRangeFlag { get; }
         public byte[] IccProfile { get; }
-        private const uint NclxTag = 0x6E636C78; // nclx
-        private const uint RICCTag = 0x72494343; // rICC
-        private const uint ProfTag = 0x70726F66; // prof
+        public const uint NclxTag = 0x6E636C78; // nclx
+        public const uint RICCTag = 0x72494343; // rICC
+        public const uint ProfTag = 0x70726F66; // prof
         public ColorInformationBox(BoxLocation location, SequentialReader sr) : base(location)
         {
             ColorType = sr.GetUInt32();

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/DataEntryLocationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/DataEntryLocationBox.cs
@@ -1,0 +1,16 @@
+﻿using System.Text;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class DataEntryLocationBox: FullBox
+    {
+        public string Name {get;}
+        public string Location {get;}
+        public DataEntryLocationBox(BoxLocation loc, SequentialReader sr, bool hasName):base(loc,sr)
+        {
+            Name = hasName ? sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8) : "";
+            Location = loc.DoneReading(sr)?"":sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/DataInformationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/DataInformationBox.cs
@@ -10,5 +10,7 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         {
             Boxes = BoxReader.BoxList(loc, sr);
         }
+
+        public override IEnumerable<Box> Children() => Boxes;
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/DataInformationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/DataInformationBox.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class DataInformationBox : Box
+    {
+        public IList<Box> Boxes { get; }
+        public DataInformationBox(BoxLocation loc, SequentialReader sr) : base(loc)
+        {
+            Boxes = BoxReader.BoxList(loc, sr);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/DataReferenceBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/DataReferenceBox.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class DataReferenceBox : FullBox
+    {
+        public IList<Box> Boxes { get; }
+        public uint BoxCount { get; }
+        public DataReferenceBox(BoxLocation loc, SequentialReader sr) : base(loc, sr)
+        {
+            BoxCount = sr.GetUInt32();
+            Boxes = BoxReader.BoxList(loc, sr);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/DataReferenceBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/DataReferenceBox.cs
@@ -12,5 +12,7 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
             BoxCount = sr.GetUInt32();
             Boxes = BoxReader.BoxList(loc, sr);
         }
+        public override IEnumerable<Box> Children() => Boxes;
+
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/DecoderConfigurationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/DecoderConfigurationBox.cs
@@ -13,12 +13,15 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         public ushort MinSpacialSegmentationIdc {get;}
         public byte ParallelismType { get; }
         public byte ChromaFormat{ get; }
+        /*
+         These fields appear in the standard document but are never read in the parser
         public ushort PicWidthInLumaSamples { get; }
         public ushort PicHeightInLumaSamples { get; }
         public ushort ConfWinLeftOffset { get; }
         public ushort ConfWinRightOffset { get; }
         public ushort ConfWinTopOffset { get; }
         public ushort ConfWinBottomOffset { get; }
+        */
         public byte BitDepthLumaMinus8 { get; }
         public byte BitDepthChromaMinus8 { get; }
         public ushort AvgFrameRate{ get; }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/DecoderConfigurationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/DecoderConfigurationBox.cs
@@ -1,0 +1,60 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class DecoderConfigurationBox: Box {
+        public byte ConfigurationVersion { get; }
+        public byte GeneralProfileSpace{ get; }
+        public byte GeneralTierTag { get; }
+        public byte GeneralProfileIdc { get; }
+        public uint GeneralProfileCompatibilityFlags {get;}
+        public byte[] GeneralConstraintIndicatorFlags {get;} = new byte[6];
+        public byte GeneralLevelIdc {get;}
+        public ushort MinSpacialSegmentationIdc {get;}
+        public byte ParallelismType { get; }
+        public byte ChromaFormat{ get; }
+        public ushort PicWidthInLumaSamples { get; }
+        public ushort PicHeightInLumaSamples { get; }
+        public ushort ConfWinLeftOffset { get; }
+        public ushort ConfWinRightOffset { get; }
+        public ushort ConfWinTopOffset { get; }
+        public ushort ConfWinBottomOffset { get; }
+        public byte BitDepthLumaMinus8 { get; }
+        public byte BitDepthChromaMinus8 { get; }
+        public ushort AvgFrameRate{ get; }
+        public byte ConstantFrameRate { get; }
+        public byte NumTemporalLayers { get; }
+        public byte TemporalIdNested { get; }
+        public byte LengthSizeMinus1 { get; }
+
+        public DecoderConfigurationBox(BoxLocation location, SequentialReader sr) : base(location)
+        {
+            var bitReader = new BitsReader(sr);
+            ConfigurationVersion = bitReader.GetByte(8);
+            GeneralProfileSpace = bitReader.GetByte(2);
+            GeneralTierTag = bitReader.GetByte(1);
+            GeneralProfileIdc = bitReader.GetByte(5);
+            GeneralProfileCompatibilityFlags = bitReader.GetUInt32(32);
+            for (int i = 0; i < 6; i++)
+            {
+                GeneralConstraintIndicatorFlags[i] = bitReader.GetByte(8);
+            }
+            GeneralLevelIdc = bitReader.GetByte(8);
+            bitReader.GetUInt32(4); // reserved should be all 1's
+            MinSpacialSegmentationIdc = bitReader.GetUInt16(12);
+            bitReader.GetUInt32(6); // reserved should be all 1's
+            ParallelismType = bitReader.GetByte(2);
+            bitReader.GetUInt32(6); // reserved should be all 1's
+            ChromaFormat = bitReader.GetByte(2);
+            bitReader.GetUInt32(5); // reserved should be all 1's
+            BitDepthLumaMinus8 = bitReader.GetByte(3);
+            bitReader.GetUInt32(5); // reserved should be all 1's
+            BitDepthChromaMinus8 = bitReader.GetByte(3);
+            AvgFrameRate = bitReader.GetUInt16(16);
+            ConstantFrameRate = bitReader.GetByte(2);
+            NumTemporalLayers = bitReader.GetByte(3);
+            TemporalIdNested = bitReader.GetByte(1);
+            LengthSizeMinus1 = bitReader.GetByte(2);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/FileTypeBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/FileTypeBox.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class FileTypeBox: Box{
+        public uint MajorBrand { get; }
+        public uint MinorBrand { get; }
+        public IList<uint> CompatibleBrands { get; }
+
+        public string MajorBrandString => TypeStringConverter.ToTypeString(MajorBrand);
+        public string MinorBrandString  => TypeStringConverter.ToTypeString(MinorBrand);
+        public IEnumerable<string> CompatibleBrandStrings =>
+            CompatibleBrands.Select(TypeStringConverter.ToTypeString);
+        public FileTypeBox(BoxLocation loc, SequentialReader sr) : base(loc)
+        {
+            MajorBrand = sr.GetUInt32();
+            MinorBrand = sr.GetUInt32();
+            var cBrands = new List<uint>();
+            CompatibleBrands = cBrands;
+            while (!loc.DoneReading(sr)){
+                cBrands.Add(sr.GetUInt32());
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/FullBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/FullBox.cs
@@ -1,0 +1,16 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class FullBox : Box
+    {
+        private uint typeAndFlags;
+        public byte Version => (byte)(typeAndFlags >> 24);
+        public uint Flags => typeAndFlags & 0x00FFFFFF;
+
+        public FullBox(BoxLocation loc, SequentialReader sr) : base(loc)
+        {
+            typeAndFlags = sr.GetUInt32();
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/HandlerBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/HandlerBox.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Text;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class HandlerBox : FullBox
+    {
+        public uint HandlerType { get; }
+        public string HandlerTypeString => TypeStringConverter.ToTypeString(HandlerType);
+        public String TrackType { get; }
+
+        public HandlerBox(BoxLocation loc, SequentialReader sr) : base(loc, sr)
+        {
+            sr.GetUInt32(); // should be Zero	
+            HandlerType = sr.GetUInt32();
+            sr.GetUInt32(); // should be Zero	
+            sr.GetUInt32(); // should be Zero	
+            sr.GetUInt32(); // should be Zero	
+            TrackType = sr.GetString((int)loc.BytesLeft(sr), Encoding.UTF8);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ImageRotationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ImageRotationBox.cs
@@ -1,0 +1,13 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ImageRotationBox : Box
+    {
+        public uint Rotation { get; } // rotation is anti-clockwise and valid values are 0,90,180, and 270
+        public ImageRotationBox(BoxLocation boxLocation, SequentialReader sr) : base(boxLocation)
+        {
+            Rotation = (uint)((sr.GetByte() & 3) * 90);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ImageSpatialExtentsBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ImageSpatialExtentsBox.cs
@@ -1,0 +1,14 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ImageSpatialExtentsBox : FullBox{
+        public uint X {get;}
+        public uint Y {get;}
+	
+        public ImageSpatialExtentsBox(BoxLocation loc, SequentialReader sr):base(loc,sr){
+            X = sr.GetUInt32();
+            Y = sr.GetUInt32();
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemDataBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemDataBox.cs
@@ -1,0 +1,14 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemDataBox : Box
+    {
+        public byte[] Data { get; }
+
+        public ItemDataBox(BoxLocation location, SequentialReader sr) : base(location)
+        {
+            Data = ReadRemainingData(sr);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemInfoEntryBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemInfoEntryBox.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Text;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemInfoEntryBox : FullBox
+    {
+
+        public uint ItemId { get; }
+        public ushort ItemProtectionIndex { get; }
+        public string ItemName { get; } = "";
+        public string ContentType { get; } = "";
+        public string ContentEncoding { get; } = "";
+        // version 1
+        public uint ExtensionType { get; }
+        public string Location { get; } = "";
+        public string MD5 { get; } = "";
+        public ulong ContentLength { get; }
+        ulong TransferLength { get; }
+        public byte GroupIdCount { get; }
+        public uint[] GroupIds { get; } = new uint[0];
+        public uint ItemType { get; }
+        public string ItemTypeString => TypeStringConverter.ToTypeString(ItemType);
+        public string ItemUri { get; } = "";
+
+        private const uint FdelTag = 0x6664656C; // fdel
+        private const uint MimeTag = 0x6D696D65; // fdel
+        private const uint UriTag = 0x75726920; // fdel
+
+        public ItemInfoEntryBox(BoxLocation loc, SequentialReader sr) : base(loc, sr)
+        {
+            if (Version <= 1)
+            {
+                ItemId = sr.GetUInt16();
+                ItemProtectionIndex = sr.GetUInt16();
+                ItemName = sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+            }
+            if (Version == 1)
+            {
+                ExtensionType = sr.GetUInt32();
+                if (ExtensionType == FdelTag)
+                {
+                    Location = sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+                    MD5 = sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+                    ContentLength = sr.GetUInt64();
+                    TransferLength = sr.GetUInt64();
+                    GroupIdCount = sr.GetByte();
+                    GroupIds = new uint[GroupIdCount];
+                    for (int i = 0; i < GroupIdCount; i++)
+                    {
+                        GroupIds[i] = sr.GetUInt32();
+                    }
+                }
+            }
+            if (Version >= 2)
+            {
+                ItemId = Version == 2 ? sr.GetUInt16() : sr.GetUInt32();
+                ItemProtectionIndex = sr.GetUInt16();
+                ItemType = sr.GetUInt32();
+                ItemName = sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+
+                if (ItemType == MimeTag)
+                {
+                    ContentType = sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+                    ContentEncoding = sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+                }
+                if (ItemType == UriTag)
+                {
+                    ItemUri = sr.GetNullTerminatedString((int)loc.BytesLeft(sr), Encoding.UTF8);
+                }
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemInformationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemInformationBox.cs
@@ -12,5 +12,7 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
             Count = Version == 0?sr.GetUInt16():sr.GetUInt32();
             Boxes = BoxReader.BoxList(loc, sr);
         }
+        public override IEnumerable<Box> Children() => Boxes;
+
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemInformationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemInformationBox.cs
@@ -1,0 +1,16 @@
+﻿using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemInformationBox : FullBox
+    {
+        public uint Count {get;}
+        public IList<Box> Boxes { get; }
+        public ItemInformationBox(BoxLocation loc, SequentialReader sr) : base(loc, sr)
+        {
+            Count = Version == 0?sr.GetUInt16():sr.GetUInt32();
+            Boxes = BoxReader.BoxList(loc, sr);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemLocationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemLocationBox.cs
@@ -1,0 +1,121 @@
+﻿using System.IO;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemLocationBox : FullBox
+    {
+        public byte OffsetSize { get; }
+        public byte LengthSize { get; }
+        public byte BaseOffsetSize { get; }
+        public byte IndexSize { get; }
+        public uint ItemCount { get; }
+        public ItemLocation[] ItemLocations { get; }
+        public ItemLocationBox(BoxLocation loc, SequentialReader sr) : base(loc, sr)
+        {
+            var reader = new BitsReader(sr);
+            OffsetSize = reader.GetByte(4);
+            LengthSize = reader.GetByte(4);
+            BaseOffsetSize = reader.GetByte(4);
+            if (Version == 1 || Version == 2)
+            {
+                IndexSize = reader.GetByte(4);
+            }
+            else
+            {
+                reader.GetByte(4);
+            }
+
+            ItemCount = (Version < 2) ? reader.GetUInt32(16) : reader.GetUInt32(32);
+            ItemLocations = ParseLocationArray(sr);
+        }
+
+        private ItemLocation[] ParseLocationArray(SequentialReader sr)
+        {
+            var ret = new ItemLocation[ItemCount];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = ParseLocation(sr);
+            }
+
+            return ret;
+        }
+
+        private ItemLocation ParseLocation(SequentialReader sr)
+        {
+            return new ItemLocation(ReadItemNumber(sr), ReadConstructionMethod(sr), sr.GetUInt16(),
+                ReadSizedPointer(sr, BaseOffsetSize), ReadExtentList(sr));
+        }
+
+        private uint ReadItemNumber(SequentialReader sr) => Version<2?(uint)sr.GetUInt16():sr.GetUInt32();
+
+        private ConstructionMethod ReadConstructionMethod(SequentialReader sr) =>
+            (ConstructionMethod)((Version==1||Version==2)?(sr.GetUInt16()&0x0F):0);
+
+        private ulong ReadSizedPointer(SequentialReader sr, byte pointerSize) =>
+            pointerSize switch
+            {
+                0 => 0,
+                4 => sr.GetUInt32(),
+                8 => sr.GetUInt64(),
+                _ => throw new InvalidDataException("Pointer size must be 0,4,or 8 bytes")
+            };
+
+        private ItemLocationExtent[] ReadExtentList(SequentialReader sr)
+        {
+            var ret = new ItemLocationExtent[sr.GetUInt16()];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = ReadExtent(sr);
+            }
+            return ret;
+        }
+
+        private ItemLocationExtent ReadExtent(SequentialReader sr) =>
+            new ItemLocationExtent(ReadItemIndex(sr), ReadSizedPointer(sr, OffsetSize),
+                ReadSizedPointer(sr, LengthSize));
+
+        private ulong ReadItemIndex(SequentialReader sr) =>
+            (Version==1 || Version==2)?ReadSizedPointer(sr, IndexSize):0;
+    }
+
+    public enum ConstructionMethod
+    {
+        FileOffset = 0,
+        IdatOffset = 1,
+        ItemOffset = 2,
+    }
+
+    public class ItemLocation
+    {
+        public uint ItemId { get; }
+        public ConstructionMethod ConstructionMethod { get; }
+        public ushort DataReferenceIndex { get; }
+        public ulong BaseOffset { get; }
+        public ItemLocationExtent[] ExtentList { get; }
+
+        public ItemLocation(uint itemId, ConstructionMethod constructionMethod,
+            ushort dataReferenceIndex, ulong baseOffset, ItemLocationExtent[] extentList)
+        {
+            ItemId = itemId;
+            ConstructionMethod = constructionMethod;
+            DataReferenceIndex = dataReferenceIndex;
+            BaseOffset = baseOffset;
+            ExtentList = extentList;
+        }
+    }
+
+    public class ItemLocationExtent
+    {
+        public ulong ExtentIndex { get; }
+        public ulong ExtentOffset { get; }
+        public ulong ExtentLength { get; }
+
+        public ItemLocationExtent(ulong extentIndex, ulong extentOffset, ulong extentLength)
+        {
+            ExtentIndex = extentIndex;
+            ExtentOffset = extentOffset;
+            ExtentLength = extentLength;
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyAssociationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyAssociationBox.cs
@@ -1,0 +1,80 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemPropertyAssociationBox : FullBox
+    {
+        public uint EntryCount { get; }
+        public ItemPropertyAssociationEntry[] Entries;
+
+        public ItemPropertyAssociationBox(BoxLocation loc, SequentialReader sr) : base(loc, sr)
+        {
+            EntryCount = sr.GetUInt32();
+            Entries = ParseEntries(sr);
+        }
+
+        private ItemPropertyAssociationEntry[] ParseEntries(SequentialReader sr)
+        {
+            var bits = new BitsReader(sr);
+            var ret = new ItemPropertyAssociationEntry[EntryCount];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = ParseAssociationEntry(bits);
+            }
+            return ret;
+        }
+
+        private ItemPropertyAssociationEntry ParseAssociationEntry(BitsReader bits)
+        {
+            return new ItemPropertyAssociationEntry(bits.GetUInt32(ItemIndexWidth),
+                ReadAssociatedItems(bits));
+
+        }
+
+        private AssociatedProperty[] ReadAssociatedItems(BitsReader bits)
+        {
+            var ret = new AssociatedProperty[bits.GetByte(8)];
+            for (int i = 0; i < ret.Length; i++)
+            {
+                ret[i] = ParseAssociatedItem(bits);
+            }
+
+            return ret;
+        }
+
+        private AssociatedProperty ParseAssociatedItem(BitsReader bits)
+        {
+            return new AssociatedProperty(
+                bits.GetBit(),
+                bits.GetUInt16(PropertyIndexWidth));
+        }
+
+        private int ItemIndexWidth => Version<1?16:32;
+
+        private int PropertyIndexWidth => (Flags & 0x1) == 0x1 ? 15 : 7;
+    }
+
+    public class ItemPropertyAssociationEntry
+    {
+        public uint ItemId { get; }
+        public AssociatedProperty[] Properties { get; }
+
+        public ItemPropertyAssociationEntry(uint itemId, AssociatedProperty[] properties)
+        {
+            ItemId = itemId;
+            Properties = properties;
+        }
+    }
+
+    public class AssociatedProperty
+    {
+        public bool Essential { get;}
+        public ushort Index { get;}
+
+        public AssociatedProperty(bool essential, ushort index)
+        {
+            Essential = essential;
+            Index = index;
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyBox.cs
@@ -1,0 +1,15 @@
+﻿using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemPropertyBox : Box
+    {
+        public IList<Box> Boxes { get;}
+
+        public ItemPropertyBox(BoxLocation loc, SequentialReader sr):base(loc)
+        {
+            Boxes = BoxReader.BoxList(loc,sr);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyBox.cs
@@ -11,5 +11,6 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         {
             Boxes = BoxReader.BoxList(loc,sr);
         }
+        public override IEnumerable<Box> Children() => Boxes;
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyContainerBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyContainerBox.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemPropertyContainerBox:  Box
+    {
+        public IList<Box> Boxes { get; }
+        public ItemPropertyContainerBox(BoxLocation loc, SequentialReader sr): base(loc)
+        {
+            Boxes = BoxReader.BoxList(loc, sr);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyContainerBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemPropertyContainerBox.cs
@@ -10,5 +10,6 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         {
             Boxes = BoxReader.BoxList(loc, sr);
         }
+        public override IEnumerable<Box> Children() => Boxes;
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemReferenceBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemReferenceBox.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 using MetadataExtractor.IO;
 
 namespace MetadataExtractor.Formats.Heif.Iso14496Parser
@@ -12,9 +13,11 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
             var list = new List<SingleItemTypeReferenceBox>();
             Boxes = list;
             while (!loc.DoneReading(sr)) {
-                list.Add((SingleItemTypeReferenceBox)BoxReader.ReadBox(sr, (l,r)=> new SingleItemTypeReferenceBox(l,r,Version)));
+                list.Add((SingleItemTypeReferenceBox)BoxReader.ReadBox(sr,
+                    (l,r)=> new SingleItemTypeReferenceBox(l,r,Version)));
             }
         }
+        public override IEnumerable<Box> Children() => Boxes.OfType<Box>();
 
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemReferenceBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/ItemReferenceBox.cs
@@ -1,0 +1,20 @@
+﻿using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class ItemReferenceBox : FullBox
+    {
+        public IList<SingleItemTypeReferenceBox> Boxes { get; }
+
+        public ItemReferenceBox(BoxLocation loc, SequentialReader sr): base(loc, sr)
+        {
+            var list = new List<SingleItemTypeReferenceBox>();
+            Boxes = list;
+            while (!loc.DoneReading(sr)) {
+                list.Add((SingleItemTypeReferenceBox)BoxReader.ReadBox(sr, (l,r)=> new SingleItemTypeReferenceBox(l,r,Version)));
+            }
+        }
+
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/MetaBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/MetaBox.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class MetaBox: FullBox{
+        public IList<Box> Boxes{get;}
+        public MetaBox(BoxLocation loc, SequentialReader sr):base(loc, sr){
+            Boxes =  BoxReader.BoxList(loc, sr);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/MetaBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/MetaBox.cs
@@ -8,5 +8,6 @@ namespace MetadataExtractor.Formats.Heif.Iso14496Parser
         public MetaBox(BoxLocation loc, SequentialReader sr):base(loc, sr){
             Boxes =  BoxReader.BoxList(loc, sr);
         }
+        public override IEnumerable<Box> Children() => Boxes;
     }
 }

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/PixelInformationBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/PixelInformationBox.cs
@@ -1,0 +1,20 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class PixelInformationBox : FullBox
+    {
+        public byte ChannelCount { get; }
+        public byte[] BitsPerChannel { get; }
+
+        public PixelInformationBox(BoxLocation loc, SequentialReader sr) : base(loc, sr)
+        {
+            ChannelCount = sr.GetByte();
+            BitsPerChannel = new byte[ChannelCount];
+            for (int i = 0; i < BitsPerChannel.Length; i++)
+            {
+                BitsPerChannel[i] = sr.GetByte();
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/PrimaryItemBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/PrimaryItemBox.cs
@@ -1,0 +1,12 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class PrimaryItemBox: FullBox {
+        public uint PrimaryItem {get;}
+        public PrimaryItemBox(BoxLocation loc, SequentialReader sr):base(loc, sr)
+        {
+            PrimaryItem = Version == 0?sr.GetUInt16():sr.GetUInt32();	
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/SingleItemTypeReferenceBox.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/SingleItemTypeReferenceBox.cs
@@ -1,0 +1,22 @@
+﻿using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public class SingleItemTypeReferenceBox: Box{
+        public uint FromItemId{get;}
+        public ushort ReferenceCount{get;}
+        public uint[] ToItemIds{get;}
+	
+        public SingleItemTypeReferenceBox(BoxLocation loc, SequentialReader sr, byte parentVersion): base(loc)
+        {
+            FromItemId = parentVersion == 0?sr.GetUInt16():sr.GetUInt32();
+            ReferenceCount = sr.GetUInt16();
+            ToItemIds = new uint[ReferenceCount];
+            for (int i = 0; i < ReferenceCount; i++)
+            {
+                ToItemIds[i] = parentVersion == 0?sr.GetUInt16():sr.GetUInt32();
+            }
+        }
+	
+    }
+}

--- a/MetadataExtractor/Formats/Heif/Iso14496Parser/TypeStringConverter.cs
+++ b/MetadataExtractor/Formats/Heif/Iso14496Parser/TypeStringConverter.cs
@@ -1,0 +1,26 @@
+﻿namespace MetadataExtractor.Formats.Heif.Iso14496Parser
+{
+    public static class TypeStringConverter
+    {
+        public static uint ToCode(string s)
+        {
+            uint ret = 0;
+            for (int i = 0; i < 4; i++)
+            {
+                ret = ret << 8;
+                ret |= s[i];
+            }
+            return ret;
+        }
+
+        public static string ToTypeString(uint input)
+        {
+            return string.Concat(MakeChar(input >> 24), MakeChar(input >> 16), MakeChar(input >> 8), MakeChar(input));
+        }
+
+        private static char MakeChar(uint v)
+        {
+            return (char)(v & 0xFF);
+        }
+    }
+}

--- a/MetadataExtractor/Formats/QuickTime/HeifChecker.cs
+++ b/MetadataExtractor/Formats/QuickTime/HeifChecker.cs
@@ -1,0 +1,36 @@
+﻿using System.IO;
+using System.Linq;
+using MetadataExtractor.IO;
+
+namespace MetadataExtractor.Formats.QuickTime
+{
+    public static class HeifChecker
+    {
+        private static readonly uint[] heicTypes = new[]
+        {
+            0x68656963u, // heic
+            0x68656966u, // heif
+            0x68657663u, //hevc
+        };
+        public static bool IsHeicStream(Stream str)
+        {
+            try
+            {
+                str.Seek(0, SeekOrigin.Begin);
+                var reader = new SequentialStreamReader(str);
+                var fTypeLen = reader.GetUInt32();
+                while (reader.Position < fTypeLen)
+                {
+                    var candidate = reader.GetUInt32();
+                    if (heicTypes.Contains(candidate)) return true;
+                }
+
+                return false;
+            }
+            finally
+            {
+                str.Seek(0, SeekOrigin.Begin);
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -152,7 +152,7 @@ namespace MetadataExtractor.Formats.QuickTime
                             }
                             var atomType = a.Reader.GetUInt32();
 
-                            // Indexes into the metadata item keys atom are 1-based (1…entry_count).
+                            // Indexes into the metadata item keys atom are 1-based (1â€¦entry_count).
                             // atom type for each metadata item atom is the index of the key
                             if (atomType < 1 || atomType > metaDataKeys.Count)
                             {

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
@@ -18,6 +18,7 @@ namespace MetadataExtractor.Formats.QuickTime
             return fourCC switch
             {
                 "crx " => Util.FileType.Crx,
+                "heic" => Util.FileType.Heif,
                 _ => Util.FileType.QuickTime,
             };
         }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
@@ -18,7 +18,6 @@ namespace MetadataExtractor.Formats.QuickTime
             return fourCC switch
             {
                 "crx " => Util.FileType.Crx,
-                "heic" => Util.FileType.Heif,
                 _ => Util.FileType.QuickTime,
             };
         }

--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -9,6 +9,7 @@ using MetadataExtractor.Formats.Eps;
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.FileType;
 using MetadataExtractor.Formats.Gif;
+using MetadataExtractor.Formats.Heif;
 using MetadataExtractor.Formats.Ico;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Mpeg;
@@ -100,6 +101,7 @@ namespace MetadataExtractor
                 FileType.Tiff      => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Wav       => WavMetadataReader.ReadMetadata(stream),
                 FileType.WebP      => WebPMetadataReader.ReadMetadata(stream),
+                FileType.Heif      => HeifMetadataReader.ReadMetadata(stream),
 
                 FileType.Unknown   => throw new ImageProcessingException("File format could not be determined"),
                 _                  => Enumerable.Empty<Directory>()

--- a/MetadataExtractor/Util/FileType.cs
+++ b/MetadataExtractor/Util/FileType.cs
@@ -38,13 +38,13 @@ namespace MetadataExtractor.Util
 
         /// <summary>Resource Interchange File Format.</summary>
         Riff = 9,
-        
+
         /// <summary>Waveform Audio File Format.</summary>
         Wav = 10, // ("WAV", "Waveform Audio File Format", "audio/vnd.wave", "wav", "wave"),
-        
+
         /// <summary>Audio Video Interleaved.</summary>
         Avi = 11, //("AVI", "Audio Video Interleaved", "video/vnd.avi", "avi"),
-        
+
         /// <summary>WebP.</summary>
         WebP = 12, //("WebP", "WebP", "image/webp", "webp"),
 
@@ -86,7 +86,10 @@ namespace MetadataExtractor.Util
         Tga = 24,
 
         /// <summary>MPEG-1 / MPEG-2 Audio Layer III.</summary>
-        Mp3 = 25
+        Mp3 = 25,
+
+        // <summary>High Efficency Image File Format.</summary>
+        Heif = 26,
     }
 
     public static class FileTypeExtensions
@@ -118,9 +121,10 @@ namespace MetadataExtractor.Util
             "CRX",
             "EPS",
             "TGA",
-            "MP3"
+            "MP3",
+            "HEIC"
         };
-        
+
         private static readonly string[] _longNames =
         {
             "Unknown",
@@ -148,7 +152,8 @@ namespace MetadataExtractor.Util
             "Canon Camera Raw",
             "Encapsulated PostScript",
             "Truevision Graphics",
-            "MPEG Audio Layer III"
+            "MPEG Audio Layer III",
+            "High Efficiency Image File Format"
         };
 
         private static readonly string?[] _mimeTypes =
@@ -178,7 +183,8 @@ namespace MetadataExtractor.Util
             null,
             "application/postscript",
             "image/x-targa",
-            "audio/mpeg"
+            "audio/mpeg",
+            "image/heic"
         };
 
         private static readonly string[]?[] _extensions =
@@ -208,9 +214,10 @@ namespace MetadataExtractor.Util
             new[] { "cr3", "crm" },
             new[] { "eps", "epsf", "epsi" },
             new[] { "tga", "icb", "vda", "vst" },
-            new[] { "mp3" }
+            new[] { "mp3" },
+            new [] {"heic", "heif"}
         };
-        
+
         public static string GetName(this FileType fileType)
         {
             var i = (int)fileType;
@@ -218,7 +225,7 @@ namespace MetadataExtractor.Util
                 throw new ArgumentException($"Invalid {nameof(FileType)} enum member.", nameof(fileType));
             return _shortNames[i];
         }
-        
+
         public static string GetLongName(this FileType fileType)
         {
             var i = (int)fileType;
@@ -226,7 +233,7 @@ namespace MetadataExtractor.Util
                 throw new ArgumentException($"Invalid {nameof(FileType)} enum member.", nameof(fileType));
             return _longNames[i];
         }
-        
+
         public static string? GetMimeType(this FileType fileType)
         {
             var i = (int)fileType;
@@ -234,7 +241,7 @@ namespace MetadataExtractor.Util
                 throw new ArgumentException($"Invalid {nameof(FileType)} enum member.", nameof(fileType));
             return _mimeTypes[i];
         }
-        
+
         public static string? GetCommonExtension(this FileType fileType)
         {
             var i = (int)fileType;
@@ -242,7 +249,7 @@ namespace MetadataExtractor.Util
                 throw new ArgumentException($"Invalid {nameof(FileType)} enum member.", nameof(fileType));
             return _extensions[i]?.FirstOrDefault();
         }
-        
+
         public static IEnumerable<string>? GetAllExtensions(this FileType fileType)
         {
             var i = (int)fileType;

--- a/MetadataExtractor/Util/FileType.cs
+++ b/MetadataExtractor/Util/FileType.cs
@@ -215,7 +215,7 @@ namespace MetadataExtractor.Util
             new[] { "eps", "epsf", "epsi" },
             new[] { "tga", "icb", "vda", "vst" },
             new[] { "mp3" },
-            new [] {"heic", "heif"}
+            new [] {"heic", "heif", "avci"}
         };
 
         public static string GetName(this FileType fileType)

--- a/MetadataExtractor/Util/FileTypeDetector.cs
+++ b/MetadataExtractor/Util/FileTypeDetector.cs
@@ -103,6 +103,8 @@ namespace MetadataExtractor.Util
                     if (bytesRead >= fixedChecker.ByteCount)
                     {
                         fileType = fixedChecker.CheckType(bytes);
+                        if (fileType == FileType.QuickTime && HeifChecker.IsHeicStream(stream))
+                            return FileType.Heif;
                         if (fileType != FileType.Unknown)
                             return fileType;
                     }


### PR DESCRIPTION
[NB.  This is my first pull request ever -- on any project.  My Apologies in advance if I have done it incorrectly.]

This is a large pull request, but the vast majority of the code is new code to parse the ISOBFF box format.  (Including a variety of minor modifications Apple made in the HEIC format)

I ran the regression test against the image database and the only regressions occur in HEIC files (which used to be incorrectly identified as quicktime files.]  All of the diff outputs appear to be appropriate changes incidental to parsing HEIC files.  Notably a few of the files which cause errors in the Java version now parse to errors instead of being incorrectly recognized as valid quicktime files.

I also downloaded the Nokia HEIC conformance images, which I did not add to the repository for copyright concerns.  The software correctly parses all of the images in the Nokia conformance set with no errors and rational appearing output for each file.

Here is the diff from the regression test'

    diff --git a/heic/metadata/dotnet/IMG_1034.heic.txt b/heic/metadata/dotnet/IMG_1034.heic.txt
    index b101efc6..742f87d1 100644
    --- a/heic/metadata/dotnet/IMG_1034.heic.txt
    +++ b/heic/metadata/dotnet/IMG_1034.heic.txt
    @@ -1,20 +1,196 @@
     FILE: IMG_1034.heic
    -TYPE: QUICKTIME
    +TYPE: HEIF
    
     [QuickTime File Type - 0x0001] Major Brand = heic
    -[QuickTime File Type - 0x0002] Minor Version = 0
     [QuickTime File Type - 0x0003] Compatible Brands = mif1, heic
    
    -[File Type - 0x0001] Detected File Type Name = QuickTime
    -[File Type - 0x0002] Detected File Type Long Name = QuickTime
    -[File Type - 0x0003] Detected MIME Type = video/quicktime
    -[File Type - 0x0004] Expected File Name Extension = mov
    +[HEIC Primary Item Properties - 0x0001] Image Width = 4032
    +[HEIC Primary Item Properties - 0x0002] Image Height = 3024
    +[HEIC Primary Item Properties - 0x0003] Default Rotation = 0 degrees
    +[HEIC Primary Item Properties - 0x0004] Pixel Depth in Bits = 8 8 8
    +[HEIC Primary Item Properties - 0x0018] Color Data Format = prof
    +[HEIC Primary Item Properties - 0x0005] HEVC Configuration Version = 1
    +[HEIC Primary Item Properties - 0x0006] General Profile Space = 0
    +[HEIC Primary Item Properties - 0x0007] General Tiler Tag = 0
    +[HEIC Primary Item Properties - 0x0008] General Profile = 3
    +[HEIC Primary Item Properties - 0x0009] General Profile Compatibility = 1879048192
    +[HEIC Primary Item Properties - 0x000a] General Level = 90
    +[HEIC Primary Item Properties - 0x000b] Minimum Spacial Segmentation = 0
    +[HEIC Primary Item Properties - 0x000c] Parallelism Type = 0
    +[HEIC Primary Item Properties - 0x000d] Chroma Format = 1
    +[HEIC Primary Item Properties - 0x000e] Luma Bit Depth = 8
    +[HEIC Primary Item Properties - 0x000f] Chroma Bit Depth = 8
    +[HEIC Primary Item Properties - 0x0010] Average Frame Rate = 0
    +[HEIC Primary Item Properties - 0x0011] Constant Frame Rate = 0
    +[HEIC Primary Item Properties - 0x0012] Number of Temporal Layers = 1
    +[HEIC Primary Item Properties - 0x0013] Length or Size = 4
    +
    +[ICC Profile - 0x0000] Profile Size = 548
    +[ICC Profile - 0x0004] CMM Type = appl
    +[ICC Profile - 0x0008] Version = 4.0.0
    +[ICC Profile - 0x000c] Class = Display Device
    +[ICC Profile - 0x0010] Color space = RGB
    +[ICC Profile - 0x0014] Profile Connection Space = XYZ
    +[ICC Profile - 0x0018] Profile Date/Time = 2017:07:07 13:22:32
    +[ICC Profile - 0x0024] Signature = acsp
    +[ICC Profile - 0x0028] Primary Platform = Apple Computer, Inc.
    +[ICC Profile - 0x0030] Device manufacturer = APPL
    +[ICC Profile - 0x0044] XYZ values = 0.964 1 0.825
    +[ICC Profile - 0x0080] Tag Count = 10
    +[ICC Profile - 0x64657363] Profile Description = Display P3
    +[ICC Profile - 0x63707274] Copyright = Copyright Apple Inc., 2017
    +[ICC Profile - 0x77747074] Media White Point = (0.9505, 1, 1.0891)
    +[ICC Profile - 0x7258595a] Red Colorant = (0.5151, 0.2412, 65536)
    +[ICC Profile - 0x6758595a] Green Colorant = (0.292, 0.6922, 0.0419)
    +[ICC Profile - 0x6258595a] Blue Colorant = (0.1571, 0.0666, 0.7841)
    +[ICC Profile - 0x72545243] Red TRC = para (0x70617261): 32 bytes
    +[ICC Profile - 0x63686164] Chromatic Adaptation = sf32 (0x73663332): 44 bytes
    +[ICC Profile - 0x62545243] Blue TRC = para (0x70617261): 32 bytes
    +[ICC Profile - 0x67545243] Green TRC = para (0x70617261): 32 bytes
    +
    +[HEIC Thumbnail Properties - 0x0018] Color Data Format = prof
    +[HEIC Thumbnail Properties - 0x0005] HEVC Configuration Version = 1
    +[HEIC Thumbnail Properties - 0x0006] General Profile Space = 0
    +[HEIC Thumbnail Properties - 0x0007] General Tiler Tag = 0
    +[HEIC Thumbnail Properties - 0x0008] General Profile = 3
    +[HEIC Thumbnail Properties - 0x0009] General Profile Compatibility = 1879048192
    +[HEIC Thumbnail Properties - 0x000a] General Level = 60
    +[HEIC Thumbnail Properties - 0x000b] Minimum Spacial Segmentation = 0
    +[HEIC Thumbnail Properties - 0x000c] Parallelism Type = 0
    +[HEIC Thumbnail Properties - 0x000d] Chroma Format = 1
    +[HEIC Thumbnail Properties - 0x000e] Luma Bit Depth = 8
    +[HEIC Thumbnail Properties - 0x000f] Chroma Bit Depth = 8
    +[HEIC Thumbnail Properties - 0x0010] Average Frame Rate = 0
    +[HEIC Thumbnail Properties - 0x0011] Constant Frame Rate = 0
    +[HEIC Thumbnail Properties - 0x0012] Number of Temporal Layers = 1
    +[HEIC Thumbnail Properties - 0x0013] Length or Size = 4
    +[HEIC Thumbnail Properties - 0x0001] Image Width = 320
    +[HEIC Thumbnail Properties - 0x0002] Image Height = 240
    +[HEIC Thumbnail Properties - 0x0003] Default Rotation = 0 degrees
    +[HEIC Thumbnail Properties - 0x0004] Pixel Depth in Bits = 8 8 8
    +
    +[ICC Profile - 0x0000] Profile Size = 548
    +[ICC Profile - 0x0004] CMM Type = appl
    +[ICC Profile - 0x0008] Version = 4.0.0
    +[ICC Profile - 0x000c] Class = Display Device
    +[ICC Profile - 0x0010] Color space = RGB
    +[ICC Profile - 0x0014] Profile Connection Space = XYZ
    +[ICC Profile - 0x0018] Profile Date/Time = 2017:07:07 13:22:32
    +[ICC Profile - 0x0024] Signature = acsp
    +[ICC Profile - 0x0028] Primary Platform = Apple Computer, Inc.
    +[ICC Profile - 0x0030] Device manufacturer = APPL
    +[ICC Profile - 0x0044] XYZ values = 0.964 1 0.825
    +[ICC Profile - 0x0080] Tag Count = 10
    +[ICC Profile - 0x64657363] Profile Description = Display P3
    +[ICC Profile - 0x63707274] Copyright = Copyright Apple Inc., 2017
    +[ICC Profile - 0x77747074] Media White Point = (0.9505, 1, 1.0891)
    +[ICC Profile - 0x7258595a] Red Colorant = (0.5151, 0.2412, 65536)
    +[ICC Profile - 0x6758595a] Green Colorant = (0.292, 0.6922, 0.0419)
    +[ICC Profile - 0x6258595a] Blue Colorant = (0.1571, 0.0666, 0.7841)
    +[ICC Profile - 0x72545243] Red TRC = para (0x70617261): 32 bytes
    +[ICC Profile - 0x63686164] Chromatic Adaptation = sf32 (0x73663332): 44 bytes
    +[ICC Profile - 0x62545243] Blue TRC = para (0x70617261): 32 bytes
    +[ICC Profile - 0x67545243] Green TRC = para (0x70617261): 32 bytes
    +
    +[HEIC Thumbnail Data - 0x0001] Offset From Beginning of File = 3996
    +[HEIC Thumbnail Data - 0x0002] Data Length = 14957
    +
    +[Exif IFD0 - 0x010f] Make = Apple
    +[Exif IFD0 - 0x0110] Model = iPhone 8
    +[Exif IFD0 - 0x0112] Orientation = Top, left side (Horizontal / normal)
    +[Exif IFD0 - 0x011a] X Resolution = 72 dots per inch
    +[Exif IFD0 - 0x011b] Y Resolution = 72 dots per inch
    +[Exif IFD0 - 0x0128] Resolution Unit = Inch
    +[Exif IFD0 - 0x0131] Software = 11.2.2
    +[Exif IFD0 - 0x0132] Date/Time = 2018:02:05 15:11:44
    +[Exif IFD0 - 0x0213] YCbCr Positioning = Center of pixel array
    +
    +[Exif SubIFD - 0x829a] Exposure Time = 1/17 sec
    +[Exif SubIFD - 0x829d] F-Number = f/1.8
    +[Exif SubIFD - 0x8822] Exposure Program = Program normal
    +[Exif SubIFD - 0x8827] ISO Speed Ratings = 80
    +[Exif SubIFD - 0x9000] Exif Version = 2.21
    +[Exif SubIFD - 0x9003] Date/Time Original = 2018:02:05 15:11:44
    +[Exif SubIFD - 0x9004] Date/Time Digitized = 2018:02:05 15:11:44
    +[Exif SubIFD - 0x9101] Components Configuration = YCbCr
    +[Exif SubIFD - 0x9201] Shutter Speed Value = 1/16 sec
    +[Exif SubIFD - 0x9202] Aperture Value = f/1.8
    +[Exif SubIFD - 0x9203] Brightness Value = 1.448
    +[Exif SubIFD - 0x9204] Exposure Bias Value = 0 EV
    +[Exif SubIFD - 0x9207] Metering Mode = Multi-segment
    +[Exif SubIFD - 0x9209] Flash = Flash did not fire
    +[Exif SubIFD - 0x920a] Focal Length = 4 mm
    +[Exif SubIFD - 0x9214] Subject Location = 2015 1511 2217 1330
    +[Exif SubIFD - 0x9291] Sub-Sec Time Original = 277
    +[Exif SubIFD - 0x9292] Sub-Sec Time Digitized = 277
    +[Exif SubIFD - 0xa000] FlashPix Version = 1.00
    +[Exif SubIFD - 0xa001] Color Space = Undefined
    +[Exif SubIFD - 0xa002] Exif Image Width = 4032 pixels
    +[Exif SubIFD - 0xa003] Exif Image Height = 3024 pixels
    +[Exif SubIFD - 0xa217] Sensing Method = One-chip color area sensor
    +[Exif SubIFD - 0xa301] Scene Type = Directly photographed image
    +[Exif SubIFD - 0xa402] Exposure Mode = Auto exposure
    +[Exif SubIFD - 0xa403] White Balance Mode = Auto white balance
    +[Exif SubIFD - 0xa405] Focal Length 35 = 28 mm
    +[Exif SubIFD - 0xa406] Scene Capture Type = Standard
    +[Exif SubIFD - 0xa432] Lens Specification = 3.99mm f/1.8
    +[Exif SubIFD - 0xa433] Lens Make = Apple
    +[Exif SubIFD - 0xa434] Lens Model = iPhone 8 back camera 3.99mm f/1.8
    +
    +[Apple Makernote - 0x0001] Unknown tag (0x0001) = 9
    +[Apple Makernote - 0x0002] Unknown tag (0x0002) = [558 values]
    +[Apple Makernote - 0x0003] Run Time = [104 values]
    +[Apple Makernote - 0x0004] Unknown tag (0x0004) = 1
    +[Apple Makernote - 0x0005] Unknown tag (0x0005) = 172
    +[Apple Makernote - 0x0006] Unknown tag (0x0006) = 170
    +[Apple Makernote - 0x0007] Unknown tag (0x0007) = 1
    +[Apple Makernote - 0x0008] Unknown tag (0x0008) = -1085/1163 524/48363 -9136/26097
    +[Apple Makernote - 0x000c] Unknown tag (0x000c) = 5817/256 2965/64
    +[Apple Makernote - 0x000d] Unknown tag (0x000d) = 22
    +[Apple Makernote - 0x000e] Unknown tag (0x000e) = 0
    +[Apple Makernote - 0x000f] Unknown tag (0x000f) = 2
    +[Apple Makernote - 0x0010] Unknown tag (0x0010) = 1
    +[Apple Makernote - 0x0014] Unknown tag (0x0014) = 5
    +[Apple Makernote - 0x0017] Unknown tag (0x0017) = 8192
    +[Apple Makernote - 0x0019] Unknown tag (0x0019) = 0
    +[Apple Makernote - 0x001a] Unknown tag (0x001a) = q825s
    +[Apple Makernote - 0x001f] Unknown tag (0x001f) = 0
    +
    +[GPS - 0x0001] GPS Latitude Ref = N
    +[GPS - 0x0002] GPS Latitude = 23<C2><B0> 10' 40.5"
    +[GPS - 0x0003] GPS Longitude Ref = E
    +[GPS - 0x0004] GPS Longitude = 113 < C2 >< B0 > 23' 39.54"
       +[GPS - 0x0005] GPS Altitude Ref = Sea level
       +[GPS - 0x0006] GPS Altitude = 42.81 metres
       +[GPS - 0x0007] GPS Time-Stamp = 07:11:43.070 UTC
       +[GPS - 0x000c] GPS Speed Ref = km / h
       +[GPS - 0x000d] GPS Speed = 0 km / h
       +[GPS - 0x0010] GPS Img Direction Ref = True direction
       +[GPS - 0x0011] GPS Img Direction = 25.27 degrees
       +[GPS - 0x0017] GPS Dest Bearing Ref = True direction
       +[GPS - 0x0018] GPS Dest Bearing = 25.27 degrees
       +[GPS - 0x001d] GPS Date Stamp = 2018:02:05
       +[GPS - 0x001f] GPS Horizontal Positioning Error = 65 metres
       +
       +[File Type - 0x0001] Detected File Type Name = HEIC
       +[File Type - 0x0002] Detected File Type Long Name = High Efficiency Image File Format
    +[File Type - 0x0003] Detected MIME Type = image / heic
    +[File Type - 0x0004] Expected File Name Extension = heic
    
     [File - 0x0001] File Name = IMG_1034.heic
     [File - 0x0002] File Size = 1499892 bytes
     [File - 0x0003] File Modified Date = < omitted for regression testing as checkout dependent >
    
      -QuickTime File Type
     + -HEIC Primary Item Properties
     + -ICC Profile
     + -HEIC Thumbnail Properties
     + -ICC Profile
     + -HEIC Thumbnail Data
     + -Exif IFD0
     + -Exif SubIFD
     + -Apple Makernote
     + -GPS
      - File Type
      - File
     
    
     diff--git a / heic / metadata / dotnet / IllegalArgumentException.HeifReader.processBoxes.heif.txt b / heic / metadata / dotnet / IllegalArgumentException.HeifReader.processBoxes.heif.txt
     index 6314ca5f..c2aabbee 100644
     -- - a / heic / metadata / dotnet / IllegalArgumentException.HeifReader.processBoxes.heif.txt
     ++ + b / heic / metadata / dotnet / IllegalArgumentException.HeifReader.processBoxes.heif.txt
    @@ -1, 22 + 1, 7 @@
    
      FILE: IllegalArgumentException.HeifReader.processBoxes.heif
     - TYPE: QUICKTIME
     + TYPE: HEIF
    
     -[QuickTime File Type - 0x0001] Major Brand = mif1
     -[QuickTime File Type - 0x0002] Minor Version = 0
     -[QuickTime File Type - 0x0003] Compatible Brands = mif1, heic
     -
     -[File Type - 0x0001] Detected File Type Name = QuickTime
     -[File Type - 0x0002] Detected File Type Long Name = QuickTime
     -[File Type - 0x0003] Detected MIME Type = video / quicktime
     -[File Type - 0x0004] Expected File Name Extension = mov
     -
     -[File - 0x0001] File Name = IllegalArgumentException.HeifReader.processBoxes.heif
     -[File - 0x0002] File Size = 8195 bytes
     -[File - 0x0003] File Modified Date = < omitted for regression testing as checkout dependent >
      -
      --QuickTime File Type
      -- File Type
      -- File
      + EXCEPTION: Pointer size must be 0, 4, or 8 bytes
      
    
       Generated using metadata-extractor
     https://drewnoakes.com/code/exif/
    diff--git a/ heic / metadata / dotnet / NegativeArraySizeException.HeifReader.processBoxes.heif.txt b / heic / metadata / dotnet / NegativeArraySizeException.HeifReader.processBoxes.heif.txt
    index 66466a5d..282609d2 100644
    -- - a / heic / metadata / dotnet / NegativeArraySizeException.HeifReader.processBoxes.heif.txt
    ++ + b / heic / metadata / dotnet / NegativeArraySizeException.HeifReader.processBoxes.heif.txt
    @@ -1,22 + 1,7 @@
     FILE: NegativeArraySizeException.HeifReader.processBoxes.heif
    - TYPE: QUICKTIME
     + TYPE: HEIF
    
      -[QuickTime File Type - 0x0001] Major Brand = mif1
      -[QuickTime File Type - 0x0002] Minor Version = 0
      -[QuickTime File Type - 0x0003] Compatible Brands = mif1, heic
    -
    -[File Type - 0x0001] Detected File Type Name = QuickTime
    -[File Type - 0x0002] Detected File Type Long Name = QuickTime
    -[File Type - 0x0003] Detected MIME Type = video / quicktime
    -[File Type - 0x0004] Expected File Name Extension = mov
    -
    -[File - 0x0001] File Name = NegativeArraySizeException.HeifReader.processBoxes.heif
    -[File - 0x0002] File Size = 41389 bytes
    -[File - 0x0003] File Modified Date = < omitted for regression testing as checkout dependent >
     -
     --QuickTime File Type
     -- File Type
     -- File
     + EXCEPTION: n must be zero or greater.
    
      Generated using metadata-extractor
     https://drewnoakes.com/code/exif/
    diff--git a/ heic / metadata / dotnet / NegativeArraySizeException.ItemInfoBox.init.heif.txt b / heic / metadata / dotnet / NegativeArraySizeException.ItemInfoBox.init.heif.txt
    index d0f0d5b4..f8ff9862 100644
    -- - a / heic / metadata / dotnet / NegativeArraySizeException.ItemInfoBox.init.heif.txt
    ++ + b / heic / metadata / dotnet / NegativeArraySizeException.ItemInfoBox.init.heif.txt
    @@ -1,22 + 1,7 @@
     FILE: NegativeArraySizeException.ItemInfoBox.init.heif
    - TYPE: QUICKTIME
     + TYPE: HEIF
    
      -[QuickTime File Type - 0x0001] Major Brand = mif1
      -[QuickTime File Type - 0x0002] Minor Version = 0
      -[QuickTime File Type - 0x0003] Compatible Brands = mif1, heic
    -
    -[File Type - 0x0001] Detected File Type Name = QuickTime
    -[File Type - 0x0002] Detected File Type Long Name = QuickTime
    -[File Type - 0x0003] Detected MIME Type = video / quicktime
    -[File Type - 0x0004] Expected File Name Extension = mov
    -
    -[File - 0x0001] File Name = NegativeArraySizeException.ItemInfoBox.init.heif
    -[File - 0x0002] File Size = 41389 bytes
    -[File - 0x0003] File Modified Date = < omitted for regression testing as checkout dependent >
     -
     --QuickTime File Type
     -- File Type
     -- File
     + EXCEPTION: n must be zero or greater.
    
      Generated using metadata-extractor
     https://drewnoakes.com/code/exif/
    diff--git a/ heic / metadata / dotnet / NullPointerException.HeifPictureHandler.processBox.heif.txt b / heic / metadata / dotnet / NullPointerException.HeifPictureHandler.processBox.heif.txt
    index 1083bb3b..30485ca5 100644
    -- - a / heic / metadata / dotnet / NullPointerException.HeifPictureHandler.processBox.heif.txt
    ++ + b / heic / metadata / dotnet / NullPointerException.HeifPictureHandler.processBox.heif.txt
    @@ -1,22 + 1,7 @@
     FILE: NullPointerException.HeifPictureHandler.processBox.heif
    - TYPE: QUICKTIME
     + TYPE: HEIF
    
      -[QuickTime File Type - 0x0001] Major Brand = mif1
      -[QuickTime File Type - 0x0002] Minor Version = 0
      -[QuickTime File Type - 0x0003] Compatible Brands = mif1, heic
    -
    -[File Type - 0x0001] Detected File Type Name = QuickTime
    -[File Type - 0x0002] Detected File Type Long Name = QuickTime
    -[File Type - 0x0003] Detected MIME Type = video / quicktime
    -[File Type - 0x0004] Expected File Name Extension = mov
    -
    -[File - 0x0001] File Name = NullPointerException.HeifPictureHandler.processBox.heif
    -[File - 0x0002] File Size = 41389 bytes
    -[File - 0x0003] File Modified Date = < omitted for regression testing as checkout dependent >
     -
     --QuickTime File Type
     -- File Type
     -- File
     + EXCEPTION: Sequence contains no matching element
     
    
      Generated using metadata-extractor
     https://drewnoakes.com/code/exif/
    diff--git a/ heic / metadata / dotnet / cheers_1440x960.heic.txt b / heic / metadata / dotnet / cheers_1440x960.heic.txt
    index aa67d977..16d8d7d7 100644
    -- - a / heic / metadata / dotnet / cheers_1440x960.heic.txt
    ++ + b / heic / metadata / dotnet / cheers_1440x960.heic.txt
    @@ -1,20 + 1,61 @@
     FILE: cheers_1440x960.heic
    - TYPE: QUICKTIME
     + TYPE: HEIF
    
       [QuickTime File Type - 0x0001] Major Brand = mif1
      -[QuickTime File Type - 0x0002] Minor Version = 0
       [QuickTime File Type - 0x0003] Compatible Brands = mif1, heic
    
    -[File Type - 0x0001] Detected File Type Name = QuickTime
    -[File Type - 0x0002] Detected File Type Long Name = QuickTime
    -[File Type - 0x0003] Detected MIME Type = video / quicktime
    -[File Type - 0x0004] Expected File Name Extension = mov
    +[HEIC Primary Item Properties - 0x0005] HEVC Configuration Version = 1
    +[HEIC Primary Item Properties - 0x0006] General Profile Space = 0
    +[HEIC Primary Item Properties - 0x0007] General Tiler Tag = 0
    +[HEIC Primary Item Properties - 0x0008] General Profile = 1
    +[HEIC Primary Item Properties - 0x0009] General Profile Compatibility = 1610612736
    +[HEIC Primary Item Properties - 0x000a] General Level = 186
    +[HEIC Primary Item Properties - 0x000b] Minimum Spacial Segmentation = 0
    +[HEIC Primary Item Properties - 0x000c] Parallelism Type = 0
    +[HEIC Primary Item Properties - 0x000d] Chroma Format = 1
    +[HEIC Primary Item Properties - 0x000e] Luma Bit Depth = 8
    +[HEIC Primary Item Properties - 0x000f] Chroma Bit Depth = 8
    +[HEIC Primary Item Properties - 0x0010] Average Frame Rate = 0
    +[HEIC Primary Item Properties - 0x0011] Constant Frame Rate = 0
    +[HEIC Primary Item Properties - 0x0012] Number of Temporal Layers = 1
    +[HEIC Primary Item Properties - 0x0013] Length or Size = 4
    +[HEIC Primary Item Properties - 0x0001] Image Width = 1440
    +[HEIC Primary Item Properties - 0x0002] Image Height = 960
    +
    +[HEIC Thumbnail Properties - 0x0005] HEVC Configuration Version = 1
    +[HEIC Thumbnail Properties - 0x0006] General Profile Space = 0
    +[HEIC Thumbnail Properties - 0x0007] General Tiler Tag = 0
    +[HEIC Thumbnail Properties - 0x0008] General Profile = 1
    +[HEIC Thumbnail Properties - 0x0009] General Profile Compatibility = 1610612736
    +[HEIC Thumbnail Properties - 0x000a] General Level = 186
    +[HEIC Thumbnail Properties - 0x000b] Minimum Spacial Segmentation = 0
    +[HEIC Thumbnail Properties - 0x000c] Parallelism Type = 0
    +[HEIC Thumbnail Properties - 0x000d] Chroma Format = 1
    +[HEIC Thumbnail Properties - 0x000e] Luma Bit Depth = 8
    +[HEIC Thumbnail Properties - 0x000f] Chroma Bit Depth = 8
    +[HEIC Thumbnail Properties - 0x0010] Average Frame Rate = 0
    +[HEIC Thumbnail Properties - 0x0011] Constant Frame Rate = 0
    +[HEIC Thumbnail Properties - 0x0012] Number of Temporal Layers = 1
    +[HEIC Thumbnail Properties - 0x0013] Length or Size = 4
    +[HEIC Thumbnail Properties - 0x0001] Image Width = 240
    +[HEIC Thumbnail Properties - 0x0002] Image Height = 160
    +
    +[HEIC Thumbnail Data - 0x0001] Offset From Beginning of File = 38467
    +[HEIC Thumbnail Data - 0x0002] Data Length = 2922
    +
    +[File Type - 0x0001] Detected File Type Name = HEIC
    +[File Type - 0x0002] Detected File Type Long Name = High Efficiency Image File Format
    +[File Type - 0x0003] Detected MIME Type = image / heic
    +[File Type - 0x0004] Expected File Name Extension = heic
    
     [File - 0x0001] File Name = cheers_1440x960.heic
     [File - 0x0002] File Size = 41389 bytes
     [File - 0x0003] File Modified Date = < omitted for regression testing as checkout dependent >
    
      -QuickTime File Type
     + -HEIC Primary Item Properties
     + -HEIC Thumbnail Properties
     + -HEIC Thumbnail Data
      - File Type
      - File
    
     (END)                       '                                                                                                                                                                                                                