### PR TITLE
Fix unsigned comparison

### DIFF
--- a/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
@@ -49,7 +49,7 @@ namespace MetadataExtractor.Formats.Photoshop
                     if (tag == 0)
                         break;
 
-                    var length = reader.GetUInt16();
+                    int length = reader.GetUInt16();
 
                     switch (tag)
                     {


### PR DESCRIPTION
A few lines down from here, the number is reduced by four then checked whether the value is less than zero. An unsigned value can never be less than zero. The fix is to declare this as signed.