### PR TITLE
Simplify Directory subclasses

### DIFF
--- a/MetadataExtractor.Tests/MockDirectory.cs
+++ b/MetadataExtractor.Tests/MockDirectory.cs
@@ -1,6 +1,6 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-using System.Diagnostics.CodeAnalysis;
+using System.Collections.Generic;
 
 namespace MetadataExtractor.Tests
 {
@@ -10,10 +10,8 @@ namespace MetadataExtractor.Tests
     {
         public override string Name => string.Empty;
 
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
+        public MockDirectory() : base(new Dictionary<int, string>())
         {
-            tagName = null;
-            return false;
         }
     }
 }

--- a/MetadataExtractor/Formats/Adobe/AdobeJpegDirectory.cs
+++ b/MetadataExtractor/Formats/Adobe/AdobeJpegDirectory.cs
@@ -36,16 +36,11 @@ namespace MetadataExtractor.Formats.Adobe
             { TagColorTransform, "Color Transform" }
         };
 
-        public AdobeJpegDirectory()
+        public AdobeJpegDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new AdobeJpegDescriptor(this));
         }
 
         public override string Name => "Adobe JPEG";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Avi/AviDirectory.cs
+++ b/MetadataExtractor/Formats/Avi/AviDirectory.cs
@@ -32,16 +32,11 @@ namespace MetadataExtractor.Formats.Avi
             {TagDateTimeOriginal, "Date/Time Original"}
         };
 
-        public AviDirectory()
+        public AviDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new AviDescriptor(this));
         }
 
         public override string Name => "AVI";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Bmp/BmpHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpHeaderDirectory.cs
@@ -61,17 +61,12 @@ namespace MetadataExtractor.Formats.Bmp
             { TagLinkedProfile, "Linked Profile File Name" }
         };
 
-        public BmpHeaderDirectory()
+        public BmpHeaderDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new BmpHeaderDescriptor(this));
         }
 
         public override string Name => "BMP Header";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         /// <summary>
         /// Possible "magic bytes" indicating bitmap type

--- a/MetadataExtractor/Formats/Eps/EpsDirectory.cs
+++ b/MetadataExtractor/Formats/Eps/EpsDirectory.cs
@@ -138,16 +138,11 @@ namespace MetadataExtractor.Formats.Eps
             { "%%+", TagContinueLine }
         };
 
-        public EpsDirectory()
+        public EpsDirectory() : base(TagNameMap)
         {
             SetDescriptor(new EpsDescriptor(this));
         }
 
         public override string Name => "EPS";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return TagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDirectoryBase.cs
@@ -710,6 +710,11 @@ namespace MetadataExtractor.Formats.Exif
 
         public const int TagLens = 0xFDEA;
 
+        protected ExifDirectoryBase(Dictionary<int, string> tagNameMap)
+            : base(tagNameMap)
+        {
+        }
+
         protected static void AddExifTagNames(Dictionary<int, string> map)
         {
             map[TagInteropIndex] = "Interoperability Index";

--- a/MetadataExtractor/Formats/Exif/ExifIFD0Directory.cs
+++ b/MetadataExtractor/Formats/Exif/ExifIFD0Directory.cs
@@ -16,7 +16,7 @@ namespace MetadataExtractor.Formats.Exif
         /// <summary>This tag is a pointer to the Exif GPS IFD.</summary>
         public const int TagGpsInfoOffset = 0x8825;
 
-        public ExifIfd0Directory()
+        public ExifIfd0Directory() : base(_tagNameMap)
         {
             SetDescriptor(new ExifIfd0Descriptor(this));
         }
@@ -29,10 +29,5 @@ namespace MetadataExtractor.Formats.Exif
         }
 
         public override string Name => "Exif IFD0";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/ExifImageDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/ExifImageDirectory.cs
@@ -12,7 +12,7 @@ namespace MetadataExtractor.Formats.Exif
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public sealed class ExifImageDirectory : ExifDirectoryBase
     {
-        public ExifImageDirectory()
+        public ExifImageDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new ExifImageDescriptor(this));
         }
@@ -25,10 +25,5 @@ namespace MetadataExtractor.Formats.Exif
         }
 
         public override string Name => "Exif Image";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/ExifInteropDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/ExifInteropDirectory.cs
@@ -17,16 +17,11 @@ namespace MetadataExtractor.Formats.Exif
             AddExifTagNames(_tagNameMap);
         }
 
-        public ExifInteropDirectory()
+        public ExifInteropDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new ExifInteropDescriptor(this));
         }
 
         public override string Name => "Interoperability";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/ExifSubIFDDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/ExifSubIFDDirectory.cs
@@ -13,7 +13,7 @@ namespace MetadataExtractor.Formats.Exif
         /// <summary>This tag is a pointer to the Exif Interop IFD.</summary>
         public const int TagInteropOffset = 0xA005;
 
-        public ExifSubIfdDirectory()
+        public ExifSubIfdDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new ExifSubIfdDescriptor(this));
         }
@@ -26,10 +26,5 @@ namespace MetadataExtractor.Formats.Exif
         }
 
         public override string Name => "Exif SubIFD";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/ExifThumbnailDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/ExifThumbnailDirectory.cs
@@ -28,16 +28,11 @@ namespace MetadataExtractor.Formats.Exif
             AddExifTagNames(_tagNameMap);
         }
 
-        public ExifThumbnailDirectory()
+        public ExifThumbnailDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new ExifThumbnailDescriptor(this));
         }
 
         public override string Name => "Exif Thumbnail";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/GpsDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/GpsDirectory.cs
@@ -147,17 +147,12 @@ namespace MetadataExtractor.Formats.Exif
             _tagNameMap[TagHPositioningError] = "GPS Horizontal Positioning Error";
         }
 
-        public GpsDirectory()
+        public GpsDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new GpsDescriptor(this));
         }
 
         public override string Name => "GPS";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         /// <summary>
         /// Parses various tags in an attempt to obtain a single object representing the latitude and longitude

--- a/MetadataExtractor/Formats/Exif/PanasonicRawDistortionDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/PanasonicRawDistortionDirectory.cs
@@ -39,16 +39,11 @@ namespace MetadataExtractor.Formats.Exif
             { TagDistortionN, "Distortion N" }
         };
 
-        public PanasonicRawDistortionDirectory()
+        public PanasonicRawDistortionDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new PanasonicRawDistortionDescriptor(this));
         }
 
         public override string Name => "PanasonicRaw DistortionInfo";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/PanasonicRawIFD0Directory.cs
