### PR TITLE
Support BigTIFF encoded TIFF data

### DIFF
--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -249,6 +249,46 @@ namespace MetadataExtractor
                 catch
                 {
                     // ignored
+                }
+            }
+
+            value = default;
+            return false;
+        }
+
+        #endregion
+
+        #region UInt64
+
+        /// <summary>Returns a tag's value as an <see cref="ulong"/>, or throws if conversion is not possible.</summary>
+        /// <remarks>
+        /// If the value is <see cref="IConvertible"/>, then that interface is used for conversion of the value.
+        /// If the value is an array of <see cref="IConvertible"/> having length one, then the single item is converted.
+        /// </remarks>
+        /// <exception cref="MetadataException">No value exists for <paramref name="tagType"/>, or the value is not convertible to the requested type.</exception>
+        [Pure]
+        public static ulong GetUInt64(this Directory directory, int tagType)
+        {
+            if (directory.TryGetUInt64(tagType, out ulong value))
+                return value;
+
+            return ThrowValueNotPossible<ulong>(directory, tagType);
+        }
+
+        [Pure]
+        public static bool TryGetUInt64(this Directory directory, int tagType, out ulong value)
+        {
+            var convertible = GetConvertibleObject(directory, tagType);
+
+            if (convertible != null)
+            {
+                try
+                {
+                    value = convertible.ToUInt64(null);
+                    return true;
+                }
+                catch
+                {
                     // ignored
                 }
             }

--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -30,14 +30,14 @@ namespace MetadataExtractor.Formats.Exif
         { }
 
         /// <exception cref="TiffProcessingException"/>
-        public override void SetTiffMarker(int marker)
+        public override void SetTiffMarker(ushort marker)
         {
 #pragma warning disable format
 
-            const int StandardTiffMarker     = 0x002A;
-            const int OlympusRawTiffMarker   = 0x4F52; // for ORF files
-            const int OlympusRawTiffMarker2  = 0x5352; // for ORF files
-            const int PanasonicRawTiffMarker = 0x0055; // for RAW, RW2, and RWL files
+            const ushort StandardTiffMarker     = 0x002A;
+            const ushort OlympusRawTiffMarker   = 0x4F52; // for ORF files
+            const ushort OlympusRawTiffMarker2  = 0x5352; // for ORF files
+            const ushort PanasonicRawTiffMarker = 0x0055; // for RAW, RW2, and RWL files
 
 #pragma warning restore format
 

--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -138,7 +138,7 @@ namespace MetadataExtractor.Formats.Exif
             }
         }
 
-        public override bool CustomProcessTag(int tagOffset, ICollection<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount)
+        public override bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount)
         {
             // Some 0x0000 tags have a 0 byteCount. Determine whether it's bad.
             if (tagId == 0)
@@ -318,7 +318,7 @@ namespace MetadataExtractor.Formats.Exif
         }
 
         /// <exception cref="IOException"/>
-        private bool ProcessMakernote(int makernoteOffset, ICollection<int> processedIfdOffsets, IndexedReader reader)
+        private bool ProcessMakernote(int makernoteOffset, HashSet<int> processedIfdOffsets, IndexedReader reader)
         {
             Debug.Assert(makernoteOffset >= 0, "makernoteOffset >= 0");
 

--- a/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
+++ b/MetadataExtractor/Formats/Exif/ExifTiffHandler.cs
@@ -30,11 +30,12 @@ namespace MetadataExtractor.Formats.Exif
         { }
 
         /// <exception cref="TiffProcessingException"/>
-        public override void SetTiffMarker(ushort marker)
+        public override TiffStandard ProcessTiffMarker(ushort marker)
         {
 #pragma warning disable format
 
             const ushort StandardTiffMarker     = 0x002A;
+            const ushort BigTiffMarker          = 0x002B;
             const ushort OlympusRawTiffMarker   = 0x4F52; // for ORF files
             const ushort OlympusRawTiffMarker2  = 0x5352; // for ORF files
             const ushort PanasonicRawTiffMarker = 0x0055; // for RAW, RW2, and RWL files
@@ -44,6 +45,7 @@ namespace MetadataExtractor.Formats.Exif
             switch (marker)
             {
                 case StandardTiffMarker:
+                case BigTiffMarker:
                 case OlympusRawTiffMarker:  // Todo: implement an IFD0
                 case OlympusRawTiffMarker2: // Todo: implement an IFD0
                     PushDirectory(new ExifIfd0Directory());
@@ -54,6 +56,10 @@ namespace MetadataExtractor.Formats.Exif
                 default:
                     throw new TiffProcessingException($"Unexpected TIFF marker: 0x{marker:X}");
             }
+
+            return marker == BigTiffMarker
+                ? TiffStandard.BigTiff
+                : TiffStandard.Tiff;
         }
 
         public override bool TryEnterSubIfd(int tagId)
@@ -138,7 +144,7 @@ namespace MetadataExtractor.Formats.Exif
             }
         }
 
-        public override bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount)
+        public override bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount, bool isBigTiff)
         {
             // Some 0x0000 tags have a 0 byteCount. Determine whether it's bad.
             if (tagId == 0)
@@ -156,7 +162,7 @@ namespace MetadataExtractor.Formats.Exif
 
             // Custom processing for the Makernote tag
             if (tagId == ExifDirectoryBase.TagMakernote && CurrentDirectory is ExifSubIfdDirectory)
-                return ProcessMakernote(tagOffset, processedIfdOffsets, reader);
+                return ProcessMakernote(tagOffset, processedIfdOffsets, reader, isBigTiff);
 
             // Custom processing for embedded IPTC data
             if (tagId == ExifDirectoryBase.TagIptcNaa && CurrentDirectory is ExifIfd0Directory)
@@ -222,35 +228,35 @@ namespace MetadataExtractor.Formats.Exif
                 {
                     case OlympusMakernoteDirectory.TagEquipment:
                         PushDirectory(new OlympusEquipmentMakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                     case OlympusMakernoteDirectory.TagCameraSettings:
                         PushDirectory(new OlympusCameraSettingsMakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                     case OlympusMakernoteDirectory.TagRawDevelopment:
                         PushDirectory(new OlympusRawDevelopmentMakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                     case OlympusMakernoteDirectory.TagRawDevelopment2:
                         PushDirectory(new OlympusRawDevelopment2MakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                     case OlympusMakernoteDirectory.TagImageProcessing:
                         PushDirectory(new OlympusImageProcessingMakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                     case OlympusMakernoteDirectory.TagFocusInfo:
                         PushDirectory(new OlympusFocusInfoMakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                     case OlympusMakernoteDirectory.TagRawInfo:
                         PushDirectory(new OlympusRawInfoMakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                     case OlympusMakernoteDirectory.TagMainInfo:
                         PushDirectory(new OlympusMakernoteDirectory());
-                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset);
+                        TiffReader.ProcessIfd(this, reader, processedIfdOffsets, tagOffset, isBigTiff);
                         return true;
                 }
             }
@@ -298,7 +304,7 @@ namespace MetadataExtractor.Formats.Exif
             return false;
         }
 
-        public override bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, uint componentCount, out long byteCount)
+        public override bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount)
         {
             if ((ushort)formatCode == 13u)
             {
@@ -318,7 +324,7 @@ namespace MetadataExtractor.Formats.Exif
         }
 
         /// <exception cref="IOException"/>
-        private bool ProcessMakernote(int makernoteOffset, HashSet<int> processedIfdOffsets, IndexedReader reader)
+        private bool ProcessMakernote(int makernoteOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, bool isBigTiff)
         {
             Debug.Assert(makernoteOffset >= 0, "makernoteOffset >= 0");
 
@@ -344,7 +350,7 @@ namespace MetadataExtractor.Formats.Exif
                 // Olympus Makernote
                 // Epson and Agfa use Olympus makernote standard: http://www.ozhiker.com/electronics/pjmt/jpeg_info/
                 PushDirectory(new OlympusMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 8);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 8, isBigTiff);
             }
             else if (string.Equals("OLYMPUS\0II", firstTenChars, StringComparison.Ordinal))
             {
@@ -352,14 +358,14 @@ namespace MetadataExtractor.Formats.Exif
                 // Note that data is relative to the beginning of the makernote
                 // http://exiv2.org/makernote.html
                 PushDirectory(new OlympusMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 12);
+                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 12, isBigTiff);
             }
             else if (cameraMake != null && cameraMake.StartsWith("MINOLTA", StringComparison.OrdinalIgnoreCase))
             {
                 // Cases seen with the model starting with MINOLTA in capitals seem to have a valid Olympus makernote
                 // area that commences immediately.
                 PushDirectory(new OlympusMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
             }
             else if (cameraMake != null && cameraMake.TrimStart().StartsWith("NIKON", StringComparison.OrdinalIgnoreCase))
             {
@@ -378,13 +384,13 @@ namespace MetadataExtractor.Formats.Exif
                              * :0010: 00 08 00 1E 00 01 00 07-00 00 00 04 30 32 30 30 ............0200
                              */
                             PushDirectory(new NikonType1MakernoteDirectory());
-                            TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 8);
+                            TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 8, isBigTiff);
                             break;
                         }
                         case 2:
                         {
                             PushDirectory(new NikonType2MakernoteDirectory());
-                            TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset + 10), processedIfdOffsets, 8);
+                            TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset + 10), processedIfdOffsets, 8, isBigTiff);
                             break;
                         }
                         default:
