### PR TITLE
Add support for FLIR thermal image metadata

### DIFF
--- a/MetadataExtractor.Samples/FlirSamples.cs
+++ b/MetadataExtractor.Samples/FlirSamples.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Drawing;
+using System.Drawing.Imaging;
+using System.IO;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using MetadataExtractor.Formats.Flir;
+using MetadataExtractor.Formats.Jpeg;
+using MetadataExtractor.Util;
+
+namespace MetadataExtractor.Samples
+{
+    public static class FlirSamples
+    {
+        public static void Main()
+        {
+            var inputFile = "my-input.jpg";   // path to a FLIR JPEG file
+            var outputFile = "my-output.png"; // path to the output thermal image
+
+            if (TryGetThermalImageBytesFromJpeg(inputFile, out byte[]? bytes, out int width, out int height))
+            {
+                WritePng(bytes, width, height, outputFile);
+            }
+        }
+
+        public static bool TryGetThermalImageBytesFromJpeg(
+            string jpegFile,
+            [NotNullWhen(returnValue: true)] out byte[]? imageBytes,
+            out int width,
+            out int height)
+        {
+            var readers = JpegMetadataReader
+                .AllReaders
+                .Where(reader => reader is not FlirReader)
+                .Concat(new[] { new FlirReader { ExtractRawThermalImage = true } })
+                .ToList();
+
+            var directories = JpegMetadataReader.ReadMetadata(jpegFile, readers);
+
+            var flirRawDataDirectory = directories.OfType<FlirRawDataDirectory>().FirstOrDefault();
+
+            if (flirRawDataDirectory is null)
+            {
+                imageBytes = null;
+                width = 0;
+                height = 0;
+                return false;
+            }
+
+            width = flirRawDataDirectory.GetInt32(FlirRawDataDirectory.TagRawThermalImageWidth);
+            height = flirRawDataDirectory.GetInt32(FlirRawDataDirectory.TagRawThermalImageHeight);
+            imageBytes = flirRawDataDirectory.GetByteArray(FlirRawDataDirectory.TagRawThermalImage);
+
+            return imageBytes != null;
+        }
+
+        public static void WritePng(byte[] thermalImageBytes, int width, int height, string outputFile)
+        {
+            var fileType = FileTypeDetector.DetectFileType(new MemoryStream(thermalImageBytes));
+
+            if (fileType == FileType.Png)
+            {
+                // Data is already in PNG format.
+                // It is likely already coloured and ready for presentation to a human.
+
+                File.WriteAllBytes(outputFile, thermalImageBytes);
+                return;
+            }
+
+            // Assume data is in uint16 grayscale.
+            //
+            // It is "raw" meaning uncoloured but, more importantly, the levels are unadjusted.
+            // For example, if the scene did not have much temperature variation relative to the
+            // range of the sensor, most values may be within a very narrow band of the 16-bit spectrum,
+            // making the image appear a flat gray. Opening it in Photoshop/Gimp/etc and adjusting levels
+            // will reveal the image.
+            //
+            // There is other metadata in the image that may inform this process (untested -- please
+            // share if you find a good process here).
+
+            var pixelFormats = PixelFormats.Gray16;
+
+            var bitmap = new Bitmap(width, height, System.Drawing.Imaging.PixelFormat.Format16bppGrayScale);
+
+            var data = bitmap.LockBits(new Rectangle(0, 0, width, height), ImageLockMode.WriteOnly, bitmap.PixelFormat);
+
+            Marshal.Copy(thermalImageBytes, 0, data.Scan0, thermalImageBytes.Length);
+
+            var source = BitmapSource.Create(
+                width,
+                height,
+                bitmap.HorizontalResolution,
+                bitmap.VerticalResolution,
+                pixelFormats,
+                null,
+                data.Scan0,
+                data.Stride * height,
+                data.Stride);
+
+            bitmap.UnlockBits(data);
+
+            using var stream = new FileStream(outputFile, FileMode.Create);
+
+            var encoder = new PngBitmapEncoder();
+            encoder.Frames.Add(BitmapFrame.Create(source));
+            encoder.Save(stream);
+        }
+    }
+}

--- a/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
+++ b/MetadataExtractor.Samples/MetadataExtractor.Samples.csproj
@@ -1,21 +1,25 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0;net35;net45</TargetFrameworks>
+    <TargetFramework>net48</TargetFramework>
     <OutputType>Exe</OutputType>
+    <StartupObject>MetadataExtractor.Samples.Program</StartupObject>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MetadataExtractor\MetadataExtractor.csproj" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System" />
+  <ItemGroup>
+    <PackageReference Include="Nullable" Version="1.3.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
+  <ItemGroup>
+    <Reference Include="PresentationCore" />
+    <Reference Include="WindowsBase" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.Tools.FileProcessor/MetadataExtractor.Tools.FileProcessor.csproj
+++ b/MetadataExtractor.Tools.FileProcessor/MetadataExtractor.Tools.FileProcessor.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net5.0</TargetFrameworks>
+    <TargetFramework>net5.0</TargetFramework>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
 