+++ b/MetadataExtractor/Formats/Exif/PanasonicRawIFD0Directory.cs
@@ -106,16 +106,11 @@ namespace MetadataExtractor.Formats.Exif
             { TagRawDataOffset, "Raw Data Offset" }
         };
 
-        public PanasonicRawIfd0Directory()
+        public PanasonicRawIfd0Directory() : base(_tagNameMap)
         {
             SetDescriptor(new PanasonicRawIfd0Descriptor(this));
         }
 
         public override string Name => "PanasonicRaw Exif IFD0";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/PanasonicRawWbInfo2Directory.cs
+++ b/MetadataExtractor/Formats/Exif/PanasonicRawWbInfo2Directory.cs
@@ -55,16 +55,11 @@ namespace MetadataExtractor.Formats.Exif
             { TagWbRgbLevels7, "WB RGB Levels 7" }
         };
 
-        public PanasonicRawWbInfo2Directory()
+        public PanasonicRawWbInfo2Directory() : base(_tagNameMap)
         {
             SetDescriptor(new PanasonicRawWbInfo2Descriptor(this));
         }
 
         public override string Name => "PanasonicRaw WbInfo2";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/PanasonicRawWbInfoDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/PanasonicRawWbInfoDirectory.cs
@@ -55,16 +55,11 @@ namespace MetadataExtractor.Formats.Exif
             { TagWbRbLevels7, "WB RGB Levels 7" }
         };
 
-        public PanasonicRawWbInfoDirectory()
+        public PanasonicRawWbInfoDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new PanasonicRawWbInfoDescriptor(this));
         }
 
         public override string Name => "PanasonicRaw WbInfo";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/PrintIMDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/PrintIMDirectory.cs
@@ -19,16 +19,11 @@ namespace MetadataExtractor.Formats.Exif
             { TagPrintImVersion, "PrintIM Version" }
         };
 
-        public PrintIMDirectory()
+        public PrintIMDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new PrintIMDescriptor(this));
         }
 
         public override string Name => "PrintIM";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/AppleMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/AppleMakernoteDirectory.cs
@@ -42,16 +42,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagLivePhotoId, "Live Photo ID" }
         };
 
-        public AppleMakernoteDirectory()
+        public AppleMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new AppleMakernoteDescriptor(this));
         }
 
         public override string Name => "Apple Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/CanonMakernoteDirectory.cs
@@ -661,17 +661,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagFilterInfoArray, "Filter Info Array" }
         };
 
-        public CanonMakernoteDirectory()
+        public CanonMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new CanonMakernoteDescriptor(this));
         }
 
         public override string Name => "Canon Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         public override void Set(int tagType, object value)
         {

--- a/MetadataExtractor/Formats/Exif/makernotes/CasioType1MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/CasioType1MakernoteDirectory.cs
@@ -60,16 +60,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagWhiteBalance, "White Balance" }
         };
 
-        public CasioType1MakernoteDirectory()
+        public CasioType1MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new CasioType1MakernoteDescriptor(this));
         }
 
         public override string Name => "Casio Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/CasioType2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/CasioType2MakernoteDirectory.cs
@@ -178,16 +178,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagFilter, "Filter" }
         };
 
-        public CasioType2MakernoteDirectory()
+        public CasioType2MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new CasioType2MakernoteDescriptor(this));
         }
 
         public override string Name => "Casio Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/DJIMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/DJIMakernoteDirectory.cs
@@ -49,17 +49,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagCameraRoll, "Camera Roll" }
         };
 
-        public DjiMakernoteDirectory()
+        public DjiMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new DjiMakernoteDescriptor(this));
         }
 
         public override string Name => "DJI Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         /// <summary>
         /// Parses various tags in an attempt to obtain a single object representing the x speed,

--- a/MetadataExtractor/Formats/Exif/makernotes/FujifilmMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/FujifilmMakernoteDirectory.cs
@@ -104,16 +104,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagParallax, "Parallax" }
         };
 
-        public FujifilmMakernoteDirectory()
+        public FujifilmMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new FujifilmMakernoteDescriptor(this));
         }
 
         public override string Name => "Fujifilm Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/KodakMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/KodakMakernoteDirectory.cs
@@ -67,16 +67,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagSharpness, "Sharpness" }
         };
 
-        public KodakMakernoteDirectory()
+        public KodakMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new KodakMakernoteDescriptor(this));
         }
 
         public override string Name => "Kodak Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/KyoceraMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/KyoceraMakernoteDirectory.cs
@@ -19,16 +19,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagPrintImageMatchingInfo, "Print Image Matching (PIM) Info" }
         };
 
-        public KyoceraMakernoteDirectory()
+        public KyoceraMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new KyoceraMakernoteDescriptor(this));
         }
 
         public override string Name => "Kyocera/Contax Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/LeicaMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/LeicaMakernoteDirectory.cs
@@ -54,16 +54,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagImageIdNumber, "Image ID Number" }
         };
 
-        public LeicaMakernoteDirectory()
+        public LeicaMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new LeicaMakernoteDescriptor(this));
         }
 
         public override string Name => "Leica Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/LeicaType5MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/LeicaType5MakernoteDirectory.cs
@@ -33,16 +33,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagWbRgbLevels, "WB RGB Levels" }
         };
 
-        public LeicaType5MakernoteDirectory()
+        public LeicaType5MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new LeicaType5MakernoteDescriptor(this));
         }
 
         public override string Name => "Leica Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/NikonType1MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/NikonType1MakernoteDirectory.cs
@@ -48,16 +48,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagWhiteBalance, "White Balance" }
         };
 
-        public NikonType1MakernoteDirectory()
+        public NikonType1MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new NikonType1MakernoteDescriptor(this));
         }
 
         public override string Name => "Nikon Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDirectory.cs
@@ -946,16 +946,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagUnknown55, "Unknown 55" }
         };
 
-        public NikonType2MakernoteDirectory()
+        public NikonType2MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new NikonType2MakernoteDescriptor(this));
         }
 
         public override string Name => "Nikon Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDirectory.cs
@@ -157,16 +157,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagDateTimeUtc, "Date Time UTC" }
         };
 
-        public OlympusCameraSettingsMakernoteDirectory()
+        public OlympusCameraSettingsMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusCameraSettingsMakernoteDescriptor(this));
         }
 
         public override string Name => "Olympus Camera Settings";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusEquipmentMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusEquipmentMakernoteDirectory.cs
@@ -79,16 +79,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagFlashSerialNumber, "Flash Serial Number" }
         };
 
-        public OlympusEquipmentMakernoteDirectory()
+        public OlympusEquipmentMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusEquipmentMakernoteDescriptor(this));
         }
 
         public override string Name => "Olympus Equipment";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDirectory.cs