@@ -398,14 +404,14 @@ namespace MetadataExtractor.Formats.Exif
                 {
                     // The IFD begins with the first Makernote byte (no ASCII name).  This occurs with CoolPix 775, E990 and D1 models.
                     PushDirectory(new NikonType2MakernoteDirectory());
-                    TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                    TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
                 }
             }
             else if (string.Equals("SONY CAM", firstEightChars, StringComparison.Ordinal) ||
                      string.Equals("SONY DSC", firstEightChars, StringComparison.Ordinal))
             {
                 PushDirectory(new SonyType1MakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 12);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 12, isBigTiff);
             }
             // Do this check LAST after most other Sony checks
             else if (cameraMake != null && cameraMake.StartsWith("SONY", StringComparison.Ordinal) &&
@@ -413,20 +419,20 @@ namespace MetadataExtractor.Formats.Exif
             {
                 // The IFD begins with the first Makernote byte (no ASCII name). Used in SR2 and ARW images
                 PushDirectory(new SonyType1MakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
             }
             else if (string.Equals("SEMC MS\u0000\u0000\u0000\u0000\u0000", firstTwelveChars, StringComparison.Ordinal))
             {
                 // Force Motorola byte order for this directory
                 // skip 12 byte header + 2 for "MM" + 6
                 PushDirectory(new SonyType6MakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: true), processedIfdOffsets, makernoteOffset + 20);
+                TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: true), processedIfdOffsets, makernoteOffset + 20, isBigTiff);
             }
             else if (string.Equals("SIGMA\u0000\u0000\u0000", firstEightChars, StringComparison.Ordinal) ||
                      string.Equals("FOVEON\u0000\u0000", firstEightChars, StringComparison.Ordinal))
             {
                 PushDirectory(new SigmaMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 10);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 10, isBigTiff);
             }
             else if (string.Equals("KDK", firstThreeChars, StringComparison.Ordinal))
             {
@@ -437,19 +443,19 @@ namespace MetadataExtractor.Formats.Exif
             else if ("CANON".Equals(cameraMake, StringComparison.OrdinalIgnoreCase))
             {
                 PushDirectory(new CanonMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
             }
             else if (cameraMake != null && cameraMake.StartsWith("CASIO", StringComparison.OrdinalIgnoreCase))
             {
                 if (string.Equals("QVC\u0000\u0000\u0000", firstSixChars, StringComparison.Ordinal))
                 {
                     PushDirectory(new CasioType2MakernoteDirectory());
-                    TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 6);
+                    TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 6, isBigTiff);
                 }
                 else
                 {
                     PushDirectory(new CasioType1MakernoteDirectory());
-                    TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                    TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
                 }
             }
             else if (string.Equals("FUJIFILM", firstEightChars, StringComparison.Ordinal) ||
@@ -461,13 +467,13 @@ namespace MetadataExtractor.Formats.Exif
                 var makernoteReader = reader.WithShiftedBaseOffset(makernoteOffset).WithByteOrder(isMotorolaByteOrder: false);
                 var ifdStart = makernoteReader.GetInt32(8);
                 PushDirectory(new FujifilmMakernoteDirectory());
-                TiffReader.ProcessIfd(this, makernoteReader, processedIfdOffsets, ifdStart);
+                TiffReader.ProcessIfd(this, makernoteReader, processedIfdOffsets, ifdStart, isBigTiff);
             }
             else if (string.Equals("KYOCERA", firstSevenChars, StringComparison.Ordinal))
             {
                 // http://www.ozhiker.com/electronics/pjmt/jpeg_info/kyocera_mn.html
                 PushDirectory(new KyoceraMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 22);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 22, isBigTiff);
             }
             else if (string.Equals("LEICA", firstFiveChars, StringComparison.Ordinal))
             {
@@ -485,18 +491,18 @@ namespace MetadataExtractor.Formats.Exif
                     string.Equals("LEICA\0\x7\0", firstEightChars, StringComparison.Ordinal))
                 {
                     PushDirectory(new LeicaType5MakernoteDirectory());
-                    TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 8);
+                    TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 8, isBigTiff);
                 }
                 else if (string.Equals("Leica Camera AG", cameraMake, StringComparison.Ordinal))
                 {
                     PushDirectory(new LeicaMakernoteDirectory());
-                    TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: false), processedIfdOffsets, makernoteOffset + 8);
+                    TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: false), processedIfdOffsets, makernoteOffset + 8, isBigTiff);
                 }
                 else if (string.Equals("LEICA", cameraMake, StringComparison.Ordinal))
                 {
                     // Some Leica cameras use Panasonic makernote tags
                     PushDirectory(new PanasonicMakernoteDirectory());
-                    TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: false), processedIfdOffsets, makernoteOffset + 8);
+                    TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: false), processedIfdOffsets, makernoteOffset + 8, isBigTiff);
                 }
                 else
                 {
@@ -509,7 +515,7 @@ namespace MetadataExtractor.Formats.Exif
                 // Offsets are relative to the start of the TIFF header at the beginning of the EXIF segment
                 // more information here: http://www.ozhiker.com/electronics/pjmt/jpeg_info/panasonic_mn.html
                 PushDirectory(new PanasonicMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 12);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset + 12, isBigTiff);
             }
             else if (string.Equals("AOC\u0000", firstFourChars, StringComparison.Ordinal))
             {
@@ -519,7 +525,7 @@ namespace MetadataExtractor.Formats.Exif
                 // Observed for:
                 // - Pentax ist D
                 PushDirectory(new CasioType2MakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 6);
+                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 6, isBigTiff);
             }
             else if (cameraMake != null && (cameraMake.StartsWith("PENTAX", StringComparison.OrdinalIgnoreCase) || cameraMake.StartsWith("ASAHI", StringComparison.OrdinalIgnoreCase)))
             {
@@ -530,7 +536,7 @@ namespace MetadataExtractor.Formats.Exif
                 // - PENTAX Optio 330
                 // - PENTAX Optio 430
                 PushDirectory(new PentaxMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 0);
+                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 0, isBigTiff);
             }
             /*
             else if ("KC" == firstTwoChars || "MINOL" == firstFiveChars || "MLY" == firstThreeChars || "+M+M+M+M" == firstEightChars)
@@ -544,7 +550,7 @@ namespace MetadataExtractor.Formats.Exif
             else if (string.Equals("SANYO\x0\x1\x0", firstEightChars, StringComparison.Ordinal))
             {
                 PushDirectory(new SanyoMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 8);
+                TiffReader.ProcessIfd(this, reader.WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 8, isBigTiff);
             }
             else if (cameraMake != null && cameraMake.StartsWith("RICOH", StringComparison.OrdinalIgnoreCase))
             {
@@ -562,14 +568,14 @@ namespace MetadataExtractor.Formats.Exif
                 {
                     PushDirectory(new RicohMakernoteDirectory());
                     // Always in Motorola byte order
-                    TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: true).WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 8);
+                    TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: true).WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 8, isBigTiff);
                 }
             }
             else if (string.Equals(firstTenChars, "Apple iOS\0", StringComparison.Ordinal))
             {
                 PushDirectory(new AppleMakernoteDirectory());
                 // Always in Motorola byte order
-                TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: true).WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 14);
+                TiffReader.ProcessIfd(this, reader.WithByteOrder(isMotorolaByteOrder: true).WithShiftedBaseOffset(makernoteOffset), processedIfdOffsets, 14, isBigTiff);
             }
             else if (reader.GetUInt16(makernoteOffset) == ReconyxHyperFireMakernoteDirectory.MakernoteVersion)
             {
@@ -593,17 +599,17 @@ namespace MetadataExtractor.Formats.Exif
             {
                 // Only handles Type2 notes correctly. Others aren't implemented, and it's complex to determine which ones to use
                 PushDirectory(new SamsungType2MakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
             }
             else if (string.Equals("DJI", cameraMake, StringComparison.Ordinal))
             {
                 PushDirectory(new DjiMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
             }
             else if (string.Equals("FLIR Systems", cameraMake, StringComparison.Ordinal))
             {
                 PushDirectory(new FlirMakernoteDirectory());
-                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset);
+                TiffReader.ProcessIfd(this, reader, processedIfdOffsets, makernoteOffset, isBigTiff);
             }
             else
             {

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopTiffHandler.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopTiffHandler.cs
@@ -30,7 +30,7 @@ namespace MetadataExtractor.Formats.Photoshop
         {
         }
 
-        public override bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount)
+        public override bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount, bool isBigTiff)
         {
             switch (tagId)
             {
@@ -45,7 +45,7 @@ namespace MetadataExtractor.Formats.Photoshop
                     return true;
             }
 
-            return base.CustomProcessTag(tagOffset, processedIfdOffsets, reader, tagId, byteCount);
+            return base.CustomProcessTag(tagOffset, processedIfdOffsets, reader, tagId, byteCount, isBigTiff);
         }
     }
 }

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopTiffHandler.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopTiffHandler.cs
@@ -30,7 +30,7 @@ namespace MetadataExtractor.Formats.Photoshop
         {
         }
 
-        public override bool CustomProcessTag(int tagOffset, ICollection<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount)
+        public override bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount)
         {
             switch (tagId)
             {

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
@@ -14,9 +14,9 @@ namespace MetadataExtractor.Formats.QuickTime
         {
         }
 
-        public override void SetTiffMarker(int marker)
+        public override void SetTiffMarker(ushort marker)
         {
-            const int StandardTiffMarker = 0x002A;
+            const ushort StandardTiffMarker = 0x002A;
             if (marker != StandardTiffMarker)
             {
                 throw new TiffProcessingException($"Unexpected TIFF marker: 0x{marker:X}");

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTiffHandler.cs
@@ -14,14 +14,21 @@ namespace MetadataExtractor.Formats.QuickTime
         {
         }
 
-        public override void SetTiffMarker(ushort marker)
+        public override TiffStandard ProcessTiffMarker(ushort marker)
         {
             const ushort StandardTiffMarker = 0x002A;
-            if (marker != StandardTiffMarker)
+            const ushort BigTiffMarker = 0x002B;
+
+            var standard = marker switch
             {
-                throw new TiffProcessingException($"Unexpected TIFF marker: 0x{marker:X}");
-            }
+                StandardTiffMarker => TiffStandard.Tiff,
+                BigTiffMarker => TiffStandard.BigTiff,
+                _ => throw new TiffProcessingException($"Unexpected TIFF marker: 0x{marker:X}")
+            };
+
             PushDirectory(new T());
+
+            return standard;
         }
     }
 }

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -88,6 +88,6 @@ namespace MetadataExtractor.Formats.Tiff
 
         public abstract bool TryEnterSubIfd(int tagType);
 
-        public abstract void SetTiffMarker(int marker);
+        public abstract void SetTiffMarker(ushort marker);
     }
 }

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -80,7 +80,7 @@ namespace MetadataExtractor.Formats.Tiff
 
 #pragma warning restore format
 
-        public abstract bool CustomProcessTag(int tagOffset, ICollection<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount);
+        public abstract bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount);
 
         public abstract bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, uint componentCount, out long byteCount);
 

--- a/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/DirectoryTiffHandler.cs
@@ -77,17 +77,21 @@ namespace MetadataExtractor.Formats.Tiff
         public void SetInt32SArray(int tagId, int[] array)        => CurrentDirectory!.Set(tagId, array);
         public void SetInt32U(int tagId, uint int32U)             => CurrentDirectory!.Set(tagId, int32U);
         public void SetInt32UArray(int tagId, uint[] array)       => CurrentDirectory!.Set(tagId, array);
+        public void SetInt64S(int tagId, long int64S)             => CurrentDirectory!.Set(tagId, int64S);
+        public void SetInt64SArray(int tagId, long[] array)       => CurrentDirectory!.Set(tagId, array);
+        public void SetInt64U(int tagId, ulong int64U)            => CurrentDirectory!.Set(tagId, int64U);
+        public void SetInt64UArray(int tagId, ulong[] array)      => CurrentDirectory!.Set(tagId, array);
 
 #pragma warning restore format
 
-        public abstract bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount);
+        public abstract bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount, bool isBigTiff);
 
-        public abstract bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, uint componentCount, out long byteCount);
+        public abstract bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount);
 
         public abstract bool HasFollowerIfd();
 
         public abstract bool TryEnterSubIfd(int tagType);
 
-        public abstract void SetTiffMarker(ushort marker);
+        public abstract TiffStandard ProcessTiffMarker(ushort marker);
     }
 }

--- a/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
@@ -30,7 +30,7 @@ namespace MetadataExtractor.Formats.Tiff
         void EndingIfd();
 
         /// <exception cref="System.IO.IOException"/>
-        bool CustomProcessTag(int tagOffset, ICollection<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount);
+        bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount);
 
         bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, uint componentCount, out long byteCount);
 

--- a/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
@@ -12,16 +12,17 @@ namespace MetadataExtractor.Formats.Tiff
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public interface ITiffHandler
     {
-        /// <summary>Receives the 2-byte marker found in the TIFF header.</summary>
-        /// <remarks>
+        /// <summary>
         /// Receives the 2-byte marker found in the TIFF header.
-        /// <para />
+        /// </summary>
+        /// <remarks>
         /// Implementations are not obligated to use this information for any purpose, though it may be useful for
         /// validation or perhaps differentiating the type of mapping to use for observed tags and IFDs.
         /// </remarks>
-        /// <param name="marker">the 2-byte value found at position 2 of the TIFF header</param>
-        /// <exception cref="TiffProcessingException"/>
-        void SetTiffMarker(ushort marker);
+        /// <param name="marker">The 2-byte value found at position 2 of the TIFF header.</param>
+        /// <returns>The TIFF standard via which to interpret the data stream.</returns>
+        /// <exception cref="TiffProcessingException">The value of <paramref name="marker"/> is not supported.</exception>
+        TiffStandard ProcessTiffMarker(ushort marker);
 
         bool TryEnterSubIfd(int tagType);
 
@@ -30,9 +31,9 @@ namespace MetadataExtractor.Formats.Tiff
         void EndingIfd();
 
         /// <exception cref="System.IO.IOException"/>
-        bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount);
+        bool CustomProcessTag(int tagOffset, HashSet<int> processedIfdOffsets, IndexedReader reader, int tagId, int byteCount, bool isBigTiff);
 
-        bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, uint componentCount, out long byteCount);
+        bool TryCustomProcessFormat(int tagId, TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount);
 
         void Warn(string message);
 
@@ -77,5 +78,13 @@ namespace MetadataExtractor.Formats.Tiff
         void SetInt32U(int tagId, uint int32U);
 
         void SetInt32UArray(int tagId, uint[] array);
+
+        void SetInt64S(int tagId, long int64S);
+
+        void SetInt64SArray(int tagId, long[] array);
+
+        void SetInt64U(int tagId, ulong int64U);
+
+        void SetInt64UArray(int tagId, ulong[] array);
     }
 }

--- a/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
+++ b/MetadataExtractor/Formats/Tiff/ITiffHandler.cs
@@ -21,7 +21,7 @@ namespace MetadataExtractor.Formats.Tiff
         /// </remarks>
         /// <param name="marker">the 2-byte value found at position 2 of the TIFF header</param>
         /// <exception cref="TiffProcessingException"/>
-        void SetTiffMarker(int marker);
+        void SetTiffMarker(ushort marker);
 
         bool TryEnterSubIfd(int tagType);
 

--- a/MetadataExtractor/Formats/Tiff/TiffDataFormat.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffDataFormat.cs
@@ -17,7 +17,12 @@ namespace MetadataExtractor.Formats.Tiff
         Int32S = 9,
         RationalS = 10,
         Single = 11,
-        Double = 12
+        Double = 12,
+
+        // From BigTIFF
+        Int64U = 16,
+        Int64S = 17,
+        Ifd8 = 18
     }
 
     /// <summary>An enumeration of data formats used by the TIFF specification.</summary>
@@ -37,9 +42,14 @@ namespace MetadataExtractor.Formats.Tiff
         public static readonly TiffDataFormat RationalS = new("SRATIONAL", TiffDataFormatCode.RationalS, 8);
         public static readonly TiffDataFormat Single    = new("SINGLE",    TiffDataFormatCode.Single,    4);
         public static readonly TiffDataFormat Double    = new("DOUBLE",    TiffDataFormatCode.Double,    8);
+
+        // From BigTIFF
+        public static readonly TiffDataFormat Int64U    = new("ULONG8",    TiffDataFormatCode.Int64U,    8);
+        public static readonly TiffDataFormat Int64S    = new("SLONG8",    TiffDataFormatCode.Int64S,    8);
+        public static readonly TiffDataFormat Ifd8      = new("IFD8",      TiffDataFormatCode.Ifd8,      8);
 #pragma warning restore format
 
-        public static TiffDataFormat? FromTiffFormatCode(TiffDataFormatCode tiffFormatCode)
+        public static TiffDataFormat? FromTiffFormatCode(TiffDataFormatCode tiffFormatCode, bool isBigTiff)
         {
             return tiffFormatCode switch
             {
@@ -56,15 +66,22 @@ namespace MetadataExtractor.Formats.Tiff
                 TiffDataFormatCode.Single => Single,
                 TiffDataFormatCode.Double => Double,
 
+                // From BigTIFF
+                TiffDataFormatCode.Int64U => isBigTiff ? Int64U : null,
+                TiffDataFormatCode.Int64S => isBigTiff ? Int64S : null,
+                TiffDataFormatCode.Ifd8 => isBigTiff ? Ifd8 : null,
+
                 _ => null,
             };
         }
 
         public string Name { get; }
-        public int ComponentSizeBytes { get; }
+
+        public byte ComponentSizeBytes { get; }
+
         public TiffDataFormatCode TiffFormatCode { get; }
 
-        private TiffDataFormat(string name, TiffDataFormatCode tiffFormatCode, int componentSizeBytes)
+        private TiffDataFormat(string name, TiffDataFormatCode tiffFormatCode, byte componentSizeBytes)
         {
             Name = name ?? throw new ArgumentNullException(nameof(name));
             TiffFormatCode = tiffFormatCode;

--- a/MetadataExtractor/Formats/Tiff/TiffReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffReader.cs
@@ -29,7 +29,7 @@ namespace MetadataExtractor.Formats.Tiff
             };
 
             // Check the next two values for correctness.
-            int tiffMarker = reader.GetUInt16(2);
+            var tiffMarker = reader.GetUInt16(2);
             handler.SetTiffMarker(tiffMarker);
 
             var firstIfdOffset = reader.GetInt32(4);

--- a/MetadataExtractor/Formats/Tiff/TiffReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffReader.cs
@@ -19,8 +19,25 @@ namespace MetadataExtractor.Formats.Tiff
         /// <exception cref="TiffProcessingException"/>
         public static void ProcessTiff(IndexedReader reader, ITiffHandler handler)
         {
+            // Standard TIFF
+            //
+            // TIFF Header:
+            //   - 2 bytes: byte order (MM or II)
+            //   - 2 bytes: version (always 42)
+            //   - 4 bytes: offset to first IFD
+
+            // Big TIFF
+            //
+            // TIFF Header:
+            //   - 2 bytes: byte order (MM or II)
+            //   - 2 bytes: version (always 43)
+            //   - 2 bytes: byte size of offsets (always 8)
+            //   - 2 bytes: reserved (always 0)
+            //   - 8 bytes: offset to first IFD
+
             // Read byte order.
             var byteOrder = reader.GetInt16(0);
+
             reader = byteOrder switch
             {
                 0x4d4d => reader.WithByteOrder(isMotorolaByteOrder: true),
@@ -30,45 +47,86 @@ namespace MetadataExtractor.Formats.Tiff
 
             // Check the next two values for correctness.
             var tiffMarker = reader.GetUInt16(2);
-            handler.SetTiffMarker(tiffMarker);
+            var tiffStandard = handler.ProcessTiffMarker(tiffMarker);
 
-            var firstIfdOffset = reader.GetInt32(4);
+            bool isBigTiff;
 
-            // David Ekholm sent a digital camera image that has this problem
-            // TODO calling Length should be avoided as it causes IndexedCapturingReader to read to the end of the stream
-            if (firstIfdOffset >= reader.Length - 1)
+            int firstIfdOffset;
+
+            switch (tiffStandard)
             {
-                handler.Warn("First IFD offset is beyond the end of the TIFF data segment -- trying default offset");
-                // First directory normally starts immediately after the offset bytes, so try that
-                firstIfdOffset = 2 + 2 + 4;
+                case TiffStandard.Tiff:
+                    isBigTiff = false;
+                    firstIfdOffset = checked((int)reader.GetUInt32(4));
+
+                    // David Ekholm sent a digital camera image that has this problem
+                    // TODO calling Length should be avoided as it causes IndexedCapturingReader to read to the end of the stream
+                    if (firstIfdOffset >= reader.Length - 1)
+                    {
+                        handler.Warn("First IFD offset is beyond the end of the TIFF data segment -- trying default offset");
+                        // First directory normally starts immediately after the offset bytes, so try that
+                        firstIfdOffset = 2 + 2 + 4;
+                    }
+
+                    break;
+
+                case TiffStandard.BigTiff:
+                    isBigTiff = true;
+                    var offsetByteSize = reader.GetInt16(4);
+
+                    if (offsetByteSize != 8)
+                    {
+                        handler.Error($"Unsupported offset byte size: {offsetByteSize}");
+                        return;
+                    }
+
+                    // There are two reserved bytes at offset 6, which are expected to have zero value.
+                    // We skip without validation for now, but may change this in future.
+
+                    firstIfdOffset = checked((int)reader.GetUInt64(8));
+                    break;
+
+                default:
+                    handler.Error($"Unsupported TiffStandard {tiffStandard}.");
+                    return;
             }
 
             var processedIfdOffsets = new HashSet<int>();
 
-            ProcessIfd(handler, reader, processedIfdOffsets, firstIfdOffset);
+            ProcessIfd(handler, reader, processedIfdOffsets, firstIfdOffset, isBigTiff);
         }
 
         /// <summary>Processes a TIFF IFD.</summary>
-        /// <remarks>
-        /// IFD Header:
-        /// <list type="bullet">
-        ///   <item><b>2 bytes</b> number of tags</item>
-        /// </list>
-        /// Tag structure:
-        /// <list type="bullet">
-        ///   <item><b>2 bytes</b> tag type</item>
-        ///   <item><b>2 bytes</b> format code (values 1 to 12, inclusive)</item>
-        ///   <item><b>4 bytes</b> component count</item>
-        ///   <item><b>4 bytes</b> inline value, or offset pointer if too large to fit in four bytes</item>
-        /// </list>
-        /// </remarks>
         /// <param name="handler">the <see cref="ITiffHandler"/> that will coordinate processing and accept read values</param>
         /// <param name="reader">the <see cref="IndexedReader"/> from which the data should be read</param>
         /// <param name="processedIfdOffsets">the set of visited IFD offsets, to avoid revisiting the same IFD in an endless loop</param>
         /// <param name="ifdOffset">the offset within <c>reader</c> at which the IFD data starts</param>
+        /// <param name="isBigTiff">Whether the IFD uses the BigTIFF data format.</param>
         /// <exception cref="System.IO.IOException">an error occurred while accessing the required data</exception>
-        public static void ProcessIfd(ITiffHandler handler, IndexedReader reader, HashSet<int> processedIfdOffsets, int ifdOffset)
+        public static void ProcessIfd(ITiffHandler handler, IndexedReader reader, HashSet<int> processedIfdOffsets, int ifdOffset, bool isBigTiff)
         {
+            // Standard TIFF
+            //
+            // IFD Header:
+            //   - 2 bytes: number of tags
+            //
+            // Tag structure:
+            //   - 2 bytes: tag type
+            //   - 2 bytes: format code (values 1 to 12, inclusive)
+            //   - 4 bytes: component count
+            //   - 4 bytes: inline value, or offset pointer if too large to fit in four bytes
+
+            // BigTIFF
+            //
+            // IFD Header:
+            //   - 8 bytes: number of tags
+            //
+            // Tag structure:
+            //   - 2 bytes: tag type
+            //   - 2 bytes: format code (values 1 to 12, inclusive)
+            //   - 8 bytes: component count
+            //   - 8 bytes: inline value, or offset pointer if too large to fit in eight bytes
+
             try
             {
                 // Check for directories we've already visited to avoid stack overflows when recursive/cyclic directory structures exist.
@@ -85,25 +143,32 @@ namespace MetadataExtractor.Formats.Tiff
                     return;
                 }
 
-                // First two bytes in the IFD are the number of tags in this directory
-                int dirTagCount = reader.GetUInt16(ifdOffset);
+                // The number of tags in this directory
+                var dirTagCount = isBigTiff
+                    ? checked((int)reader.GetUInt64(ifdOffset))
+                    : reader.GetUInt16(ifdOffset);
 
                 // Some software modifies the byte order of the file, but misses some IFDs (such as makernotes).
                 // The entire test image repository doesn't contain a single IFD with more than 255 entries.
                 // Here we detect switched bytes that suggest this problem, and temporarily swap the byte order.
                 // This was discussed in GitHub issue #136.
-                if (dirTagCount > 0xFF && (dirTagCount & 0xFF) == 0)
+                if (!isBigTiff && dirTagCount > 0xFF && (dirTagCount & 0xFF) == 0)
                 {
                     dirTagCount >>= 8;
                     reader = reader.WithByteOrder(!reader.IsMotorolaByteOrder);
                 }
 
-                var dirLength = 2 + 12 * dirTagCount + 4;
-                if (dirLength + ifdOffset > reader.Length)
+                var dirLength = isBigTiff
+                    ? 8 + 20 * dirTagCount + 8
+                    : 2 + 12 * dirTagCount + 4;
+
+                if (dirLength + ifdOffset > checked((int)reader.Length))
                 {
                     handler.Error("Illegally sized IFD");
                     return;
                 }
+
+                var inlineValueSize = isBigTiff ? 8u : 4u;
 
                 //
                 // Handle each tag in this directory
@@ -111,27 +176,26 @@ namespace MetadataExtractor.Formats.Tiff
                 var invalidTiffFormatCodeCount = 0;
                 for (var tagNumber = 0; tagNumber < dirTagCount; tagNumber++)
                 {
-                    var tagOffset = CalculateTagOffset(ifdOffset, tagNumber);
+                    var tagOffset = CalculateTagOffset(ifdOffset, tagNumber, isBigTiff);
 
-                    // 2 bytes for the tag id
                     int tagId = reader.GetUInt16(tagOffset);
 
-                    // 2 bytes for the format code
                     var formatCode = (TiffDataFormatCode)reader.GetUInt16(tagOffset + 2);
 
-                    // 4 bytes dictate the number of components in this tag's data
-                    var componentCount = reader.GetUInt32(tagOffset + 4);
+                    var componentCount = isBigTiff
+                        ? reader.GetUInt64(tagOffset + 4)
+                        : reader.GetUInt32(tagOffset + 4);
 
-                    var format = TiffDataFormat.FromTiffFormatCode(formatCode);
+                    var format = TiffDataFormat.FromTiffFormatCode(formatCode, isBigTiff);
 
-                    long byteCount;
+                    ulong byteCount;
                     if (format == null)
                     {
                         if (!handler.TryCustomProcessFormat(tagId, formatCode, componentCount, out byteCount))
                         {
                             // This error suggests that we are processing at an incorrect index and will generate
                             // rubbish until we go out of bounds (which may be a while).  Exit now.
-                            handler.Error($"Invalid TIFF tag format code {formatCode} for tag 0x{tagId:X4}");
+                            handler.Error($"Invalid TIFF tag format code {(int)formatCode} for tag 0x{tagId:X4}");
                             // TODO specify threshold as a parameter, or provide some other external control over this behaviour
                             if (++invalidTiffFormatCodeCount > 5)
                             {
@@ -143,28 +207,33 @@ namespace MetadataExtractor.Formats.Tiff
                     }
                     else
                     {
-                        byteCount = componentCount * format.ComponentSizeBytes;
+                        byteCount = checked(componentCount * format.ComponentSizeBytes);
                     }
 
-                    long tagValueOffset;
-                    if (byteCount > 4)
+                    uint tagValueOffset;
+                    if (byteCount > inlineValueSize)
                     {
-                        // If it's bigger than 4 bytes, the dir entry contains an offset.
-                        tagValueOffset = reader.GetUInt32(tagOffset + 8);
-                        if (tagValueOffset + byteCount > reader.Length)
+                        // Value(s) are too big to fit inline. Follow the pointer.
+                        tagValueOffset = isBigTiff
+                            ? checked((uint)reader.GetUInt64(tagOffset + 12))
+                            : reader.GetUInt32(tagOffset + 8);
+
+                        if (tagValueOffset + byteCount > checked((ulong)reader.Length))
                         {
-                            // Bogus pointer offset and / or byteCount value
+                            // Bogus pointer offset and/or byteCount value
                             handler.Error("Illegal TIFF tag pointer offset");
                             continue;
                         }
                     }
                     else
                     {
-                        // 4 bytes or less and value is in the dir entry itself.
-                        tagValueOffset = tagOffset + 8;
+                        // Value(s) can fit inline.
+                        tagValueOffset = isBigTiff
+                            ? checked((uint)tagOffset + 12)
+                            : checked((uint)tagOffset + 8);
                     }
 
-                    if (tagValueOffset < 0 || tagValueOffset > reader.Length)
+                    if (tagValueOffset > reader.Length)
                     {
                         handler.Error("Illegal TIFF tag pointer offset");
                         continue;
@@ -172,7 +241,7 @@ namespace MetadataExtractor.Formats.Tiff
 
                     // Check that this tag isn't going to allocate outside the bounds of the data array.
                     // This addresses an uncommon OutOfMemoryError.
-                    if (byteCount < 0 || tagValueOffset + byteCount > reader.Length)
+                    if (tagValueOffset + byteCount > checked((ulong)reader.Length))
                     {
                         handler.Error("Illegal number of bytes for TIFF tag data: " + byteCount);
                         continue;
@@ -180,21 +249,21 @@ namespace MetadataExtractor.Formats.Tiff
 
                     // Some tags point to one or more additional IFDs to process
                     var isIfdPointer = false;
-                    if (byteCount == checked(4L * componentCount))
+                    if (byteCount == checked(4L * componentCount) || formatCode == TiffDataFormatCode.Ifd8)
                     {
-                        for (var i = 0; i < componentCount; i++)
+                        for (ulong i = 0; i < componentCount; i++)
                         {
                             if (handler.TryEnterSubIfd(tagId))
                             {
                                 isIfdPointer = true;
-                                var subDirOffset = reader.GetUInt32((int)(tagValueOffset + i * 4));
-                                ProcessIfd(handler, reader, processedIfdOffsets, (int)subDirOffset);
+                                var subDirOffset = reader.GetUInt32(checked((int)(tagValueOffset + i * 4)));
+                                ProcessIfd(handler, reader, processedIfdOffsets, (int)subDirOffset, isBigTiff);
                             }
                         }
                     }
 
                     // If it wasn't an IFD pointer, allow custom tag processing to occur
-                    if (!isIfdPointer && !handler.CustomProcessTag((int)tagValueOffset, processedIfdOffsets, reader, tagId, (int)byteCount))
+                    if (!isIfdPointer && !handler.CustomProcessTag((int)tagValueOffset, processedIfdOffsets, reader, tagId, (int)byteCount, isBigTiff))
                     {
                         // If no custom processing occurred, process the tag in the standard fashion
                         ProcessTag(handler, tagId, (int)tagValueOffset, (int)componentCount, formatCode, reader);
@@ -202,10 +271,16 @@ namespace MetadataExtractor.Formats.Tiff
                 }
 
                 // at the end of each IFD is an optional link to the next IFD
-                var finalTagOffset = CalculateTagOffset(ifdOffset, dirTagCount);
-                var nextIfdOffset = reader.GetInt32(finalTagOffset);
-                if (nextIfdOffset != 0)
+                var finalTagOffset = CalculateTagOffset(ifdOffset, dirTagCount, isBigTiff);
+
+                var nextIfdOffsetLong = isBigTiff
+                    ? reader.GetUInt64(finalTagOffset)
+                    : reader.GetUInt32(finalTagOffset);
+
+                if (nextIfdOffsetLong != 0 && nextIfdOffsetLong <= int.MaxValue)
                 {
+                    var nextIfdOffset = (int)nextIfdOffsetLong;
+
                     if (nextIfdOffset >= reader.Length)
                     {
                         // Last 4 bytes of IFD reference another IFD with an address that is out of bounds
@@ -219,7 +294,9 @@ namespace MetadataExtractor.Formats.Tiff
                     }
 
                     if (handler.HasFollowerIfd())
-                        ProcessIfd(handler, reader, processedIfdOffsets, nextIfdOffset);
+                    {
+                        ProcessIfd(handler, reader, processedIfdOffsets, nextIfdOffset, isBigTiff);
+                    }
                 }
             }
             finally
@@ -396,9 +473,39 @@ namespace MetadataExtractor.Formats.Tiff
                     }
                     break;
                 }
+                case TiffDataFormatCode.Int64S:
+                {
+                    if (componentCount == 1)
+                    {
+                        handler.SetInt64S(tagId, reader.GetInt64(tagValueOffset));
+                    }
+                    else
+                    {
+                        var array = new long[componentCount];
+                        for (var i = 0; i < componentCount; i++)
+                            array[i] = reader.GetInt64(tagValueOffset + i * 8);
+                        handler.SetInt64SArray(tagId, array);
+                    }
+                    break;
+                }
+                case TiffDataFormatCode.Int64U:
+                {
+                    if (componentCount == 1)
+                    {
+                        handler.SetInt64U(tagId, reader.GetUInt64(tagValueOffset));
+                    }
+                    else
+                    {
+                        var array = new ulong[componentCount];
+                        for (var i = 0; i < componentCount; i++)
+                            array[i] = reader.GetUInt64(tagValueOffset + i * 8);
+                        handler.SetInt64UArray(tagId, array);
+                    }
+                    break;
+                }
                 default:
                 {
-                    handler.Error($"Invalid TIFF tag format code {formatCode} for tag 0x{tagId:X4}");
+                    handler.Error($"Invalid TIFF tag format code {(int)formatCode} for tag 0x{tagId:X4}");
                     break;
                 }
             }
@@ -407,10 +514,16 @@ namespace MetadataExtractor.Formats.Tiff
         /// <summary>Determine the offset of a given tag within the specified IFD.</summary>
         /// <remarks>
         /// Add 2 bytes for the tag count.
-        /// Each entry is 12 bytes.
+        /// Each entry is 12 bytes for regular TIFF, or 20 bytes for BigTIFF.
         /// </remarks>
-        /// <param name="ifdStartOffset">the offset at which the IFD starts</param>
-        /// <param name="entryNumber">the zero-based entry number</param>
-        private static int CalculateTagOffset(int ifdStartOffset, int entryNumber) => ifdStartOffset + 2 + 12 * entryNumber;
+        /// <param name="ifdStartOffset">The offset at which the IFD starts.</param>
+        /// <param name="entryNumber">The zero-based entry number.</param>
+        /// <param name="isBigTiff">Whether we are using BigTIFF encoding.</param>
+        private static int CalculateTagOffset(int ifdStartOffset, int entryNumber, bool isBigTiff)
+        {
+            return !isBigTiff
+                ? ifdStartOffset + 2 + 12 * entryNumber
+                : ifdStartOffset + 8 + 20 * entryNumber;
+        }
     }
 }

--- a/MetadataExtractor/Formats/Tiff/TiffStandard.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffStandard.cs
@@ -1,0 +1,18 @@
+// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MetadataExtractor.Formats.Tiff
+{
+    public enum TiffStandard
+    {
+        /// <summary>
+        /// Regular TIFF.
+        /// </summary>
+        Tiff,
+
+        /// <summary>
+        /// The "BigTIFF" standard, which supports greater than 4GB files, more entries
+        /// in IFDs, and larger tag value arrays.
+        /// </summary>
+        BigTiff
+    }
+}

--- a/MetadataExtractor/IO/IndexedReader.cs
+++ b/MetadataExtractor/IO/IndexedReader.cs
@@ -256,6 +256,38 @@ namespace MetadataExtractor.IO
                       GetByte(index    );
         }
 
+        /// <summary>Get an unsigned 64-bit integer from the buffer.</summary>
+        /// <param name="index">position within the data buffer to read first byte</param>
+        /// <returns>the 64 bit int value, between 0x0000000000000000 and 0xFFFFFFFFFFFFFFFF</returns>
+        /// <exception cref="System.IO.IOException">the buffer does not contain enough bytes to service the request, or index is negative</exception>
+        public ulong GetUInt64(int index)
+        {
+            ValidateIndex(index, 8);
+            if (IsMotorolaByteOrder)
+            {
+                // Motorola - MSB first
+                return
+                    (ulong)GetByte(index    ) << 56 |
+                    (ulong)GetByte(index + 1) << 48 |
+                    (ulong)GetByte(index + 2) << 40 |
+                    (ulong)GetByte(index + 3) << 32 |
+                    (ulong)GetByte(index + 4) << 24 |
+                    (ulong)GetByte(index + 5) << 16 |
+                    (ulong)GetByte(index + 6) <<  8 |
+                          GetByte(index + 7);
+            }
+            // Intel ordering - LSB first
+            return
+                (ulong)GetByte(index + 7) << 56 |
+                (ulong)GetByte(index + 6) << 48 |
+                (ulong)GetByte(index + 5) << 40 |
+                (ulong)GetByte(index + 4) << 32 |
+                (ulong)GetByte(index + 3) << 24 |
+                (ulong)GetByte(index + 2) << 16 |
+                (ulong)GetByte(index + 1) <<  8 |
+                      GetByte(index    );
+        }
+
 #pragma warning restore format
 
         /// <summary>Gets a s15.16 fixed point float from the buffer.</summary>

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
@@ -1343,7 +1343,7 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(int marker) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
@@ -1597,7 +1597,7 @@ abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fou
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(int marker) -> void
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
@@ -3608,7 +3608,7 @@ override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(i
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
@@ -3736,7 +3736,7 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
@@ -1319,7 +1319,6 @@ MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetRationalArray(int tagId, 
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetString(int tagId, MetadataExtractor.StringValue stringValue) -> void
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.EndingIfd() -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.Error(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.HasFollowerIfd() -> bool
@@ -1595,7 +1594,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3606,7 +3604,6 @@ override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3723,7 +3720,6 @@ override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
@@ -3879,7 +3875,6 @@ static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! file
 static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.ICollection<int>! processedGlobalIfdOffsets, int ifdOffset) -> void
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void
 static MetadataExtractor.Formats.Wav.WavFormatHandler.Populate(MetadataExtractor.Formats.Wav.WavFormatDirectory! directory, MetadataExtractor.IO.SequentialReader! reader, int chunkSize) -> void
 static MetadataExtractor.Formats.Wav.WavMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
@@ -1342,12 +1342,9 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.TiffDataFormat
-MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> int
 MetadataExtractor.Formats.Tiff.TiffDataFormat.Name.get -> string!
 MetadataExtractor.Formats.Tiff.TiffDataFormat.TiffFormatCode.get -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
 MetadataExtractor.Formats.Tiff.TiffDataFormatCode
@@ -1595,8 +1592,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! director
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
@@ -3605,8 +3600,6 @@ override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
@@ -3732,7 +3725,6 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?
@@ -3872,7 +3864,7 @@ static MetadataExtractor.Formats.QuickTime.QuickTimeReaderExtensions.GetMatrix(t
 static MetadataExtractor.Formats.Raf.RafMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
+static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode, bool isBigTiff) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -89,6 +90,7 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -111,6 +113,7 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -120,9 +123,11 @@ override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
@@ -2,7 +2,9 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -90,7 +92,25 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+MetadataExtractor.Formats.Tiff.ITiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
+MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> byte
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Ifd8 = 18 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64S = 17 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64U = 16 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.BigTiff = 1 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.Tiff = 0 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.IO.IndexedReader.GetUInt64(int index) -> ulong
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -113,7 +133,9 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -123,11 +145,17 @@ override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+static MetadataExtractor.DirectoryExtensions.GetUInt64(this MetadataExtractor.Directory! directory, int tagType) -> ulong
+static MetadataExtractor.DirectoryExtensions.TryGetUInt64(this MetadataExtractor.Directory! directory, int tagType, out ulong value) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset, bool isBigTiff) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Ifd8 -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64S -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64U -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -1342,12 +1342,9 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.TiffDataFormat
-MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> int
 MetadataExtractor.Formats.Tiff.TiffDataFormat.Name.get -> string!
 MetadataExtractor.Formats.Tiff.TiffDataFormat.TiffFormatCode.get -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
 MetadataExtractor.Formats.Tiff.TiffDataFormatCode
@@ -1595,8 +1592,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! director
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
@@ -3605,8 +3600,6 @@ override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
@@ -3732,7 +3725,6 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?
@@ -3872,7 +3864,7 @@ static MetadataExtractor.Formats.QuickTime.QuickTimeReaderExtensions.GetMatrix(t
 static MetadataExtractor.Formats.Raf.RafMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
+static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode, bool isBigTiff) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -1319,7 +1319,6 @@ MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetRationalArray(int tagId, 
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetString(int tagId, MetadataExtractor.StringValue stringValue) -> void
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.EndingIfd() -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.Error(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.HasFollowerIfd() -> bool
@@ -1595,7 +1594,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3606,7 +3604,6 @@ override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3723,7 +3720,6 @@ override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
@@ -3879,7 +3875,6 @@ static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! file
 static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.ICollection<int>! processedGlobalIfdOffsets, int ifdOffset) -> void
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void
 static MetadataExtractor.Formats.Wav.WavFormatHandler.Populate(MetadataExtractor.Formats.Wav.WavFormatDirectory! directory, MetadataExtractor.IO.SequentialReader! reader, int chunkSize) -> void
 static MetadataExtractor.Formats.Wav.WavMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -1343,7 +1343,7 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(int marker) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
@@ -1597,7 +1597,7 @@ abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fou
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(int marker) -> void
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
@@ -3608,7 +3608,7 @@ override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(i
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
@@ -3736,7 +3736,7 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -89,6 +90,7 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -111,6 +113,7 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -120,9 +123,11 @@ override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -2,7 +2,9 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -90,7 +92,25 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+MetadataExtractor.Formats.Tiff.ITiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
+MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> byte
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Ifd8 = 18 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64S = 17 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64U = 16 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.BigTiff = 1 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.Tiff = 0 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.IO.IndexedReader.GetUInt64(int index) -> ulong
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -113,7 +133,9 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -123,11 +145,17 @@ override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+static MetadataExtractor.DirectoryExtensions.GetUInt64(this MetadataExtractor.Directory! directory, int tagType) -> ulong
+static MetadataExtractor.DirectoryExtensions.TryGetUInt64(this MetadataExtractor.Directory! directory, int tagType, out ulong value) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset, bool isBigTiff) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Ifd8 -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64S -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64U -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -1316,7 +1316,6 @@ MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetRationalArray(int tagId, 
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetString(int tagId, MetadataExtractor.StringValue stringValue) -> void
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.EndingIfd() -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.Error(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.HasFollowerIfd() -> bool
@@ -1588,7 +1587,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3599,7 +3597,6 @@ override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3716,7 +3713,6 @@ override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
@@ -3872,7 +3868,6 @@ static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! file
 static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.ICollection<int>! processedGlobalIfdOffsets, int ifdOffset) -> void
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void
 static MetadataExtractor.Formats.Wav.WavFormatHandler.Populate(MetadataExtractor.Formats.Wav.WavFormatDirectory! directory, MetadataExtractor.IO.SequentialReader! reader, int chunkSize) -> void
 static MetadataExtractor.Formats.Wav.WavMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -1339,12 +1339,9 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.TiffDataFormat
-MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> int
 MetadataExtractor.Formats.Tiff.TiffDataFormat.Name.get -> string!
 MetadataExtractor.Formats.Tiff.TiffDataFormat.TiffFormatCode.get -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
 MetadataExtractor.Formats.Tiff.TiffDataFormatCode
@@ -1588,8 +1585,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! director
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
@@ -3598,8 +3593,6 @@ override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
@@ -3725,7 +3718,6 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?
@@ -3865,7 +3857,7 @@ static MetadataExtractor.Formats.QuickTime.QuickTimeReaderExtensions.GetMatrix(t
 static MetadataExtractor.Formats.Raf.RafMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
+static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode, bool isBigTiff) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -1340,7 +1340,7 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(int marker) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
@@ -1590,7 +1590,7 @@ abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fou
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(int marker) -> void
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
@@ -3601,7 +3601,7 @@ override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(i
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
@@ -3729,7 +3729,7 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -89,6 +90,7 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -111,6 +113,7 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -120,9 +123,11 @@ override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -2,7 +2,9 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -90,7 +92,25 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+MetadataExtractor.Formats.Tiff.ITiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
+MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> byte
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Ifd8 = 18 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64S = 17 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64U = 16 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.BigTiff = 1 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.Tiff = 0 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.IO.IndexedReader.GetUInt64(int index) -> ulong
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -113,7 +133,9 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -123,11 +145,17 @@ override MetadataExtractor.Formats.Jfif.JfifReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+static MetadataExtractor.DirectoryExtensions.GetUInt64(this MetadataExtractor.Directory! directory, int tagType) -> ulong
+static MetadataExtractor.DirectoryExtensions.TryGetUInt64(this MetadataExtractor.Directory! directory, int tagType, out ulong value) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset, bool isBigTiff) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Ifd8 -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64S -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64U -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1343,7 +1343,7 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(int marker) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
@@ -1597,7 +1597,7 @@ abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fou
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(int marker) -> void
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
@@ -3608,7 +3608,7 @@ override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(i
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
@@ -3735,7 +3735,7 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(int marker) -> void
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1319,7 +1319,6 @@ MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetRationalArray(int tagId, 
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetString(int tagId, MetadataExtractor.StringValue stringValue) -> void
 MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.EndingIfd() -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.Error(string! message) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.HasFollowerIfd() -> bool
@@ -1595,7 +1594,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3606,7 +3604,6 @@ override MetadataExtractor.Formats.Exif.ExifInteropDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
@@ -3722,7 +3719,6 @@ override MetadataExtractor.Formats.Pcx.PcxDescriptor.GetDescription(int tagType)
 override MetadataExtractor.Formats.Pcx.PcxDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.DuckyDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.ICollection<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Png.PngChromaticitiesDirectory.Name.get -> string!
@@ -3878,7 +3874,6 @@ static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! file
 static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.ICollection<int>! processedGlobalIfdOffsets, int ifdOffset) -> void
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void
 static MetadataExtractor.Formats.Wav.WavFormatHandler.Populate(MetadataExtractor.Formats.Wav.WavFormatDirectory! directory, MetadataExtractor.IO.SequentialReader! reader, int chunkSize) -> void
 static MetadataExtractor.Formats.Wav.WavMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -1342,12 +1342,9 @@ MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt8UArray(int tagId, byte[]! arr
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRational(int tagId, MetadataExtractor.Rational rational) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetRationalArray(int tagId, MetadataExtractor.Rational[]! array) -> void
 MetadataExtractor.Formats.Tiff.ITiffHandler.SetString(int tagId, MetadataExtractor.StringValue str) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.SetTiffMarker(ushort marker) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.TryEnterSubIfd(int tagType) -> bool
 MetadataExtractor.Formats.Tiff.ITiffHandler.Warn(string! message) -> void
 MetadataExtractor.Formats.Tiff.TiffDataFormat
-MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> int
 MetadataExtractor.Formats.Tiff.TiffDataFormat.Name.get -> string!
 MetadataExtractor.Formats.Tiff.TiffDataFormat.TiffFormatCode.get -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
 MetadataExtractor.Formats.Tiff.TiffDataFormatCode
@@ -1595,8 +1592,6 @@ abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! director
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetTiffMarker(ushort marker) -> void
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
@@ -3605,8 +3600,6 @@ override MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifThumbnailDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.HasFollowerIfd() -> bool
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.SetTiffMarker(ushort marker) -> void
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, uint componentCount, out long byteCount) -> bool
 override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryEnterSubIfd(int tagId) -> bool
 override MetadataExtractor.Formats.Exif.GpsDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.GpsDirectory.Name.get -> string!
@@ -3731,7 +3724,6 @@ override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDescriptor.GetDesc
 override MetadataExtractor.Formats.QuickTime.QuickTimeFileTypeDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.QuickTime.QuickTimeMovieHeaderDirectory.Name.get -> string!
-override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.SetTiffMarker(ushort marker) -> void
 override MetadataExtractor.Formats.QuickTime.QuickTimeTrackHeaderDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaDeveloperDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Tga.TgaExtensionDescriptor.GetDescription(int tagType) -> string?
@@ -3871,7 +3863,7 @@ static MetadataExtractor.Formats.QuickTime.QuickTimeReaderExtensions.GetMatrix(t
 static MetadataExtractor.Formats.Raf.RafMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tga.TgaMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
+static MetadataExtractor.Formats.Tiff.TiffDataFormat.FromTiffFormatCode(MetadataExtractor.Formats.Tiff.TiffDataFormatCode tiffFormatCode, bool isBigTiff) -> MetadataExtractor.Formats.Tiff.TiffDataFormat?
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Tiff.TiffReader.ProcessTiff(MetadataExtractor.IO.IndexedReader! reader, MetadataExtractor.Formats.Tiff.ITiffHandler! handler) -> void

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,7 +2,9 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -90,7 +92,25 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
-MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+MetadataExtractor.Formats.Tiff.ITiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64S(int tagId, long int64S) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64SArray(int tagId, long[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64U(int tagId, ulong int64U) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.SetInt64UArray(int tagId, ulong[]! array) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
+MetadataExtractor.Formats.Tiff.TiffDataFormat.ComponentSizeBytes.get -> byte
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Ifd8 = 18 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64S = 17 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffDataFormatCode.Int64U = 16 -> MetadataExtractor.Formats.Tiff.TiffDataFormatCode
+MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.BigTiff = 1 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.Formats.Tiff.TiffStandard.Tiff = 0 -> MetadataExtractor.Formats.Tiff.TiffStandard
+MetadataExtractor.IO.IndexedReader.GetUInt64(int index) -> ulong
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -113,7 +133,9 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -124,11 +146,17 @@ override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
-override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount, bool isBigTiff) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
+override MetadataExtractor.Formats.QuickTime.QuickTimeTiffHandler<T>.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
+static MetadataExtractor.DirectoryExtensions.GetUInt64(this MetadataExtractor.Directory! directory, int tagType) -> ulong
+static MetadataExtractor.DirectoryExtensions.TryGetUInt64(this MetadataExtractor.Directory! directory, int tagType, out ulong value) -> bool
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
-static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset, bool isBigTiff) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Ifd8 -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64S -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
+static readonly MetadataExtractor.Formats.Tiff.TiffDataFormat.Int64U -> MetadataExtractor.Formats.Tiff.TiffDataFormat!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -2,6 +2,7 @@
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Extract(byte[]! segmentBytes, int preambleLength) -> System.Collections.Generic.IEnumerable<MetadataExtractor.Directory!>!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.PreambleBytes.get -> byte[]!
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMax = 6 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagCameraTemperatureRangeMin = 5 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.TagEmissivity = 3 -> int
@@ -89,6 +90,7 @@ MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetArtworkDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetLocationRoleDescription() -> string?
 MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.QuickTimeMetadataHeaderDescriptor(MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory! directory) -> void
+MetadataExtractor.Formats.Tiff.ITiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 MetadataExtractor.Rational.Absolute.get -> MetadataExtractor.Rational
 MetadataExtractor.Rational.IsPositive.get -> bool
 const MetadataExtractor.Formats.Avi.AviDirectory.TagDateTimeOriginal = 320 -> int
@@ -111,6 +113,7 @@ const MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TagPi
 MetadataExtractor.Rational.Rational() -> void
 MetadataExtractor.StringValue.StringValue() -> void
 override MetadataExtractor.Formats.Exif.ExifReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Exif.ExifTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.Exif.Makernotes.FlirMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Flir.FlirCameraInfoDirectory.Name.get -> string!
@@ -121,9 +124,11 @@ override MetadataExtractor.Formats.Jfxx.JfxxReader.SegmentTypes.get -> System.Co
 override MetadataExtractor.Formats.Jpeg.JpegSegment.ToString() -> string!
 override MetadataExtractor.Formats.Photoshop.PhotoshopDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Photoshop.PhotoshopReader.SegmentTypes.get -> System.Collections.Generic.ICollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
+override MetadataExtractor.Formats.Photoshop.PhotoshopTiffHandler.CustomProcessTag(int tagOffset, System.Collections.Generic.HashSet<int>! processedIfdOffsets, MetadataExtractor.IO.IndexedReader! reader, int tagId, int byteCount) -> bool
 override MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDescriptor.GetDescription(int tagType) -> string?
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
 static MetadataExtractor.Formats.Jpeg.JpegMetadataReader.AllReaders.get -> System.Collections.Generic.IEnumerable<MetadataExtractor.Formats.Jpeg.IJpegSegmentMetadataReader!>!
 static MetadataExtractor.Formats.QuickTime.QuickTimeMetadataHeaderDirectory.TryGetTag(string! name, out int tagType) -> bool
+static MetadataExtractor.Formats.Tiff.TiffReader.ProcessIfd(MetadataExtractor.Formats.Tiff.ITiffHandler! handler, MetadataExtractor.IO.IndexedReader! reader, System.Collections.Generic.HashSet<int>! processedIfdOffsets, int ifdOffset) -> void
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!
 virtual MetadataExtractor.Directory.TryGetTagName(int tagType, out string? tagName) -> bool

--- a/MetadataExtractor/Util/FileTypeDetector.cs
+++ b/MetadataExtractor/Util/FileTypeDetector.cs
@@ -24,6 +24,8 @@ namespace MetadataExtractor.Util
             { FileType.Jpeg, new byte[] { 0xff, 0xd8 } },
             { FileType.Tiff, Encoding.UTF8.GetBytes("II"), new byte[] { 0x2a, 0x00 } },
             { FileType.Tiff, Encoding.UTF8.GetBytes("MM"), new byte[] { 0x00, 0x2a } },
+            { FileType.Tiff, Encoding.UTF8.GetBytes("II"), new byte[] { 0x2b, 0x00 } }, // BigTIFF
+            { FileType.Tiff, Encoding.UTF8.GetBytes("MM"), new byte[] { 0x00, 0x2b } }, // BigTIFF
             { FileType.Psd, Encoding.UTF8.GetBytes("8BPS") },
             { FileType.Png, new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52 } },
             { FileType.Bmp, Encoding.UTF8.GetBytes("BM") }, // Standard Bitmap Windows and OS/2


### PR DESCRIPTION
Note that while BigTIFF supports files greater than 2 GiB in size, our current implementation does not due to the pervasive use of Int32 throughout the code to represent offsets into the data.

This PR involves several API changes. These are public APIs, but are unlikely to be used directly by user code.