--- a/MetadataExtractor.sln.DotSettings
+++ b/MetadataExtractor.sln.DotSettings
@@ -53,6 +53,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Finepix/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fisheye/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Flashpix/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Flir/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Foveon/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=ftyp/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Fujifilm/@EntryIndexedValue">True</s:Boolean>

--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -600,6 +600,11 @@ namespace MetadataExtractor.Formats.Exif
                 PushDirectory(new DjiMakernoteDirectory());
                 TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
             }
+            else if (string.Equals("FLIR Systems", cameraMake, StringComparison.Ordinal))
+            {
+                PushDirectory(new FlirMakernoteDirectory());
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+            }
             else
             {
                 // The makernote is not comprehended by this library.

--- a/MetadataExtractor/Formats/Exif/makernotes/FlirMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/FlirMakernoteDescriptor.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public class FlirMakernoteDescriptor : TagDescriptor<FlirMakernoteDirectory>
+    {
+        public FlirMakernoteDescriptor(FlirMakernoteDirectory directory)
+            : base(directory)
+        {
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Exif/makernotes/FlirMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/FlirMakernoteDirectory.cs
@@ -1,0 +1,35 @@
+// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+
+namespace MetadataExtractor.Formats.Exif.Makernotes
+{
+    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
+    public class FlirMakernoteDirectory : Directory
+    {
+        public const int TagImageTemperatureMax = 0x0001;
+        public const int TagImageTemperatureMin = 0x0002;
+        public const int TagEmissivity = 0x0003;
+        public const int TagUnknownTemperature = 0x0004;
+        public const int TagCameraTemperatureRangeMin = 0x0005;
+        public const int TagCameraTemperatureRangeMax = 0x0006;
+
+        private static readonly Dictionary<int, string> _tagNameMap = new()
+        {
+            { TagImageTemperatureMax, "Image Temperature Max" },
+            { TagImageTemperatureMin, "Image Temperature Min" },
+            { TagEmissivity, "Emissivity" },
+            { TagUnknownTemperature, "Unknown Temperature" },
+            { TagCameraTemperatureRangeMin, "Camera Temperature Range Max" },
+            { TagCameraTemperatureRangeMax, "Camera Temperature Range Min" }
+        };
+
+        public FlirMakernoteDirectory() : base(_tagNameMap)
+        {
+            SetDescriptor(new FlirMakernoteDescriptor(this));
+        }
+
+        public override string Name => "FLIR Makernote";
+    }
+}

--- a/MetadataExtractor/Formats/Flir/FlirCameraInfoDescriptor.cs
+++ b/MetadataExtractor/Formats/Flir/FlirCameraInfoDescriptor.cs
@@ -1,0 +1,47 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using static MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory;
+
+namespace MetadataExtractor.Formats.Flir
+{
+    public sealed class FlirCameraInfoDescriptor : TagDescriptor<FlirCameraInfoDirectory>
+    {
+        public FlirCameraInfoDescriptor(FlirCameraInfoDirectory directory)
+            : base(directory)
+        {
+        }
+
+        public override string? GetDescription(int tagType)
+        {
+            return tagType switch
+            {
+                TagReflectedApparentTemperature => KelvinToCelcius(),
+                TagAtmosphericTemperature => KelvinToCelcius(),
+                TagIRWindowTemperature => KelvinToCelcius(),
+                TagRelativeHumidity => RelativeHumidity(),
+                TagCameraTemperatureRangeMax => KelvinToCelcius(),
+                TagCameraTemperatureRangeMin => KelvinToCelcius(),
+                TagCameraTemperatureMaxClip => KelvinToCelcius(),
+                TagCameraTemperatureMinClip => KelvinToCelcius(),
+                TagCameraTemperatureMaxWarn => KelvinToCelcius(),
+                TagCameraTemperatureMinWarn => KelvinToCelcius(),
+                TagCameraTemperatureMaxSaturated => KelvinToCelcius(),
+                TagCameraTemperatureMinSaturated => KelvinToCelcius(),
+                _ => base.GetDescription(tagType)
+            };
+
+            string KelvinToCelcius()
+            {
+                float f = Directory.GetSingle(tagType) - 273.15f;
+                return $"{f:N1} C";
+            }
+
+            string RelativeHumidity()
+            {
+                float f = Directory.GetSingle(tagType);
+                float val = (f > 2 ? f / 100 : f);
+                return $"{(val * 100):N1} %";
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Flir/FlirCameraInfoDirectory.cs
+++ b/MetadataExtractor/Formats/Flir/FlirCameraInfoDirectory.cs
@@ -1,0 +1,109 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace MetadataExtractor.Formats.Flir
+{
+    public sealed class FlirCameraInfoDirectory : Directory
+    {
+        public const int TagEmissivity = 32;
+        public const int TagObjectDistance = 36;
+        public const int TagReflectedApparentTemperature = 40;
+        public const int TagAtmosphericTemperature = 44;
+        public const int TagIRWindowTemperature = 48;
+        public const int TagIRWindowTransmission = 52;
+        public const int TagRelativeHumidity = 60;
+        public const int TagPlanckR1 = 88;
+        public const int TagPlanckB = 92;
+        public const int TagPlanckF = 96;
+        public const int TagAtmosphericTransAlpha1 = 112;
+        public const int TagAtmosphericTransAlpha2 = 116;
+        public const int TagAtmosphericTransBeta1 = 120;
+        public const int TagAtmosphericTransBeta2 = 124;
+        public const int TagAtmosphericTransX = 128;
+        public const int TagCameraTemperatureRangeMax = 144;
+        public const int TagCameraTemperatureRangeMin = 148;
+        public const int TagCameraTemperatureMaxClip = 152;
+        public const int TagCameraTemperatureMinClip = 156;
+        public const int TagCameraTemperatureMaxWarn = 160;
+        public const int TagCameraTemperatureMinWarn = 164;
+        public const int TagCameraTemperatureMaxSaturated = 168;
+        public const int TagCameraTemperatureMinSaturated = 172;
+        public const int TagCameraModel = 212;
+        public const int TagCameraPartNumber = 244;
+        public const int TagCameraSerialNumber = 260;
+        public const int TagCameraSoftware = 276;
+        public const int TagLensModel = 368;
+        public const int TagLensPartNumber = 400;
+        public const int TagLensSerialNumber = 416;
+        public const int TagFieldOfView = 436;
+        public const int TagFilterModel = 492;
+        public const int TagFilterPartNumber = 508;
+        public const int TagFilterSerialNumber = 540;
+        public const int TagPlanckO = 776;
+        public const int TagPlanckR2 = 780;
+        public const int TagRawValueRangeMin = 784;
+        public const int TagRawValueRangeMax = 786;
+        public const int TagRawValueMedian = 824;
+        public const int TagRawValueRange = 828;
+        public const int TagDateTimeOriginal = 900;
+        public const int TagFocusStepCount = 912;
+        public const int TagFocusDistance = 1116;
+        public const int TagFrameRate = 1124;
+
+        public override string Name => "FLIR Camera Info";
+
+        private static readonly Dictionary<int, string> _nameByTag = new()
+        {
+            { TagEmissivity, "Emissivity" },
+            { TagObjectDistance, "Object Distance" },
+            { TagReflectedApparentTemperature, "Reflected Apparent Temperature" },
+            { TagAtmosphericTemperature, "Atmospheric Temperature" },
+            { TagIRWindowTemperature, "IR Window Temperature" },
+            { TagIRWindowTransmission, "IR Window Transmission" },
+            { TagRelativeHumidity, "Relative Humidity" },
+            { TagPlanckR1, "Planck R1" },
+            { TagPlanckB, "Planck B" },
+            { TagPlanckF, "Planck F" },
+            { TagAtmosphericTransAlpha1, "Atmospheric Trans Alpha1" },
+            { TagAtmosphericTransAlpha2, "Atmospheric Trans Alpha2" },
+            { TagAtmosphericTransBeta1, "Atmospheric Trans Beta1" },
+            { TagAtmosphericTransBeta2, "Atmospheric Trans Beta2" },
+            { TagAtmosphericTransX, "Atmospheric Trans X" },
+            { TagCameraTemperatureRangeMax, "Camera Temperature Range Max" },
+            { TagCameraTemperatureRangeMin, "Camera Temperature Range Min" },
+            { TagCameraTemperatureMaxClip, "Camera Temperature Max Clip" },
+            { TagCameraTemperatureMinClip, "Camera Temperature Min Clip" },
+            { TagCameraTemperatureMaxWarn, "Camera Temperature Max Warn" },
+            { TagCameraTemperatureMinWarn, "Camera Temperature Min Warn" },
+            { TagCameraTemperatureMaxSaturated, "Camera Temperature Max Saturated" },
+            { TagCameraTemperatureMinSaturated, "Camera Temperature Min Saturated" },
+            { TagCameraModel, "Camera Model" },
+            { TagCameraPartNumber, "Camera Part Number" },
+            { TagCameraSerialNumber, "Camera Serial Number" },
+            { TagCameraSoftware, "Camera Software" },
+            { TagLensModel, "Lens Model" },
+            { TagLensPartNumber, "Lens Part Number" },
+            { TagLensSerialNumber, "Lens Serial Number" },
+            { TagFieldOfView, "Field Of View" },
+            { TagFilterModel, "Filter Model" },
+            { TagFilterPartNumber, "Filter Part Number" },
+            { TagFilterSerialNumber, "Filter Serial Number" },
+            { TagPlanckO, "Planck O" },
+            { TagPlanckR2, "Planck R2" },
+            { TagRawValueRangeMin, "Raw Value Range Min" },
+            { TagRawValueRangeMax, "Raw Value Range Max" },
+            { TagRawValueMedian, "Raw Value Median" },
+            { TagRawValueRange, "Raw Value Range" },
+            { TagDateTimeOriginal, "Date Time Original" },
+            { TagFocusStepCount, "Focus Step Count" },
+            { TagFocusDistance, "Focus Distance" },
+            { TagFrameRate, "Frame Rate" }
+        };
+
+        public FlirCameraInfoDirectory() : base(_nameByTag)
+        {
+            SetDescriptor(new FlirCameraInfoDescriptor(this));
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Flir/FlirHeaderDirectory.cs
+++ b/MetadataExtractor/Formats/Flir/FlirHeaderDirectory.cs
@@ -1,0 +1,23 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace MetadataExtractor.Formats.Flir
+{
+    public sealed class FlirHeaderDirectory : Directory
+    {
+        public override string Name => "FLIR Header";
+
+        public const int TagCreatorSoftware = 0;
+
+        private static readonly Dictionary<int, string> _nameByTag = new()
+        {
+            { TagCreatorSoftware, "Creator Software" }
+        };
+
+        public FlirHeaderDirectory() : base(_nameByTag)
+        {
+            SetDescriptor(new TagDescriptor<FlirHeaderDirectory>(this));
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Flir/FlirMainTagType.cs
+++ b/MetadataExtractor/Formats/Flir/FlirMainTagType.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MetadataExtractor.Formats.Flir
+{
+    internal enum FlirMainTagType : ushort
+    {
+        // General
+
+        Unused = 0,
+        Pixels = 1,
+        GainMap = 2,
+        OffsMap = 3,
+        DeadMap = 4,
+        GainDeadMap = 5,
+        CoarseMap = 6,
+        ImageMap = 7,
+
+        // FLIR matrix tags
+
+        BasicData = 0x20,
+        Measure,
+        ColorPal
+    }
+}

--- a/MetadataExtractor/Formats/Flir/FlirRawDataDirectory.cs
+++ b/MetadataExtractor/Formats/Flir/FlirRawDataDirectory.cs
@@ -1,0 +1,29 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Collections.Generic;
+
+namespace MetadataExtractor.Formats.Flir
+{
+    public sealed class FlirRawDataDirectory : Directory
+    {
+        public const int TagRawThermalImageWidth = 2;
+        public const int TagRawThermalImageHeight = 4;
+        public const int TagRawThermalImageType = 34;
+        public const int TagRawThermalImage = 100;
+
+        public override string Name => "FLIR Raw Data";
+
+        private static readonly Dictionary<int, string> _nameByTag = new()
+        {
+            { TagRawThermalImageWidth, "Raw Thermal Image Width" },
+            { TagRawThermalImageHeight, "Raw Thermal Image Height" },
+            { TagRawThermalImageType, "Raw Thermal Image Type" },
+            { TagRawThermalImage, "Raw Thermal Image" }
+        };
+
+        public FlirRawDataDirectory() : base(_nameByTag)
+        {
+            SetDescriptor(new TagDescriptor<FlirRawDataDirectory>(this));
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Flir/FlirReader.cs
+++ b/MetadataExtractor/Formats/Flir/FlirReader.cs
@@ -1,0 +1,181 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using MetadataExtractor.Formats.Jpeg;
+using MetadataExtractor.IO;
+using MetadataExtractor.Util;
+using static MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory;
+
+namespace MetadataExtractor.Formats.Flir
+{
+    public class FlirReader : IJpegSegmentMetadataReader
+    {
+        /// <summary>Flir metadata stored in JPEG files' APP1 segment are preceded by this six character preamble "FLIR\0\0".</summary>
+        public const string JpegSegmentPreamble = "FLIR\0";
+
+        public bool ExtractRawThermalImage { get; set; }
+
+        private byte[] PreambleBytes { get; } = Encoding.ASCII.GetBytes(JpegSegmentPreamble);
+
+        public ICollection<JpegSegmentType> SegmentTypes { get; } = new[] { JpegSegmentType.App1 };
+
+        public IEnumerable<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
+        {
+            var preamble = PreambleBytes;
+            var preambleLength = preamble.Length + 3;
+
+            int length = 0;
+
+            foreach (var segment in segments)
+            {
+                // Skip segments not starting with the required preamble
+                if (segment.Bytes.StartsWith(preamble))
+                {
+                    length += segment.Bytes.Length - preambleLength;
+                }
+            }
+
+            if (length == 0)
+                return Enumerable.Empty<Directory>();
+
+            var buffer = new byte[length];
+            using var merged = new MemoryStream(buffer);
+
+            foreach (var segment in segments)
+            {
+                // Skip segments not starting with the required preamble
+                if (segment.Bytes.StartsWith(preamble))
+                {
+                    merged.Write(segment.Bytes, preambleLength, segment.Bytes.Length - preambleLength);
+                }
+            }
+
+            return Extract(new ByteArrayReader(buffer));
+        }
+
+        public IEnumerable<Directory> Extract(IndexedReader reader)
+        {
+            var header = reader.GetUInt32(0);
+
+            if (header != 0x46464600)
+            {
+                var flirHeaderDirectory = new FlirHeaderDirectory();
+                flirHeaderDirectory.AddError("Unexpected FFF header bytes.");
+                yield return flirHeaderDirectory;
+                yield break;
+            }
+
+            var headerDirectory = new FlirHeaderDirectory();
+            headerDirectory.Set(FlirHeaderDirectory.TagCreatorSoftware, reader.GetNullTerminatedStringValue(4, 16));
+            yield return headerDirectory;
+
+            var baseIndexOffset = reader.GetUInt32(24);
+            var indexCount = reader.GetUInt32(28);
+
+            var indexOffset = checked((int)baseIndexOffset);
+            for (int i = 0; i < indexCount; i++)
+            {
+                var mainType = (FlirMainTagType)reader.GetUInt16(indexOffset);
+                var subType = reader.GetUInt16(indexOffset + 2); // 1=BE, 2=LE, 3=PNG; 1 for other record types
+                var version = reader.GetUInt32(indexOffset + 4);
+                var id = reader.GetUInt32(indexOffset + 8);
+                var dataOffset = reader.GetInt32(indexOffset + 12);
+                var dataLength = reader.GetInt32(indexOffset + 16);
+
+                if (mainType == FlirMainTagType.Pixels)
+                {
+                    var reader2 = reader.WithShiftedBaseOffset(dataOffset);
+
+                    // should be 0x0002 if byte order is correct
+                    var marker = reader2.GetUInt16(0);
+                    if (marker > 0x0100)
+                        reader2 = reader2.WithByteOrder(!reader2.IsMotorolaByteOrder);
+
+                    var directory = new FlirRawDataDirectory();
+
+                    directory.Set(FlirRawDataDirectory.TagRawThermalImageWidth, reader2.GetUInt16(FlirRawDataDirectory.TagRawThermalImageWidth));
+                    directory.Set(FlirRawDataDirectory.TagRawThermalImageHeight, reader2.GetUInt16(FlirRawDataDirectory.TagRawThermalImageHeight));
+                    directory.Set(FlirRawDataDirectory.TagRawThermalImageType, reader2.GetUInt16(FlirRawDataDirectory.TagRawThermalImageType));
+
+                    if (ExtractRawThermalImage)
+                    {
+                        directory.Set(FlirRawDataDirectory.TagRawThermalImage, reader2.GetBytes(32, dataLength - 32));
+                    }
+
+                    yield return directory;
+                }
+                else if (mainType == FlirMainTagType.BasicData)
+                {
+                    var reader2 = reader.WithShiftedBaseOffset(dataOffset);
+
+                    // should be 0x0002 if byte order is correct
+                    var marker = reader2.GetUInt16(0);
+                    if (marker > 0x0100)
+                        reader2 = reader2.WithByteOrder(!reader2.IsMotorolaByteOrder);
+
+                    var directory = new FlirCameraInfoDirectory();
+
+                    directory.Set(TagEmissivity, reader2.GetFloat32(TagEmissivity));
+                    directory.Set(TagObjectDistance, reader2.GetFloat32(TagObjectDistance));
+                    directory.Set(TagReflectedApparentTemperature, reader2.GetFloat32(TagReflectedApparentTemperature));
+                    directory.Set(TagAtmosphericTemperature, reader2.GetFloat32(TagAtmosphericTemperature));
+                    directory.Set(TagIRWindowTemperature, reader2.GetFloat32(TagIRWindowTemperature));
+                    directory.Set(TagIRWindowTransmission, reader2.GetFloat32(TagIRWindowTransmission));
+                    directory.Set(TagRelativeHumidity, reader2.GetFloat32(TagRelativeHumidity));
+                    directory.Set(TagPlanckR1, reader2.GetFloat32(TagPlanckR1));
+                    directory.Set(TagPlanckB, reader2.GetFloat32(TagPlanckB));
+                    directory.Set(TagPlanckF, reader2.GetFloat32(TagPlanckF));
+                    directory.Set(TagAtmosphericTransAlpha1, reader2.GetFloat32(TagAtmosphericTransAlpha1));
+                    directory.Set(TagAtmosphericTransAlpha2, reader2.GetFloat32(TagAtmosphericTransAlpha2));
+                    directory.Set(TagAtmosphericTransBeta1, reader2.GetFloat32(TagAtmosphericTransBeta1));
+                    directory.Set(TagAtmosphericTransBeta2, reader2.GetFloat32(TagAtmosphericTransBeta2));
+                    directory.Set(TagAtmosphericTransX, reader2.GetFloat32(TagAtmosphericTransX));
+                    directory.Set(TagCameraTemperatureRangeMax, reader2.GetFloat32(TagCameraTemperatureRangeMax));
+                    directory.Set(TagCameraTemperatureRangeMin, reader2.GetFloat32(TagCameraTemperatureRangeMin));
+                    directory.Set(TagCameraTemperatureMaxClip, reader2.GetFloat32(TagCameraTemperatureMaxClip));
+                    directory.Set(TagCameraTemperatureMinClip, reader2.GetFloat32(TagCameraTemperatureMinClip));
+                    directory.Set(TagCameraTemperatureMaxWarn, reader2.GetFloat32(TagCameraTemperatureMaxWarn));
+                    directory.Set(TagCameraTemperatureMinWarn, reader2.GetFloat32(TagCameraTemperatureMinWarn));
+                    directory.Set(TagCameraTemperatureMaxSaturated, reader2.GetFloat32(TagCameraTemperatureMaxSaturated));
+                    directory.Set(TagCameraTemperatureMinSaturated, reader2.GetFloat32(TagCameraTemperatureMinSaturated));
+                    directory.Set(TagCameraModel, reader2.GetNullTerminatedStringValue(TagCameraModel, 32));
+                    directory.Set(TagCameraPartNumber, reader2.GetNullTerminatedStringValue(TagCameraPartNumber, 16));
+                    directory.Set(TagCameraSerialNumber, reader2.GetNullTerminatedStringValue(TagCameraSerialNumber, 16));
+                    directory.Set(TagCameraSoftware, reader2.GetNullTerminatedStringValue(TagCameraSoftware, 16));
+                    directory.Set(TagLensModel, reader2.GetNullTerminatedStringValue(TagLensModel, 32));
+                    directory.Set(TagLensPartNumber, reader2.GetNullTerminatedStringValue(TagLensPartNumber, 16));
+                    directory.Set(TagLensSerialNumber, reader2.GetNullTerminatedStringValue(TagLensSerialNumber, 16));
+                    directory.Set(TagFieldOfView, reader2.GetFloat32(TagFieldOfView));
+                    directory.Set(TagFilterModel, reader2.GetNullTerminatedStringValue(TagFilterModel, 16));
+                    directory.Set(TagFilterPartNumber, reader2.GetNullTerminatedStringValue(TagFilterPartNumber, 32));
+                    directory.Set(TagFilterSerialNumber, reader2.GetNullTerminatedStringValue(TagFilterSerialNumber, 32));
+                    directory.Set(TagPlanckO, reader2.GetInt32(TagPlanckO));
+                    directory.Set(TagPlanckR2, reader2.GetFloat32(TagPlanckR2));
+                    directory.Set(TagRawValueRangeMin, reader2.GetUInt16(TagRawValueRangeMin));
+                    directory.Set(TagRawValueRangeMax, reader2.GetUInt16(TagRawValueRangeMax));
+                    directory.Set(TagRawValueMedian, reader2.GetUInt16(TagRawValueMedian));
+                    directory.Set(TagRawValueRange, reader2.GetUInt16(TagRawValueRange));
+
+                    var dateTimeBytes = reader2.GetBytes(TagDateTimeOriginal, 10);
+                    var dateTimeReader = new SequentialByteArrayReader(dateTimeBytes, isMotorolaByteOrder: false);
+                    var tm = dateTimeReader.GetUInt32();
+                    var ss = dateTimeReader.GetUInt32() & 0xffff;
+                    var tz = dateTimeReader.GetInt16();
+                    directory.Set(TagDateTimeOriginal, new DateTimeOffset(DateUtil.FromUnixTime(tm - tz * 60).AddSeconds(ss / 1000d), TimeSpan.FromMinutes(tz)));
+
+                    directory.Set(TagFocusStepCount, reader2.GetUInt16(TagFocusStepCount));
+                    directory.Set(TagFocusDistance, reader2.GetFloat32(TagFocusDistance));
+                    directory.Set(TagFrameRate, reader2.GetUInt16(TagFrameRate));
+
+                    yield return directory;
+                }
+
+                indexOffset += 32;
+            }
+        }
+    }
+}

--- a/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
@@ -11,6 +11,7 @@ using MetadataExtractor.Formats.Jfif;
 using MetadataExtractor.Formats.Jfxx;
 using MetadataExtractor.Formats.Photoshop;
 using MetadataExtractor.Formats.FileSystem;
+using MetadataExtractor.Formats.Flir;
 using MetadataExtractor.Formats.Xmp;
 using MetadataExtractor.IO;
 
@@ -45,6 +46,7 @@ namespace MetadataExtractor.Formats.Jpeg
                 yield return new AdobeJpegReader();
                 yield return new JpegDhtReader();
                 yield return new JpegDnlReader();
+                yield return new FlirReader();
             }
         }
 

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
@@ -2,10 +2,85 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMax = 1 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMin = 2 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagUnknownTemperature = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTemperature = 44 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha1 = 112 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha2 = 116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta1 = 120 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta2 = 124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransX = 128 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraModel = 212 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraPartNumber = 244 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSerialNumber = 260 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSoftware = 276 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxClip = 152 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxSaturated = 168 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxWarn = 160 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinClip = 156 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinSaturated = 172 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinWarn = 164 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMax = 144 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMin = 148 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagDateTimeOriginal = 900 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagEmissivity = 32 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFieldOfView = 436 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterModel = 492 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterPartNumber = 508 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterSerialNumber = 540 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusDistance = 1116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusStepCount = 912 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFrameRate = 1124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTemperature = 48 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTransmission = 52 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensModel = 368 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensPartNumber = 400 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensSerialNumber = 416 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagObjectDistance = 36 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckB = 92 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckF = 96 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckO = 776 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR1 = 88 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR2 = 780 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueMedian = 824 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRange = 828 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMax = 786 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMin = 784 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagReflectedApparentTemperature = 40 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRelativeHumidity = 60 -> int
+const MetadataExtractor.Formats.Flir.FlirHeaderDirectory.TagCreatorSoftware = 0 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImage = 100 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageHeight = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageType = 34 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageWidth = 2 -> int
+const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
 MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
 MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor.FlirMakernoteDescriptor(MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory! directory) -> void
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.FlirMakernoteDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.FlirCameraInfoDescriptor(MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory! directory) -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.FlirCameraInfoDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory.FlirHeaderDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory.FlirRawDataDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirReader
+MetadataExtractor.Formats.Flir.FlirReader.Extract(MetadataExtractor.IO.IndexedReader! reader) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.get -> bool
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.set -> void
+MetadataExtractor.Formats.Flir.FlirReader.FlirReader() -> void
+MetadataExtractor.Formats.Flir.FlirReader.ReadJpegSegments(System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.JpegSegment!>! segments) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.JpegSegmentWithPreambleMetadataReader() -> void
@@ -36,11 +111,18 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirHeaderDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirRawDataDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
+static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -2,10 +2,85 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMax = 1 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMin = 2 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagUnknownTemperature = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTemperature = 44 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha1 = 112 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha2 = 116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta1 = 120 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta2 = 124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransX = 128 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraModel = 212 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraPartNumber = 244 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSerialNumber = 260 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSoftware = 276 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxClip = 152 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxSaturated = 168 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxWarn = 160 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinClip = 156 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinSaturated = 172 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinWarn = 164 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMax = 144 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMin = 148 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagDateTimeOriginal = 900 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagEmissivity = 32 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFieldOfView = 436 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterModel = 492 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterPartNumber = 508 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterSerialNumber = 540 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusDistance = 1116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusStepCount = 912 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFrameRate = 1124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTemperature = 48 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTransmission = 52 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensModel = 368 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensPartNumber = 400 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensSerialNumber = 416 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagObjectDistance = 36 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckB = 92 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckF = 96 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckO = 776 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR1 = 88 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR2 = 780 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueMedian = 824 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRange = 828 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMax = 786 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMin = 784 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagReflectedApparentTemperature = 40 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRelativeHumidity = 60 -> int
+const MetadataExtractor.Formats.Flir.FlirHeaderDirectory.TagCreatorSoftware = 0 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImage = 100 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageHeight = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageType = 34 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageWidth = 2 -> int
+const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
 MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
 MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor.FlirMakernoteDescriptor(MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory! directory) -> void
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.FlirMakernoteDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.FlirCameraInfoDescriptor(MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory! directory) -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.FlirCameraInfoDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory.FlirHeaderDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory.FlirRawDataDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirReader
+MetadataExtractor.Formats.Flir.FlirReader.Extract(MetadataExtractor.IO.IndexedReader! reader) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.get -> bool
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.set -> void
+MetadataExtractor.Formats.Flir.FlirReader.FlirReader() -> void
+MetadataExtractor.Formats.Flir.FlirReader.ReadJpegSegments(System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.JpegSegment!>! segments) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.JpegSegmentWithPreambleMetadataReader() -> void
@@ -36,11 +111,18 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirHeaderDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirRawDataDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
+static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -2,10 +2,85 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMax = 1 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMin = 2 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagUnknownTemperature = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTemperature = 44 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha1 = 112 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha2 = 116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta1 = 120 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta2 = 124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransX = 128 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraModel = 212 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraPartNumber = 244 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSerialNumber = 260 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSoftware = 276 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxClip = 152 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxSaturated = 168 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxWarn = 160 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinClip = 156 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinSaturated = 172 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinWarn = 164 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMax = 144 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMin = 148 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagDateTimeOriginal = 900 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagEmissivity = 32 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFieldOfView = 436 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterModel = 492 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterPartNumber = 508 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterSerialNumber = 540 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusDistance = 1116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusStepCount = 912 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFrameRate = 1124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTemperature = 48 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTransmission = 52 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensModel = 368 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensPartNumber = 400 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensSerialNumber = 416 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagObjectDistance = 36 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckB = 92 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckF = 96 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckO = 776 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR1 = 88 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR2 = 780 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueMedian = 824 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRange = 828 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMax = 786 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMin = 784 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagReflectedApparentTemperature = 40 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRelativeHumidity = 60 -> int
+const MetadataExtractor.Formats.Flir.FlirHeaderDirectory.TagCreatorSoftware = 0 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImage = 100 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageHeight = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageType = 34 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageWidth = 2 -> int
+const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
 MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
 MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor.FlirMakernoteDescriptor(MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory! directory) -> void
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.FlirMakernoteDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.FlirCameraInfoDescriptor(MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory! directory) -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.FlirCameraInfoDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory.FlirHeaderDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory.FlirRawDataDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirReader
+MetadataExtractor.Formats.Flir.FlirReader.Extract(MetadataExtractor.IO.IndexedReader! reader) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.get -> bool
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.set -> void
+MetadataExtractor.Formats.Flir.FlirReader.FlirReader() -> void
+MetadataExtractor.Formats.Flir.FlirReader.ReadJpegSegments(System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.JpegSegment!>! segments) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.JpegSegmentWithPreambleMetadataReader() -> void
@@ -36,11 +111,18 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirHeaderDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirRawDataDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
+static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,10 +2,85 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMax = 1 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagImageTemperatureMin = 2 -> int
+const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagUnknownTemperature = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTemperature = 44 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha1 = 112 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransAlpha2 = 116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta1 = 120 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransBeta2 = 124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagAtmosphericTransX = 128 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraModel = 212 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraPartNumber = 244 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSerialNumber = 260 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraSoftware = 276 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxClip = 152 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxSaturated = 168 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMaxWarn = 160 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinClip = 156 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinSaturated = 172 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureMinWarn = 164 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMax = 144 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagCameraTemperatureRangeMin = 148 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagDateTimeOriginal = 900 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagEmissivity = 32 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFieldOfView = 436 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterModel = 492 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterPartNumber = 508 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFilterSerialNumber = 540 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusDistance = 1116 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFocusStepCount = 912 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagFrameRate = 1124 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTemperature = 48 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagIRWindowTransmission = 52 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensModel = 368 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensPartNumber = 400 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagLensSerialNumber = 416 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagObjectDistance = 36 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckB = 92 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckF = 96 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckO = 776 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR1 = 88 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagPlanckR2 = 780 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueMedian = 824 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRange = 828 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMax = 786 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRawValueRangeMin = 784 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagReflectedApparentTemperature = 40 -> int
+const MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.TagRelativeHumidity = 60 -> int
+const MetadataExtractor.Formats.Flir.FlirHeaderDirectory.TagCreatorSoftware = 0 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImage = 100 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageHeight = 4 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageType = 34 -> int
+const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageWidth = 2 -> int
+const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
 MetadataExtractor.Directory.Directory(System.Collections.Generic.Dictionary<int, string!>? tagNameMap) -> void
 MetadataExtractor.Formats.Exif.ExifDirectoryBase.ExifDirectoryBase(System.Collections.Generic.Dictionary<int, string!>! tagNameMap) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetAccelerationVectorDescription() -> string?
 MetadataExtractor.Formats.Exif.Makernotes.AppleMakernoteDescriptor.GetHdrImageTypeDescription() -> string?
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDescriptor.FlirMakernoteDescriptor(MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory! directory) -> void
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory
+MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.FlirMakernoteDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor
+MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.FlirCameraInfoDescriptor(MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory! directory) -> void
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory
+MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.FlirCameraInfoDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory
+MetadataExtractor.Formats.Flir.FlirHeaderDirectory.FlirHeaderDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory
+MetadataExtractor.Formats.Flir.FlirRawDataDirectory.FlirRawDataDirectory() -> void
+MetadataExtractor.Formats.Flir.FlirReader
+MetadataExtractor.Formats.Flir.FlirReader.Extract(MetadataExtractor.IO.IndexedReader! reader) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.get -> bool
+MetadataExtractor.Formats.Flir.FlirReader.ExtractRawThermalImage.set -> void
+MetadataExtractor.Formats.Flir.FlirReader.FlirReader() -> void
+MetadataExtractor.Formats.Flir.FlirReader.ReadJpegSegments(System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.JpegSegment!>! segments) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
+MetadataExtractor.Formats.Flir.FlirReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 MetadataExtractor.Formats.Jpeg.HuffmanTable.HuffmanTable() -> void
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader
 MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.JpegSegmentWithPreambleMetadataReader() -> void
@@ -36,11 +111,19 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirHeaderDirectory.Name.get -> string!
+override MetadataExtractor.Formats.Flir.FlirRawDataDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
+override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
+static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/Util/DateUtil.cs
+++ b/MetadataExtractor/Util/DateUtil.cs
@@ -23,7 +23,7 @@ namespace MetadataExtractor.Util
                minutes >= 0 && minutes < 60 &&
                seconds >= 0 && seconds < 60;
 
-        private static readonly DateTime _unixEpoch = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+        private static readonly DateTime _unixEpoch = new(1970, 1, 1, 0, 0, 0);
 
         public static DateTime FromUnixTime(long unixTime) => _unixEpoch.AddSeconds(unixTime);
     }


### PR DESCRIPTION
This PR adds support for various kinds of FLIR metadata.

- FLIR Makernote
- FLIR metadata from JPEG APP1 segments
  - Header info
  - Camera info
  - Raw thermal image info

By setting `FlirReader.ExtractRawThermalImage` to `true`, it's possible to extract the raw thermal data as well. This data has been observed in both raw `int16` data and PNG encoded data.