### PR TITLE
Fix reading arrays of Float64 in TIFF files

### DIFF
--- a/MetadataExtractor/Formats/Tiff/TiffReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffReader.cs
@@ -301,7 +301,7 @@ namespace MetadataExtractor.Formats.Tiff
                     {
                         var array = new double[componentCount];
                         for (var i = 0; i < componentCount; i++)
-                            array[i] = reader.GetDouble64(tagValueOffset + i * 4);
+                            array[i] = reader.GetDouble64(tagValueOffset + i * 8);
                         handler.SetDoubleArray(tagId, array);
                     }
                     break;


### PR DESCRIPTION
Port of https://github.com/drewnoakes/metadata-extractor/pull/548

Thanks to @fclof for finding this.