### PR TITLE
Fix test assembly discovery

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,5 +36,10 @@ steps:
 
 - task: VSTest@2
   inputs:
+    testSelector: 'testAssemblies'
+    testAssemblyVer2: |
+      **\MetadataExtractor.Tests.dll
+      !**\obj\**
     platform: '$(buildPlatform)'
     configuration: '$(buildConfiguration)'
+    runInParallel: true


### PR DESCRIPTION
CI is broken, failing with messages:

```
##[error]Testhost process for source(s) 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\Microsoft.TestPlatform.CoreUtilities.dll' exited with error: A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'C:\Program Files\dotnet\'.
##[error]Failed to run as a self-contained app.
##[error]  - The application was run as a self-contained app because 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' was not found.
##[error]  - If this should be a framework-dependent app, add the 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' file and specify the appropriate framework.
##[error]. Please check the diagnostic logs for more information.
##[error]Testhost process for source(s) 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\Microsoft.TestPlatform.PlatformAbstractions.dll' exited with error: A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'C:\Program Files\dotnet\'.
##[error]Failed to run as a self-contained app.
##[error]  - The application was run as a self-contained app because 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' was not found.
##[error]  - If this should be a framework-dependent app, add the 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' file and specify the appropriate framework.
##[error]. Please check the diagnostic logs for more information.
##[error]Testhost process for source(s) 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\Microsoft.VisualStudio.TestPlatform.ObjectModel.dll' exited with error: A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'C:\Program Files\dotnet\'.
##[error]Failed to run as a self-contained app.
##[error]  - The application was run as a self-contained app because 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' was not found.
##[error]  - If this should be a framework-dependent app, add the 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' file and specify the appropriate framework.
##[error]. Please check the diagnostic logs for more information.
##[error]Testhost process for source(s) 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.dll' exited with error: A fatal error was encountered. The library 'hostpolicy.dll' required to execute the application was not found in 'C:\Program Files\dotnet\'.
##[error]Failed to run as a self-contained app.
##[error]  - The application was run as a self-contained app because 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' was not found.
##[error]  - If this should be a framework-dependent app, add the 'D:\a\1\s\MetadataExtractor.Tests\bin\Release\net6.0\testhost.runtimeconfig.json' file and specify the appropriate framework.
##[error]. Please check the diagnostic logs for more information.
```

I think what's happening is that the default test assembly discovery is matching anything with "test" in its name, and is therefore pulling in `Microsoft.TestPlatform.CoreUtilities.dll`, `Microsoft.TestPlatform.PlatformAbstractions.dll`, `Microsoft.VisualStudio.TestPlatform.ObjectModel.dll` and `testhost.dll`, none of which can be exectuted for the reasons listed.

This PR makes the test assembly explicit, which should hopefully address the above issues.

Also, run tests in parallel.