@@ -66,16 +66,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagImageStabilization, "Image Stabilization" }
         };
 
-        public OlympusFocusInfoMakernoteDirectory()
+        public OlympusFocusInfoMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusFocusInfoMakernoteDescriptor(this));
         }
 
         public override string Name => "Olympus Focus Info";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDirectory.cs
@@ -168,16 +168,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagKeystoneValue, "Keystone Value" }
         };
 
-        public OlympusImageProcessingMakernoteDirectory()
+        public OlympusImageProcessingMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusImageProcessingMakernoteDescriptor(this));
         }
 
         public override string Name => "Olympus Image Processing";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
@@ -437,7 +437,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { CameraSettings.TagDecSwitchPosition, "DEC Switch Position" }
         };
 
-        public OlympusMakernoteDirectory()
+        public OlympusMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusMakernoteDescriptor(this));
         }
@@ -465,11 +465,6 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         public bool IsIntervalMode()
         {
             return this.TryGetInt64(CameraSettings.TagShootingMode, out long value) && value == 5;
-        }
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
         }
 
         /// <summary>

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopment2MakernoteDirectory.cs
@@ -68,16 +68,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagRawDevArtFilter, "Raw Dev Art Filter" }
         };
 
-        public OlympusRawDevelopment2MakernoteDirectory()
+        public OlympusRawDevelopment2MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusRawDevelopment2MakernoteDescriptor(this));
         }
 
         public override string Name => "Olympus Raw Development 2";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopmentMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopmentMakernoteDirectory.cs
@@ -48,16 +48,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagRawDevSettings, "Raw Dev Settings" }
     };
 
-        public OlympusRawDevelopmentMakernoteDirectory()
+        public OlympusRawDevelopmentMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusRawDevelopmentMakernoteDescriptor(this));
         }
 
         public override string Name => "Olympus Raw Development";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDirectory.cs
@@ -98,16 +98,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagCmSharpness, "CM Sharpness" }
         };
 
-        public OlympusRawInfoMakernoteDirectory()
+        public OlympusRawInfoMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new OlympusRawInfoMakernoteDescriptor(this));
         }
 
         public override string Name => "Olympus Raw Info";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDirectory.cs
@@ -560,17 +560,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagTransform1, "Transform 1" }
         };
 
-        public PanasonicMakernoteDirectory()
+        public PanasonicMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new PanasonicMakernoteDescriptor(this));
         }
 
         public override string Name => "Panasonic Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         public IEnumerable<Face> GetDetectedFaces()
         {

--- a/MetadataExtractor/Formats/Exif/makernotes/PentaxMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/PentaxMakernoteDirectory.cs
@@ -119,16 +119,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagDaylightSavings, "Daylight Savings" }
         };
 
-        public PentaxMakernoteDirectory()
+        public PentaxMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new PentaxMakernoteDescriptor(this));
         }
 
         public override string Name => "Pentax Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFire2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFire2MakernoteDirectory.cs
@@ -66,10 +66,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
              { TagSerialNumber, "Serial Number" },
         };
 
-        public ReconyxHyperFire2MakernoteDirectory() => SetDescriptor(new ReconyxHyperFire2MakernoteDescriptor(this));
+        public ReconyxHyperFire2MakernoteDirectory() : base(_tagNameMap)
+        {
+            SetDescriptor(new ReconyxHyperFire2MakernoteDescriptor(this));
+        }
 
         public override string Name => "Reconyx HyperFire 2 Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(true)] out string? tagName) => _tagNameMap.TryGetValue(tagType, out tagName);
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFireMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxHyperFireMakernoteDirectory.cs
@@ -57,16 +57,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
              { TagUserLabel, "User Label" }
         };
 
-        public ReconyxHyperFireMakernoteDirectory()
+        public ReconyxHyperFireMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new ReconyxHyperFireMakernoteDescriptor(this));
         }
 
         public override string Name => "Reconyx HyperFire Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/ReconyxUltraFireMakernoteDirectory.cs
@@ -68,16 +68,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
              { TagUserLabel, "User Label" }
         };
 
-        public ReconyxUltraFireMakernoteDirectory()
+        public ReconyxUltraFireMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new ReconyxUltraFireMakernoteDescriptor(this));
         }
 
         public override string Name => "Reconyx UltraFire Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/RicohMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/RicohMakernoteDirectory.cs
@@ -23,16 +23,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagRicohCameraInfoMakernoteSubIfdPointer, "Ricoh Camera Info Makernote Sub-IFD" }
         };
 
-        public RicohMakernoteDirectory()
+        public RicohMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new RicohMakernoteDescriptor(this));
         }
 
         public override string Name => "Ricoh Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/SamsungType2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SamsungType2MakernoteDirectory.cs
@@ -105,16 +105,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagEncryptionKey, "Encryption Key" }
         };
 
-        public SamsungType2MakernoteDirectory()
+        public SamsungType2MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new SamsungType2MakernoteDescriptor(this));
         }
 
         public override string Name => "Samsung Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/SanyoMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SanyoMakernoteDirectory.cs
@@ -69,16 +69,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagDataDump, "Data Dump" }
         };
 
-        public SanyoMakernoteDirectory()
+        public SanyoMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new SanyoMakernoteDescriptor(this));
         }
 
         public override string Name => "Sanyo Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/SigmaMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SigmaMakernoteDirectory.cs
@@ -61,16 +61,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagAutoBracket, "Auto Bracket" }
         };
 
-        public SigmaMakernoteDirectory()
+        public SigmaMakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new SigmaMakernoteDescriptor(this));
         }
 
         public override string Name => "Sigma Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/SonyType1MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SonyType1MakernoteDirectory.cs
@@ -160,16 +160,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagNoPrint, "No Print" }
         };
 
-        public SonyType1MakernoteDirectory()
+        public SonyType1MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new SonyType1MakernoteDescriptor(this));
         }
 
         public override string Name => "Sony Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Exif/makernotes/SonyType6MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SonyType6MakernoteDirectory.cs
@@ -21,16 +21,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             { TagMakernoteThumbVersion, "Makernote Thumb Version" }
         };
 
-        public SonyType6MakernoteDirectory()
+        public SonyType6MakernoteDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new SonyType6MakernoteDescriptor(this));
         }
 
         public override string Name => "Sony Makernote";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/FileSystem/FileMetadataDirectory.cs
+++ b/MetadataExtractor/Formats/FileSystem/FileMetadataDirectory.cs
@@ -20,10 +20,11 @@ namespace MetadataExtractor.Formats.FileSystem
             { TagFileModifiedDate, "File Modified Date" }
         };
 
