### PR TITLE
Issue#285

### DIFF
--- a/MetadataExtractor/Formats/Mpeg/Mp3Reader.cs
+++ b/MetadataExtractor/Formats/Mpeg/Mp3Reader.cs
@@ -60,8 +60,7 @@ namespace MetadataExtractor.Formats.Mpeg
                     break;
             }
 
-
-            int protectionBit = (header & 0x00010000) >> 16;
+            // int protectionBit = (header & 0x00010000) >> 16;
 
             // Bitrate: depends on ID and Layer
             int bitrate = (header & 0x0000F000) >> 12;
@@ -86,8 +85,7 @@ namespace MetadataExtractor.Formats.Mpeg
                 frequency = frequencyMapping[1, frequency];
             }
 
-
-            int paddingBit = (header & 0x00000200) >> 9;
+            // int paddingBit = (header & 0x00000200) >> 9;
 
             // Encoding type: Stereo, Joint Stereo, Dual Channel, or Mono
             int mode = (header & 0x000000C0) >> 6;

--- a/MetadataExtractor/Formats/Mpeg/Mp3Reader.cs
+++ b/MetadataExtractor/Formats/Mpeg/Mp3Reader.cs
@@ -8,12 +8,23 @@ namespace MetadataExtractor.Formats.Mpeg
     {
         // http://id3.org/mp3Frame
         // https://www.loc.gov/preservation/digital/formats/fdd/fdd000105.shtml
+        // https://id3.org/id3v2.4.0-structure
 
         public Directory Extract(SequentialReader reader)
         {
             var directory = new Mp3Directory();
 
             var header = reader.GetInt32();
+
+            // If the file starts with ID3v2 data, try to skip over it for now.
+            // Eventually we should extract this data properly.
+            if ((header & 0xFFFFFF00) == 0x49443300) // "ID3"
+            {
+                // Adjust start to end of header
+                var id3Bytes = reader.GetBytes(6);
+                reader.Skip(id3Bytes[2] * 0x200000 + id3Bytes[3] * 0x4000 + id3Bytes[4] * 0x80 + id3Bytes[5]);
+                header = reader.GetInt32();
+            }
 
             // ID: MPEG-2.5, MPEG-2, or MPEG-1
             int id = 0;

--- a/MetadataExtractor/Formats/Mpeg/MpegAudioTypeChecker.cs
+++ b/MetadataExtractor/Formats/Mpeg/MpegAudioTypeChecker.cs
@@ -23,12 +23,20 @@ namespace MetadataExtractor.Formats.Mpeg
                 11 - Layer I
 
             Additional bits contain more information, but are not required for file type identification.
+
+            MP3 with ID3V2-Tags https://id3.org/id3v2.4.0-structure
+            MP3-File with ID3V2-Tagging at start
          */
 
         public int ByteCount => 3;
 
         public Util.FileType CheckType(byte[] bytes)
         {
+
+            // MP3-File with "ID3" at start
+            if (bytes[0] == 0x49 && bytes[1] == 0x44 && bytes[2] == 0x33)
+                return Util.FileType.Mp3;
+
             // MPEG audio requires the first 11 bits to be set
             if (bytes[0] != 0xFF || (bytes[1] & 0xE0) != 0xE0)
                 return Util.FileType.Unknown;


### PR DESCRIPTION
Fixes #285

Hi,
I took a look at the issue and found, that the sample file has ID3V2 tags at the start of the file.
I added support for this form of a mp3 file by skipping the ID3V2 tag before reading the meta data. 
I also changed the MpegAudioTypeChecker class to recognize the ID3V2 tags as mp3 file.
I've shortend the sample file to create a unit test case.

Kind regards 
Jürgen Brändle