### PR TITLE
Update QuickTimeMetadataReader.cs

### DIFF
--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -120,6 +120,23 @@ namespace MetadataExtractor.Formats.QuickTime
                 }
             }
 
+            void UserDataHandler(AtomCallbackArgs a)
+            {
+                switch (a.TypeString)
+                {
+                    case "?xyz":
+                        var directory = new QuickTimeMetadataHeaderDirectory();
+                        var stringSize = a.Reader.GetUInt16();
+                        var languageCode = a.Reader.GetUInt16();
+                        var stringValue = a.Reader.GetBytes(stringSize);
+                        var s = Encoding.UTF8.GetString(stringValue);
+
+                        directory.Set(QuickTimeMetadataHeaderDirectory.TagGpsLocation, s);
+                        directories.Add(directory);
+                        break;
+                }
+            }
+
             void MetaDataHandler(AtomCallbackArgs a)
             {
                 // see https://developer.apple.com/library/archive/documentation/QuickTime/QTFF/Metadata/Metadata.html
@@ -247,6 +264,11 @@ namespace MetadataExtractor.Formats.QuickTime
                     case "meta":
                     {
                         QuickTimeReader.ProcessAtoms(stream, MetaDataHandler, a.BytesLeft);
+                        break;
+                    }
+                    case "udta":
+                    {
+                        QuickTimeReader.ProcessAtoms(stream, UserDataHandler, a.BytesLeft);
                         break;
                     }
                     /*


### PR DESCRIPTION
We've found that MetadataExtractor isn't seeing GPS location in Android recorded video files.

I found that GPS is stored in 'udta' atom in these files, and parsing it out into metadata solved our issue.