-        public FileMetadataDirectory() => SetDescriptor(new FileMetadataDescriptor(this));
+        public FileMetadataDirectory() : base(_tagNameMap)
+        {
+            SetDescriptor(new FileMetadataDescriptor(this));
+        }
 
         public override string Name => "File";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName) => _tagNameMap.TryGetValue(tagType, out tagName);
     }
 }

--- a/MetadataExtractor/Formats/FileType/FileTypeDirectory.cs
+++ b/MetadataExtractor/Formats/FileType/FileTypeDirectory.cs
@@ -24,7 +24,7 @@ namespace MetadataExtractor.Formats.FileType
         };
 
         [SuppressMessage("ReSharper", "VirtualMemberCallInConstructor")]
-        public FileTypeDirectory(Util.FileType fileType)
+        public FileTypeDirectory(Util.FileType fileType) : base(_tagNameMap)
         {
             SetDescriptor(new FileTypeDescriptor(this));
 
@@ -43,7 +43,5 @@ namespace MetadataExtractor.Formats.FileType
         }
 
         public override string Name => "File Type";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName) => _tagNameMap.TryGetValue(tagType, out tagName);
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifAnimationDirectory.cs
+++ b/MetadataExtractor/Formats/Gif/GifAnimationDirectory.cs
@@ -17,16 +17,11 @@ namespace MetadataExtractor.Formats.Gif
             { TagIterationCount, "Iteration Count" }
         };
 
-        public GifAnimationDirectory()
+        public GifAnimationDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new GifAnimationDescriptor(this));
         }
 
         public override string Name => "GIF Animation";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifCommentDirectory.cs
+++ b/MetadataExtractor/Formats/Gif/GifCommentDirectory.cs
@@ -17,17 +17,12 @@ namespace MetadataExtractor.Formats.Gif
             { TagComment, "Comment" }
         };
 
-        public GifCommentDirectory(StringValue comment)
+        public GifCommentDirectory(StringValue comment) : base(_tagNameMap)
         {
             SetDescriptor(new GifCommentDescriptor(this));
             Set(TagComment, comment);
         }
 
         public override string Name => "GIF Comment";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifControlDirectory.cs
+++ b/MetadataExtractor/Formats/Gif/GifControlDirectory.cs
@@ -25,16 +25,11 @@ namespace MetadataExtractor.Formats.Gif
             { TagTransparentColorIndex, "Transparent Color Index" }
         };
 
-        public GifControlDirectory()
+        public GifControlDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new GifControlDescriptor(this));
         }
 
         public override string Name => "GIF Control";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/Gif/GifHeaderDirectory.cs
@@ -32,16 +32,11 @@ namespace MetadataExtractor.Formats.Gif
             { TagPixelAspectRatio, "Pixel Aspect Ratio" }
         };
 
-        public GifHeaderDirectory()
+        public GifHeaderDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new GifHeaderDescriptor(this));
         }
 
         public override string Name => "GIF Header";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifImageDirectory.cs
+++ b/MetadataExtractor/Formats/Gif/GifImageDirectory.cs
@@ -31,16 +31,11 @@ namespace MetadataExtractor.Formats.Gif
             { TagLocalColourTableBitsPerPixel, "Local Colour Table Bits Per Pixel" }
         };
 
-        public GifImageDirectory()
+        public GifImageDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new GifImageDescriptor(this));
         }
 
         public override string Name => "GIF Image";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertiesDirectory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace MetadataExtractor.Formats.Heif
 {
@@ -9,7 +8,7 @@ namespace MetadataExtractor.Formats.Heif
     {
         public override string Name { get; }
 
-        public HeicImagePropertiesDirectory(string name)
+        public HeicImagePropertiesDirectory(string name) : base(_tagNameMap)
         {
             Name = name;
             SetDescriptor(new HeicImagePropertyDescriptor(this));
@@ -67,8 +66,5 @@ namespace MetadataExtractor.Formats.Heif
             { TagFullRangeColor, "Full-Range Color" },
             { TagColorFormat, "Color Data Format" }
         };
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName) =>
-            _tagNameMap.TryGetValue(tagType, out tagName);
     }
 }

--- a/MetadataExtractor/Formats/Heif/HeicThumbnailDirectory.cs
+++ b/MetadataExtractor/Formats/Heif/HeicThumbnailDirectory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace MetadataExtractor.Formats.Heif
 {
@@ -9,7 +8,7 @@ namespace MetadataExtractor.Formats.Heif
     {
         public override string Name => "HEIC Thumbnail Data";
 
-        public HeicThumbnailDirectory()
+        public HeicThumbnailDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new HeicThumbnailTagDescriptor(this));
         }
@@ -22,8 +21,5 @@ namespace MetadataExtractor.Formats.Heif
             { TagFileOffset, "Offset From Beginning of File" },
             { TagLength, "Data Length" }
         };
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName) =>
-            _tagNameMap.TryGetValue(tagType, out tagName);
     }
 }

--- a/MetadataExtractor/Formats/Icc/IccDirectory.cs
+++ b/MetadataExtractor/Formats/Icc/IccDirectory.cs
@@ -159,16 +159,11 @@ namespace MetadataExtractor.Formats.Icc
             { TagAppleMultiLanguageProfileName, "Apple Multi-language Profile Name" }
         };
 
-        public IccDirectory()
+        public IccDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new IccDescriptor(this));
         }
 
         public override string Name => "ICC Profile";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Ico/IcoDirectory.cs
+++ b/MetadataExtractor/Formats/Ico/IcoDirectory.cs
@@ -34,16 +34,11 @@ namespace MetadataExtractor.Formats.Ico
             { TagImageOffsetBytes, "Image Offset Bytes" }
         };
 
-        public IcoDirectory()
+        public IcoDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new IcoDescriptor(this));
         }
 
         public override string Name => "ICO";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Iptc/IptcDirectory.cs
+++ b/MetadataExtractor/Formats/Iptc/IptcDirectory.cs
@@ -173,17 +173,12 @@ namespace MetadataExtractor.Formats.Iptc
             { TagObjectPreviewData, "Object Data Preview Data" }
         };
 
-        public IptcDirectory()
+        public IptcDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new IptcDescriptor(this));
         }
 
         public override string Name => "IPTC";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         /// <summary>Returns any keywords contained in the IPTC data.</summary>
         /// <remarks>This value may be <see langword="null" />.</remarks>

--- a/MetadataExtractor/Formats/Jfif/JfifDirectory.cs
+++ b/MetadataExtractor/Formats/Jfif/JfifDirectory.cs
@@ -31,17 +31,12 @@ namespace MetadataExtractor.Formats.Jfif
             { TagThumbHeight, "Thumbnail Height Pixels" }
         };
 
