### PR TITLE
Rename ICC Profile Copyright tag

### DIFF
--- a/MetadataExtractor/Formats/Icc/IccDirectory.cs
+++ b/MetadataExtractor/Formats/Icc/IccDirectory.cs
@@ -115,7 +115,7 @@ namespace MetadataExtractor.Formats.Icc
             { TagTagTarg, "Char Target" },
             { TagTagChad, "Chromatic Adaptation" },
             { TagTagChrm, "Chromaticity" },
-            { TagTagCprt, "Copyright" },
+            { TagTagCprt, "Profile Copyright" },
             { TagTagCrdi, "CrdInfo" },
             { TagTagDmnd, "Device Mfg Description" },
             { TagTagDmdd, "Device Model Description" },


### PR DESCRIPTION
This is the copyright of the profile. The new name makes it clear what the copyright applies to and more closely matches other tag names in the ICC directory.