### PR TITLE
Allow Application Notes (XMP) in SubIFD

### DIFF
--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -198,7 +198,7 @@ namespace MetadataExtractor.Formats.Exif
             }
 
             // Custom processing for embedded XMP data
-            if (tagId == ExifDirectoryBase.TagApplicationNotes && CurrentDirectory is ExifIfd0Directory)
+            if (tagId == ExifDirectoryBase.TagApplicationNotes && CurrentDirectory is ExifIfd0Directory or ExifSubIfdDirectory)
             {
                 var xmpDirectory = new XmpReader().Extract(reader.GetNullTerminatedBytes(tagOffset, byteCount));
                 xmpDirectory.Parent = CurrentDirectory;


### PR DESCRIPTION
This fixes an issue where XMP data was not being extracted from some DJI images, and allows presentation of data such as:

```
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:AbsoluteAltitude = -30.037239
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:RelativeAltitude = 19.700001
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalRollDegree = 0.000000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalYawDegree = 69.400002
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalPitchDegree = -60.000000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:FlightRollDegree = -2.100000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:FlightYawDegree = 69.699997
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:FlightPitchDegree = -0.500000
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:CamReverse = 0
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:GimbalReverse = 0
[XMPMeta - http://www.dji.com/drone-dji/1.0/] drone-dji:RtkFlag = 0
```