-        public JfifDirectory()
+        public JfifDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new JfifDescriptor(this));
         }
 
         public override string Name => "JFIF";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         public int GetVersion()
         {

--- a/MetadataExtractor/Formats/Jfxx/JfxxDirectory.cs
+++ b/MetadataExtractor/Formats/Jfxx/JfxxDirectory.cs
@@ -17,17 +17,12 @@ namespace MetadataExtractor.Formats.Jfxx
             { TagExtensionCode, "Extension Code" }
         };
 
-        public JfxxDirectory()
+        public JfxxDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new JfxxDescriptor(this));
         }
 
         public override string Name => "JFXX";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         public int GetExtensionCode()
         {

--- a/MetadataExtractor/Formats/Jpeg/HuffmanTablesDirectory.cs
+++ b/MetadataExtractor/Formats/Jpeg/HuffmanTablesDirectory.cs
@@ -100,17 +100,12 @@ namespace MetadataExtractor.Formats.Jpeg
             { TagNumberOfTables, "Number of Tables" }
         };
 
-        public HuffmanTablesDirectory()
+        public HuffmanTablesDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new HuffmanTablesDescriptor(this));
         }
 
         public override string Name => "Huffman";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         /// <remarks>Use GetNumberOfTables for bounds-checking.</remarks>
         /// <param name="tableNumber">The zero-based index of the table. This number is normally between 0 and 3.</param>

--- a/MetadataExtractor/Formats/Jpeg/JpegCommentDirectory.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegCommentDirectory.cs
@@ -22,17 +22,12 @@ namespace MetadataExtractor.Formats.Jpeg
             { TagComment, "JPEG Comment" }
         };
 
-        public JpegCommentDirectory(StringValue comment)
+        public JpegCommentDirectory(StringValue comment) : base(_tagNameMap)
         {
             SetDescriptor(new JpegCommentDescriptor(this));
             Set(TagComment, comment);
         }
 
         public override string Name => "JpegComment";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Jpeg/JpegDirectory.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegDirectory.cs
@@ -65,17 +65,12 @@ namespace MetadataExtractor.Formats.Jpeg
             { TagComponentData4, "Component 4" }
         };
 
-        public JpegDirectory()
+        public JpegDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new JpegDescriptor(this));
         }
 
         public override string Name => "JPEG";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         /// <param name="componentNumber">
         /// The zero-based index of the component.  This number is normally between 0 and 3.

--- a/MetadataExtractor/Formats/Jpeg/JpegDnlDirectory.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegDnlDirectory.cs
@@ -18,16 +18,11 @@ namespace MetadataExtractor.Formats.Jpeg
             { TagImageHeight, "Image Height" }
         };
 
-        public JpegDnlDirectory()
+        public JpegDnlDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new JpegDnlDescriptor(this));
         }
 
         public override string Name => "JPEG DNL";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Mpeg/Mp3Directory.cs
+++ b/MetadataExtractor/Formats/Mpeg/Mp3Directory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace MetadataExtractor.Formats.Mpeg
 {
@@ -28,16 +27,11 @@ namespace MetadataExtractor.Formats.Mpeg
             { TagFrameSize, "Frame Size" }
         };
 
-        public Mp3Directory()
+        public Mp3Directory() : base(_tagNameMap)
         {
             SetDescriptor(new Mp3Descriptor(this));
         }
 
         public override string Name => "MP3";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Netpbm/NetpbmHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/Netpbm/NetpbmHeaderDirectory.cs
@@ -1,7 +1,6 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using System.Collections.Generic;
-using System.Diagnostics.CodeAnalysis;
 
 namespace MetadataExtractor.Formats.Netpbm
 {
@@ -21,16 +20,11 @@ namespace MetadataExtractor.Formats.Netpbm
             { TagMaximumValue, "Maximum Value" }
         };
 
-        public NetpbmHeaderDirectory()
+        public NetpbmHeaderDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new NetpbmHeaderDescriptor(this));
         }
 
         public override string Name => "Netpbm";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Pcx/PcxDirectory.cs
+++ b/MetadataExtractor/Formats/Pcx/PcxDirectory.cs
@@ -42,16 +42,11 @@ namespace MetadataExtractor.Formats.Pcx
             { TagVScrSize, "V Scr Size" }
         };
 
-        public PcxDirectory()
+        public PcxDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new PcxDescriptor(this));
         }
 
         public override string Name => "PCX";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Photoshop/DuckyDirectory.cs
+++ b/MetadataExtractor/Formats/Photoshop/DuckyDirectory.cs
@@ -21,16 +21,11 @@ namespace MetadataExtractor.Formats.Photoshop
             { TagCopyright, "Copyright" }
         };
 
-        public DuckyDirectory()
+        public DuckyDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new TagDescriptor<DuckyDirectory>(this));
         }
 
         public override string Name => "Ducky";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopDirectory.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopDirectory.cs
@@ -202,17 +202,12 @@ namespace MetadataExtractor.Formats.Photoshop
             { TagPrintFlagsInfo, "Print Flags Information" }
         };
 
-        public PhotoshopDirectory()
+        public PhotoshopDirectory() : base(TagNameMap)
         {
             SetDescriptor(new PhotoshopDescriptor(this));
         }
 
         public override string Name => "Photoshop";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return TagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         public byte[]? GetThumbnailBytes()
         {

--- a/MetadataExtractor/Formats/Photoshop/PsdHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdHeaderDirectory.cs
@@ -40,16 +40,11 @@ namespace MetadataExtractor.Formats.Photoshop
             { TagColorMode, "Color Mode" }
         };
 
-        public PsdHeaderDirectory()
+        public PsdHeaderDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new PsdHeaderDescriptor(this));
         }
 
         public override string Name => "PSD Header";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Png/PngChromaticitiesDirectory.cs
+++ b/MetadataExtractor/Formats/Png/PngChromaticitiesDirectory.cs
@@ -30,13 +30,11 @@ namespace MetadataExtractor.Formats.Png
             { TagBlueY, "Blue Y" }
         };
 
-        public PngChromaticitiesDirectory()
+        public PngChromaticitiesDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new TagDescriptor<PngChromaticitiesDirectory>(this));
         }
 
         public override string Name => "PNG Chromaticities";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName) => _tagNameMap.TryGetValue(tagType, out tagName);
     }
 }

--- a/MetadataExtractor/Formats/Png/PngDirectory.cs
+++ b/MetadataExtractor/Formats/Png/PngDirectory.cs
@@ -54,7 +54,7 @@ namespace MetadataExtractor.Formats.Png
 
         private readonly PngChunkType _pngChunkType;
 
