### PR TITLE
Added quick time metadata with no default locale.

### DIFF
--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -177,14 +177,8 @@ namespace MetadataExtractor.Formats.QuickTime
                                 a.Reader.Skip(atomSize - 20);
                                 continue;
                             }
-                            // Currently only the Default Country/Locale is supported
-                            var dataLocaleIndicator = a.Reader.GetUInt32();
-                            if (dataLocaleIndicator != 0)
-                            {
-                                directory.AddError($"Unsupported locale indicator \"{dataLocaleIndicator}\" for key \"{key}\"");
-                                a.Reader.Skip(atomSize - 24);
-                                continue;
-                            }
+                            // locale not supported yet.
+                            a.Reader.Skip(4);
                             var data = a.Reader.GetBytes((int)atomSize - 24);
                             if (directory.TryGetTag(key, out int tag))
                             {


### PR DESCRIPTION
Removed the limitation of only default locale is supported. Now, all fields are retrieved, but without locale tag. This should be supported in future. For now, at least, we have the description metadata, which is useful for blind people, I.E., in Apple iPhone, when users labeled the pictures with Voice Over.