### PR TITLE
Culture sensitivity

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -222,10 +222,10 @@ dotnet_diagnostic.CA1303.severity = none                          # Literal stri
 # working around bug
 dotnet_diagnostic.RS0041.severity = none                          # Public members should not use oblivious types
 
-# TODO review these diagnostics as many/all are probably valid
-dotnet_diagnostic.CA1304.severity = none                          # Method behaviour depends upon user's locale
-dotnet_diagnostic.CA1305.severity = none                          # Method behaviour depends upon user's locale
-dotnet_diagnostic.CA1307.severity = none                          # Method behaviour depends upon user's locale
+# TODO review these diagnostics as many/all are probably valid, keep current output behavior (english text with localized numbers)
+dotnet_diagnostic.CA1304.severity = none                          # Method behaviour depends upon user's locale (specify CultureInfo f.e. ToLower())
+dotnet_diagnostic.CA1305.severity = none                          # Method behaviour depends upon user's locale (specify IFormatProvider f.e. ToString())
+dotnet_diagnostic.CA1307.severity = none                          # Method behaviour depends upon user's locale (specify StringComparison f.e. StartsWith(), Equals())
 
 # TODO fix these
 dotnet_diagnostic.CA1825.severity = none                          # Avoid unnecessary zero-length array allocations

--- a/MetadataExtractor.Tests/DirectoryTest.cs
+++ b/MetadataExtractor.Tests/DirectoryTest.cs
@@ -2,6 +2,7 @@
 
 using System;
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using MetadataExtractor.Formats.Exif;
 using Xunit;
@@ -103,9 +104,12 @@ namespace MetadataExtractor.Tests
         [InlineData("2002-01-30",                    2002, 1, 30,  0,  0,  0,  0, DateTimeKind.Unspecified)]
         [InlineData("2002-01",                       2002, 1,  1,  0,  0,  0,  0, DateTimeKind.Unspecified)]
         [InlineData("2002",                          2002, 1,  1,  0,  0,  0,  0, DateTimeKind.Unspecified)]
+        [InlineData("2002-01-30T23:59:59.099-08:00", 2002, 1, 31,  7, 59, 59, 99, DateTimeKind.Utc, "ar")]
 #pragma warning restore format
-        public void SetStringAndGetDate(string str, int year, int month, int day, int hour, int minute, int second, int milli, DateTimeKind kind)
+        public void SetStringAndGetDate(string str, int year, int month, int day, int hour, int minute, int second, int milli, DateTimeKind kind, string? culture = null)
         {
+            CultureInfo.CurrentCulture = string.IsNullOrWhiteSpace(culture) ? CultureInfo.CurrentCulture : CultureInfo.GetCultureInfo(culture);
+
             _directory.Set(1, str);
 
             var expected = new DateTime(year, month, day, hour, minute, second, milli, kind);

--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -662,7 +662,7 @@ namespace MetadataExtractor
 
             if (s != null)
             {
-                if (DateTime.TryParseExact(s, _datePatterns, null, DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AdjustToUniversal, out dateTime))
+                if (DateTime.TryParseExact(s, _datePatterns, CultureInfo.InvariantCulture, DateTimeStyles.AllowWhiteSpaces | DateTimeStyles.AdjustToUniversal, out dateTime))
                 {
                     return true;
                 }


### PR DESCRIPTION
Closes #138

There are still some string concatenation that do not use an invariant output format. But the main points of the issue are fixed.