-        public PngDirectory(PngChunkType pngChunkType)
+        public PngDirectory(PngChunkType pngChunkType) : base(_tagNameMap)
         {
             _pngChunkType = pngChunkType;
             SetDescriptor(new PngDescriptor(this));
@@ -67,9 +67,5 @@ namespace MetadataExtractor.Formats.Png
 
         public override string Name => "PNG-" + _pngChunkType.Identifier;
 
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeFileTypeDirectory.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeFileTypeDirectory.cs
@@ -21,14 +21,9 @@ namespace MetadataExtractor.Formats.QuickTime
             { TagCompatibleBrands, "Compatible Brands" }
         };
 
-        public QuickTimeFileTypeDirectory()
+        public QuickTimeFileTypeDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new QuickTimeFileTypeDescriptor(this));
-        }
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
         }
     }
 }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataHeaderDirectory.cs
@@ -121,14 +121,9 @@ namespace MetadataExtractor.Formats.QuickTime
             { "com.android.version",                    TagAndroidVersion },
         };
 
-        public QuickTimeMetadataHeaderDirectory()
+        public QuickTimeMetadataHeaderDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new QuickTimeMetadataHeaderDescriptor(this));
-        }
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
         }
 
         public static bool TryGetTag(string name, out int tagType)

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMovieHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMovieHeaderDirectory.cs
@@ -47,14 +47,9 @@ namespace MetadataExtractor.Formats.QuickTime
             { TagNextTrackId,       "Next Track Id" }
         };
 
-        public QuickTimeMovieHeaderDirectory()
+        public QuickTimeMovieHeaderDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new TagDescriptor<QuickTimeMovieHeaderDirectory>(this));
-        }
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
         }
     }
 }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTrackHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTrackHeaderDirectory.cs
@@ -41,14 +41,9 @@ namespace MetadataExtractor.Formats.QuickTime
             { TagRotation,       "Rotation" },
         };
 
-        public QuickTimeTrackHeaderDirectory()
+        public QuickTimeTrackHeaderDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new TagDescriptor<QuickTimeTrackHeaderDirectory>(this));
-        }
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
         }
     }
 }

--- a/MetadataExtractor/Formats/Tga/TgaDeveloperDirectory.cs
+++ b/MetadataExtractor/Formats/Tga/TgaDeveloperDirectory.cs
@@ -8,17 +8,11 @@ namespace MetadataExtractor.Formats.Tga
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     public sealed class TgaDeveloperDirectory : Directory
     {
-        public TgaDeveloperDirectory()
+        public TgaDeveloperDirectory() : base(null)
         {
             SetDescriptor(new TagDescriptor<TgaDeveloperDirectory>(this));
         }
 
         public override string Name => "TGA Developer Area";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(true)] out string? tagName)
-        {
-            tagName = null;
-            return false;
-        }
     }
 }

--- a/MetadataExtractor/Formats/Tga/TgaExtensionDirectory.cs
+++ b/MetadataExtractor/Formats/Tga/TgaExtensionDirectory.cs
@@ -41,7 +41,7 @@ namespace MetadataExtractor.Formats.Tga
             "Attributes Type"
         };
 
-        public TgaExtensionDirectory()
+        public TgaExtensionDirectory() : base(null)
         {
             SetDescriptor(new TgaExtensionDescriptor(this));
         }

--- a/MetadataExtractor/Formats/Tga/TgaHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/Tga/TgaHeaderDirectory.cs
@@ -45,7 +45,7 @@ namespace MetadataExtractor.Formats.Tga
             "Color Map"
         };
 
-        public TgaHeaderDirectory()
+        public TgaHeaderDirectory() : base(null)
         {
             SetDescriptor(new TgaHeaderDescriptor(this));
         }

--- a/MetadataExtractor/Formats/Wav/WavFactDirectory.cs
+++ b/MetadataExtractor/Formats/Wav/WavFactDirectory.cs
@@ -15,7 +15,7 @@ namespace MetadataExtractor.Formats.Wav
             "Number of Samples"
         };
 
-        public WavFactDirectory()
+        public WavFactDirectory() : base(null)
         {
             SetDescriptor(new TagDescriptor<WavFactDirectory>(this));
         }

--- a/MetadataExtractor/Formats/Wav/WavFormatDirectory.cs
+++ b/MetadataExtractor/Formats/Wav/WavFormatDirectory.cs
@@ -31,7 +31,7 @@ namespace MetadataExtractor.Formats.Wav
             "Subformat"
         };
 
-        public WavFormatDirectory()
+        public WavFormatDirectory() : base(null)
         {
             SetDescriptor(new WavFormatDescriptor(this));
         }

--- a/MetadataExtractor/Formats/WebP/WebPDirectory.cs
+++ b/MetadataExtractor/Formats/WebP/WebPDirectory.cs
@@ -22,16 +22,11 @@ namespace MetadataExtractor.Formats.WebP
             { TagIsAnimation, "Is Animation" }
         };
 
-        public WebPDirectory()
+        public WebPDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new WebPDescriptor(this));
         }
 
         public override string Name => "WebP";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
     }
 }

--- a/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpDirectory.cs
@@ -33,17 +33,12 @@ namespace MetadataExtractor.Formats.Xmp
         /// <remarks>This object provides a rich API for working with XMP data.</remarks>
         public IXmpMeta? XmpMeta { get; private set; }
 
-        public XmpDirectory()
+        public XmpDirectory() : base(_tagNameMap)
         {
             SetDescriptor(new XmpDescriptor(this));
         }
 
         public override string Name => "XMP";
-
-        protected override bool TryGetTagName(int tagType, [NotNullWhen(returnValue: true)] out string? tagName)
-        {
-            return _tagNameMap.TryGetValue(tagType, out tagName);
-        }
 
         // set only once to save some allocations
         private static readonly IteratorOptions _iteratorOptions = new() { IsJustLeafNodes = true };

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
@@ -11,7 +11,6 @@ MetadataExtractor.Age.Years.get -> int
 MetadataExtractor.Directory
 MetadataExtractor.Directory.AddError(string! message) -> void
 MetadataExtractor.Directory.ContainsTag(int tagType) -> bool
-MetadataExtractor.Directory.Directory() -> void
 MetadataExtractor.Directory.Errors.get -> System.Collections.Generic.IEnumerable<string!>!
 MetadataExtractor.Directory.GetDescription(int tagType) -> string?
 MetadataExtractor.Directory.GetObject(int tagType) -> object?
