### PR TITLE
Remove excessive bounds checking in IndexedReader

### DIFF
--- a/MetadataExtractor/IO/ByteArrayReader.cs
+++ b/MetadataExtractor/IO/ByteArrayReader.cs
@@ -33,9 +33,8 @@ namespace MetadataExtractor.IO
 
         public override long Length => _buffer.Length - _baseOffset;
 
-        public override byte GetByte(int index)
+        protected override byte GetByteInternal(int index)
         {
-            ValidateIndex(index, 1);
             return _buffer[index + _baseOffset];
         }
 

--- a/MetadataExtractor/IO/IndexedSeekingReader.cs
+++ b/MetadataExtractor/IO/IndexedSeekingReader.cs
@@ -41,7 +41,7 @@ namespace MetadataExtractor.IO
 
         public override long Length { get; }
 
-        public override byte GetByte(int index)
+        protected override byte GetByteInternal(int index)
         {
             ValidateIndex(index, 1);
 

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
@@ -12,7 +12,6 @@ abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() ->
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
-abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 abstract MetadataExtractor.IO.IndexedReader.IsValidIndex(int index, int bytesRequested) -> bool
 abstract MetadataExtractor.IO.IndexedReader.Length.get -> long
@@ -4266,7 +4265,6 @@ override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
 override MetadataExtractor.GeoLocation.ToString() -> string!
-override MetadataExtractor.IO.ByteArrayReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.ByteArrayReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.ByteArrayReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.ByteArrayReader.Length.get -> long
@@ -4274,13 +4272,11 @@ override MetadataExtractor.IO.ByteArrayReader.ToUnshiftedOffset(int localOffset)
 override MetadataExtractor.IO.ByteArrayReader.ValidateIndex(int index, int bytesRequested) -> void
 override MetadataExtractor.IO.ByteArrayReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.ByteArrayReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedCapturingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedCapturingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedCapturingReader.Length.get -> long
 override MetadataExtractor.IO.IndexedCapturingReader.ToUnshiftedOffset(int localOffset) -> int
 override MetadataExtractor.IO.IndexedCapturingReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.IndexedCapturingReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedSeekingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedSeekingReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.IndexedSeekingReader.Length.get -> long

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 ﻿#nullable enable
+abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
+MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
+override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
+override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -12,7 +12,6 @@ abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() ->
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
-abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 abstract MetadataExtractor.IO.IndexedReader.IsValidIndex(int index, int bytesRequested) -> bool
 abstract MetadataExtractor.IO.IndexedReader.Length.get -> long
@@ -4266,7 +4265,6 @@ override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
 override MetadataExtractor.GeoLocation.ToString() -> string!
-override MetadataExtractor.IO.ByteArrayReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.ByteArrayReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.ByteArrayReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.ByteArrayReader.Length.get -> long
@@ -4274,13 +4272,11 @@ override MetadataExtractor.IO.ByteArrayReader.ToUnshiftedOffset(int localOffset)
 override MetadataExtractor.IO.ByteArrayReader.ValidateIndex(int index, int bytesRequested) -> void
 override MetadataExtractor.IO.ByteArrayReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.ByteArrayReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedCapturingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedCapturingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedCapturingReader.Length.get -> long
 override MetadataExtractor.IO.IndexedCapturingReader.ToUnshiftedOffset(int localOffset) -> int
 override MetadataExtractor.IO.IndexedCapturingReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.IndexedCapturingReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedSeekingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedSeekingReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.IndexedSeekingReader.Length.get -> long

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 ﻿#nullable enable
+abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
+MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
+override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
+override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -12,7 +12,6 @@ abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() ->
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
-abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 abstract MetadataExtractor.IO.IndexedReader.IsValidIndex(int index, int bytesRequested) -> bool
 abstract MetadataExtractor.IO.IndexedReader.Length.get -> long
@@ -4259,7 +4258,6 @@ override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
 override MetadataExtractor.GeoLocation.ToString() -> string!
-override MetadataExtractor.IO.ByteArrayReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.ByteArrayReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.ByteArrayReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.ByteArrayReader.Length.get -> long
@@ -4267,13 +4265,11 @@ override MetadataExtractor.IO.ByteArrayReader.ToUnshiftedOffset(int localOffset)
 override MetadataExtractor.IO.ByteArrayReader.ValidateIndex(int index, int bytesRequested) -> void
 override MetadataExtractor.IO.ByteArrayReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.ByteArrayReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedCapturingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedCapturingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedCapturingReader.Length.get -> long
 override MetadataExtractor.IO.IndexedCapturingReader.ToUnshiftedOffset(int localOffset) -> int
 override MetadataExtractor.IO.IndexedCapturingReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.IndexedCapturingReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedSeekingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedSeekingReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.IndexedSeekingReader.Length.get -> long

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 ﻿#nullable enable
+abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
+MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
+override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
+override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -12,7 +12,6 @@ abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() ->
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryCustomProcessFormat(int tagId, MetadataExtractor.Formats.Tiff.TiffDataFormatCode formatCode, ulong componentCount, out ulong byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.TryEnterSubIfd(int tagType) -> bool
-abstract MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 abstract MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 abstract MetadataExtractor.IO.IndexedReader.IsValidIndex(int index, int bytesRequested) -> bool
 abstract MetadataExtractor.IO.IndexedReader.Length.get -> long
@@ -4266,7 +4265,6 @@ override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool
 override MetadataExtractor.GeoLocation.GetHashCode() -> int
 override MetadataExtractor.GeoLocation.ToString() -> string!
-override MetadataExtractor.IO.ByteArrayReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.ByteArrayReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.ByteArrayReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.ByteArrayReader.Length.get -> long
@@ -4274,13 +4272,11 @@ override MetadataExtractor.IO.ByteArrayReader.ToUnshiftedOffset(int localOffset)
 override MetadataExtractor.IO.ByteArrayReader.ValidateIndex(int index, int bytesRequested) -> void
 override MetadataExtractor.IO.ByteArrayReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.ByteArrayReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedCapturingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedCapturingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedCapturingReader.Length.get -> long
 override MetadataExtractor.IO.IndexedCapturingReader.ToUnshiftedOffset(int localOffset) -> int
 override MetadataExtractor.IO.IndexedCapturingReader.WithByteOrder(bool isMotorolaByteOrder) -> MetadataExtractor.IO.IndexedReader!
 override MetadataExtractor.IO.IndexedCapturingReader.WithShiftedBaseOffset(int shift) -> MetadataExtractor.IO.IndexedReader!
-override MetadataExtractor.IO.IndexedSeekingReader.GetByte(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetBytes(int index, int count) -> byte[]!
 override MetadataExtractor.IO.IndexedSeekingReader.IsValidIndex(int index, int bytesRequested) -> bool
 override MetadataExtractor.IO.IndexedSeekingReader.Length.get -> long

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Unshipped.txt
@@ -1,1 +1,5 @@
 ﻿#nullable enable
+abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
+MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
+override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
+override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte


### PR DESCRIPTION
Fixes #62

Adds a new abstract overload for reading a single byte. That method will not do any explicit bounds validation, so callers must do that beforehand. In cases where multiple bytes are read, the validation can be performed once per value, rather than once per byte.