### PR TITLE
- Added the xmp directory in HEIF format (iso-14496).

### DIFF
--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -48,6 +48,7 @@ namespace MetadataExtractor.Formats.Heif
 
             if (stream.CanSeek)
             {
+                stream.Seek(0, SeekOrigin.Begin);
                 ParseItemSegments();
             }
 
@@ -231,7 +232,8 @@ namespace MetadataExtractor.Formats.Heif
                                 Info = information.Boxes.OfType<ItemInfoEntryBox>().First(j => j.ItemId == i.FromItemId),
                                 Location = locations.ItemLocations.First(j => j.ItemId == i.FromItemId)
                             })
-                    .OrderBy(i => i.Location.BaseOffset);
+                    .OrderBy(i => i.Location.BaseOffset)
+                    .ThenBy(i => i.Location.ExtentList.FirstOrDefault()?.ExtentOffset);
 
                 foreach (var segment in segments)
                 {

--- a/MetadataExtractor/Formats/Iso14496/BoxTypes.cs
+++ b/MetadataExtractor/Formats/Iso14496/BoxTypes.cs
@@ -29,5 +29,6 @@ namespace MetadataExtractor.Formats.Iso14496
         public const uint ThmbTag = 0x74686D62; // thmb
         public const uint CdscTag = 0x63647363; // cdsc
         public const uint DimgTag = 0x64696D67; // dimg
+        public const uint MimeTag = 0x6D696D65;
     }
 }


### PR DESCRIPTION
- Added the xmp directory in HEIF format (iso-14496). Related to issue #231.
- Fixed a bug where under certain circumstances, the bytes of the exif directory were extended to the next box.
- Fixed an unknown issue when the segments to be parsed start before last position after reading all boxes. Reordered segments bassed on extended offset, not only base offset, so the read will always be in sequential order. This last change fixes the exception thrown in the image file heic/Issue 487.heic.