@@ -161,7 +160,6 @@ MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrPositioningDescript
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrSubsamplingDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYResolutionDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDirectoryBase
-MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase() -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor.ExifIfd0Descriptor(MetadataExtractor.Formats.Exif.ExifIfd0Directory! directory) -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Directory
@@ -1593,7 +1591,6 @@ MetadataExtractor.Util.FileTypeDetector
 MetadataExtractor.Util.FileTypeExtensions
 MetadataExtractor.Util.PhotographicConversions
 abstract MetadataExtractor.Directory.Name.get -> string!
-abstract MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
@@ -3596,23 +3593,17 @@ override MetadataExtractor.Face.GetHashCode() -> int
 override MetadataExtractor.Face.ToString() -> string!
 override MetadataExtractor.Formats.Adobe.AdobeJpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Avi.AviDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Avi.AviDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Avi.AviDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Eps.EpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Eps.EpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifImageDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifInteropDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
@@ -3624,38 +3615,27 @@ override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Set(int tagType, object! value) -> void
-override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusEquipmentMakernoteDescriptor.GetDescription(int tagType) -> string?
@@ -3677,73 +3657,48 @@ override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDescriptor.
 override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PrintIMDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PrintIMDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PrintIMDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileSystem.FileMetadataDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileType.FileTypeDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileType.FileTypeDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifAnimationDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifAnimationDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifAnimationDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifControlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifControlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifControlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifImageDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifImageDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertyDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Icc.IccDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Icc.IccDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Icc.IccDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Ico.IcoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Ico.IcoDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Iptc.IptcDescriptor.GetDescription(int tagType) -> string?
@@ -3755,29 +3710,23 @@ override MetadataExtractor.Formats.Jfxx.JfxxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Jpeg.JpegComponent.ToString() -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDnlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Mpeg.Mp3Directory.Name.get -> string!
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Pcx.PcxDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Pcx.PcxDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.DuckyDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.Equals(object? obj) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.GetHashCode() -> int
 override MetadataExtractor.Formats.Png.PngChunkType.ToString() -> string!
@@ -3801,7 +3750,6 @@ override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
-override MetadataExtractor.Formats.WebP.WebPDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
@@ -4109,7 +4057,6 @@ const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagId = 1 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagLayer = 2 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagMode = 5 -> int
 override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(byte[]! bytes) -> bool
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernoteId -> uint
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernotePublicId -> uint

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
+MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
@@ -41,3 +43,4 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.G
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -11,7 +11,6 @@ MetadataExtractor.Age.Years.get -> int
 MetadataExtractor.Directory
 MetadataExtractor.Directory.AddError(string! message) -> void
 MetadataExtractor.Directory.ContainsTag(int tagType) -> bool
-MetadataExtractor.Directory.Directory() -> void
 MetadataExtractor.Directory.Errors.get -> System.Collections.Generic.IReadOnlyList<string!>!
 MetadataExtractor.Directory.GetDescription(int tagType) -> string?
 MetadataExtractor.Directory.GetObject(int tagType) -> object?
@@ -161,7 +160,6 @@ MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrPositioningDescript
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrSubsamplingDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYResolutionDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDirectoryBase
-MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase() -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor.ExifIfd0Descriptor(MetadataExtractor.Formats.Exif.ExifIfd0Directory! directory) -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Directory
@@ -1593,7 +1591,6 @@ MetadataExtractor.Util.FileTypeDetector
 MetadataExtractor.Util.FileTypeExtensions
 MetadataExtractor.Util.PhotographicConversions
 abstract MetadataExtractor.Directory.Name.get -> string!
-abstract MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
@@ -3596,23 +3593,17 @@ override MetadataExtractor.Face.GetHashCode() -> int
 override MetadataExtractor.Face.ToString() -> string!
 override MetadataExtractor.Formats.Adobe.AdobeJpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Avi.AviDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Avi.AviDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Avi.AviDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Eps.EpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Eps.EpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifImageDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifInteropDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
@@ -3624,38 +3615,27 @@ override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Set(int tagType, object! value) -> void
-override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusEquipmentMakernoteDescriptor.GetDescription(int tagType) -> string?
@@ -3677,73 +3657,48 @@ override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDescriptor.
 override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PrintIMDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PrintIMDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PrintIMDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileSystem.FileMetadataDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileType.FileTypeDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileType.FileTypeDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifAnimationDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifAnimationDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifAnimationDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifControlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifControlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifControlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifImageDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifImageDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertyDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Icc.IccDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Icc.IccDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Icc.IccDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Ico.IcoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Ico.IcoDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Iptc.IptcDescriptor.GetDescription(int tagType) -> string?
@@ -3755,29 +3710,23 @@ override MetadataExtractor.Formats.Jfxx.JfxxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Jpeg.JpegComponent.ToString() -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDnlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Mpeg.Mp3Directory.Name.get -> string!
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Pcx.PcxDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Pcx.PcxDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.DuckyDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.Equals(object? obj) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.GetHashCode() -> int
 override MetadataExtractor.Formats.Png.PngChunkType.ToString() -> string!
@@ -3801,7 +3750,6 @@ override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
-override MetadataExtractor.Formats.WebP.WebPDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
@@ -4109,7 +4057,6 @@ const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagId = 1 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagLayer = 2 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagMode = 5 -> int
 override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(byte[]! bytes) -> bool
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernoteId -> uint
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernotePublicId -> uint

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
+MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
@@ -41,3 +43,4 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.G
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -11,7 +11,6 @@ MetadataExtractor.Age.Years.get -> int
 MetadataExtractor.Directory
 MetadataExtractor.Directory.AddError(string! message) -> void
 MetadataExtractor.Directory.ContainsTag(int tagType) -> bool
-MetadataExtractor.Directory.Directory() -> void
 MetadataExtractor.Directory.Errors.get -> System.Collections.Generic.IReadOnlyList<string!>!
 MetadataExtractor.Directory.GetDescription(int tagType) -> string?
 MetadataExtractor.Directory.GetObject(int tagType) -> object?
@@ -161,7 +160,6 @@ MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrPositioningDescript
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrSubsamplingDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYResolutionDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDirectoryBase
-MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase() -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor.ExifIfd0Descriptor(MetadataExtractor.Formats.Exif.ExifIfd0Directory! directory) -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Directory
@@ -1586,7 +1584,6 @@ MetadataExtractor.Util.FileTypeDetector
 MetadataExtractor.Util.FileTypeExtensions
 MetadataExtractor.Util.PhotographicConversions
 abstract MetadataExtractor.Directory.Name.get -> string!
-abstract MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
@@ -3589,23 +3586,17 @@ override MetadataExtractor.Face.GetHashCode() -> int
 override MetadataExtractor.Face.ToString() -> string!
 override MetadataExtractor.Formats.Adobe.AdobeJpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Avi.AviDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Avi.AviDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Avi.AviDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Eps.EpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Eps.EpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifImageDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifInteropDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
@@ -3617,38 +3608,27 @@ override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Set(int tagType, object! value) -> void
-override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusEquipmentMakernoteDescriptor.GetDescription(int tagType) -> string?
@@ -3670,73 +3650,48 @@ override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDescriptor.
 override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PrintIMDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PrintIMDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PrintIMDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileSystem.FileMetadataDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileType.FileTypeDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileType.FileTypeDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifAnimationDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifAnimationDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifAnimationDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifControlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifControlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifControlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifImageDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifImageDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertyDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Icc.IccDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Icc.IccDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Icc.IccDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Ico.IcoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Ico.IcoDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Iptc.IptcDescriptor.GetDescription(int tagType) -> string?
@@ -3748,29 +3703,23 @@ override MetadataExtractor.Formats.Jfxx.JfxxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Jpeg.JpegComponent.ToString() -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDnlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Mpeg.Mp3Directory.Name.get -> string!
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Pcx.PcxDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Pcx.PcxDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.DuckyDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.Equals(object? obj) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.GetHashCode() -> int
 override MetadataExtractor.Formats.Png.PngChunkType.ToString() -> string!
@@ -3794,7 +3743,6 @@ override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
-override MetadataExtractor.Formats.WebP.WebPDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
@@ -4102,7 +4050,6 @@ const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagId = 1 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagLayer = 2 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagMode = 5 -> int
 override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(byte[]! bytes) -> bool
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernoteId -> uint
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernotePublicId -> uint

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
+MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
@@ -41,3 +43,4 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.G
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -11,7 +11,6 @@ MetadataExtractor.Age.Years.get -> int
 MetadataExtractor.Directory
 MetadataExtractor.Directory.AddError(string! message) -> void
 MetadataExtractor.Directory.ContainsTag(int tagType) -> bool
-MetadataExtractor.Directory.Directory() -> void
 MetadataExtractor.Directory.Errors.get -> System.Collections.Generic.IReadOnlyList<string!>!
 MetadataExtractor.Directory.GetDescription(int tagType) -> string?
 MetadataExtractor.Directory.GetObject(int tagType) -> object?
@@ -161,7 +160,6 @@ MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrPositioningDescript
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYCbCrSubsamplingDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetYResolutionDescription() -> string?
 MetadataExtractor.Formats.Exif.ExifDirectoryBase
-MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase() -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor
 MetadataExtractor.Formats.Exif.ExifIfd0Descriptor.ExifIfd0Descriptor(MetadataExtractor.Formats.Exif.ExifIfd0Directory! directory) -> void
 MetadataExtractor.Formats.Exif.ExifIfd0Directory
@@ -1593,7 +1591,6 @@ MetadataExtractor.Util.FileTypeDetector
 MetadataExtractor.Util.FileTypeExtensions
 MetadataExtractor.Util.PhotographicConversions
 abstract MetadataExtractor.Directory.Name.get -> string!
-abstract MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
@@ -3596,23 +3593,17 @@ override MetadataExtractor.Face.GetHashCode() -> int
 override MetadataExtractor.Face.ToString() -> string!
 override MetadataExtractor.Formats.Adobe.AdobeJpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Adobe.AdobeJpegDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Avi.AviDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Avi.AviDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Avi.AviDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Bmp.BmpHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Eps.EpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Eps.EpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifDescriptorBase<T>.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifImageDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifInteropDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
@@ -3624,38 +3615,27 @@ override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.Set(int tagType, object! value) -> void
-override MetadataExtractor.Formats.Exif.Makernotes.CanonMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.CasioType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.FujifilmMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KodakMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.KyoceraMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.LeicaType5MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusCameraSettingsMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.OlympusEquipmentMakernoteDescriptor.GetDescription(int tagType) -> string?
@@ -3677,73 +3657,48 @@ override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDescriptor.
 override MetadataExtractor.Formats.Exif.Makernotes.PanasonicMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.PentaxMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFire2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.RicohMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SamsungType2MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SanyoMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SigmaMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType1MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.SonyType6MakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawDistortionDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawIfd0Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfo2Directory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PanasonicRawWbInfoDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Exif.PrintIMDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.PrintIMDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.PrintIMDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileSystem.FileMetadataDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileSystem.FileMetadataDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.FileType.FileTypeDirectory.Name.get -> string!
-override MetadataExtractor.Formats.FileType.FileTypeDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifAnimationDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifAnimationDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifAnimationDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifControlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Gif.GifControlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifControlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Gif.GifImageDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Gif.GifImageDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicImagePropertiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Heif.HeicImagePropertyDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Heif.HeicThumbnailDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Icc.IccDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Icc.IccDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Icc.IccDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Ico.IcoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Ico.IcoDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Iptc.IptcDescriptor.GetDescription(int tagType) -> string?
@@ -3755,29 +3710,22 @@ override MetadataExtractor.Formats.Jfxx.JfxxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Jpeg.JpegComponent.ToString() -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jpeg.JpegDnlDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Jpeg.JpegDnlDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Mpeg.Mp3Directory.Name.get -> string!
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Netpbm.NetpbmHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Pcx.PcxDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Pcx.PcxDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.DuckyDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
-override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.Equals(object? obj) -> bool
 override MetadataExtractor.Formats.Png.PngChunkType.GetHashCode() -> int
 override MetadataExtractor.Formats.Png.PngChunkType.ToString() -> string!
@@ -3801,7 +3749,6 @@ override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
-override MetadataExtractor.Formats.WebP.WebPDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
@@ -4109,7 +4056,6 @@ const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagId = 1 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagLayer = 2 -> int
 const MetadataExtractor.Formats.Mpeg.Mp3Directory.TagMode = 5 -> int
 override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.Makernotes.DjiMakernoteDirectory.TryGetTagName(int tagType, out string? tagName) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(byte[]! bytes) -> bool
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernoteId -> uint
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernotePublicId -> uint

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,6 +2,8 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
+MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
@@ -41,3 +43,4 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.G
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool


### PR DESCRIPTION
Rather than have (nearly) all implementations override `TryGetTagName`, accept a dictionary into the base class.