### PR TITLE
Fix NikonPictureControl1Directory parsing

### DIFF
--- a/MetadataExtractor.Tests/.editorconfig
+++ b/MetadataExtractor.Tests/.editorconfig
@@ -1,0 +1,3 @@
+[*.cs]
+
+dotnet_diagnostic.CA1707.severity = none                    # Identifiers should not contain underscores

--- a/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
+++ b/MetadataExtractor.Tests/MetadataExtractor.Tests.csproj
@@ -36,7 +36,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Using Include="Xunit"/>
+    <Using Include="Xunit" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor.Tests/StringValueTest.cs
+++ b/MetadataExtractor.Tests/StringValueTest.cs
@@ -1,0 +1,22 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+namespace MetadataExtractor.Tests;
+
+public sealed class StringValueTest
+{
+    [Theory]
+    [MemberData(nameof(GetToStringVariations))]
+    public void ToStringVariations(Encoding encoding, string expected, byte[] bytes)
+    {
+        StringValue stringValue = new(bytes, encoding);
+
+        Assert.Equal(expected, stringValue.ToString());
+    }
+
+    public static IEnumerable<object[]> GetToStringVariations()
+    {
+        yield return [Encoding.ASCII, "NEUTRAL\0\0\0", new byte[] { 78, 69, 85, 84, 82, 65, 76, 0, 0, 0 }];
+        yield return [Encoding.ASCII, "N\0N\0", new byte[] { 78, 0, 78, 0 }];
+        yield return [Encoding.ASCII, "N\0N", new byte[] { 78, 0, 78 }];
+    }
+}

--- a/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
+++ b/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
@@ -84,7 +84,7 @@ namespace MetadataExtractor.Formats.Avi
                             string time = new DateTime(new TimeSpan(hours, minutes, seconds).Ticks).ToString("HH:mm:ss");
 
                             directory.Set(AviDirectory.TagDuration, time);
-                            directory.Set(AviDirectory.TagVideoCodec, fccHandler!);
+                            directory.Set(AviDirectory.TagVideoCodec, fccHandler);
                         }
                         else if (fccType == "auds")
                         {

--- a/MetadataExtractor/Formats/Exif/Makernotes/NikonPictureControl1Directory.cs
+++ b/MetadataExtractor/Formats/Exif/Makernotes/NikonPictureControl1Directory.cs
@@ -59,9 +59,9 @@ public sealed class NikonPictureControl1Directory : Directory
 
         NikonPictureControl1Directory directory = new();
 
-        directory.Set(TagPictureControlVersion, reader.GetStringValue(4));
-        directory.Set(TagPictureControlName, reader.GetStringValue(20));
-        directory.Set(TagPictureControlBase, reader.GetStringValue(20));
+        directory.Set(TagPictureControlVersion, reader.GetNullTerminatedStringValue(4));
+        directory.Set(TagPictureControlName, reader.GetNullTerminatedStringValue(20));
+        directory.Set(TagPictureControlBase, reader.GetNullTerminatedStringValue(20));
         reader.Skip(4);
         directory.Set(TagPictureControlAdjust, reader.GetByte());
         directory.Set(TagPictureControlQuickAdjust, reader.GetByte());

--- a/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net35/PublicAPI.Shipped.txt
@@ -3999,7 +3999,7 @@ MetadataExtractor.StringValue.Encoding.get -> System.Text.Encoding?
 MetadataExtractor.StringValue.StringValue() -> void
 MetadataExtractor.StringValue.StringValue(byte[]! bytes, System.Text.Encoding? encoding = null) -> void
 MetadataExtractor.StringValue.ToString(int index, int count) -> string!
-MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoder) -> string!
+MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoding) -> string!
 MetadataExtractor.Tag
 MetadataExtractor.Tag.Description.get -> string?
 MetadataExtractor.Tag.DirectoryName.get -> string!

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -3999,7 +3999,7 @@ MetadataExtractor.StringValue.Encoding.get -> System.Text.Encoding?
 MetadataExtractor.StringValue.StringValue() -> void
 MetadataExtractor.StringValue.StringValue(byte[]! bytes, System.Text.Encoding? encoding = null) -> void
 MetadataExtractor.StringValue.ToString(int index, int count) -> string!
-MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoder) -> string!
+MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoding) -> string!
 MetadataExtractor.Tag
 MetadataExtractor.Tag.Description.get -> string?
 MetadataExtractor.Tag.DirectoryName.get -> string!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -3992,7 +3992,7 @@ MetadataExtractor.StringValue.Encoding.get -> System.Text.Encoding?
 MetadataExtractor.StringValue.StringValue() -> void
 MetadataExtractor.StringValue.StringValue(byte[]! bytes, System.Text.Encoding? encoding = null) -> void
 MetadataExtractor.StringValue.ToString(int index, int count) -> string!
-MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoder) -> string!
+MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoding) -> string!
 MetadataExtractor.Tag
 MetadataExtractor.Tag.Description.get -> string?
 MetadataExtractor.Tag.DirectoryName.get -> string!

--- a/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.0/PublicAPI.Shipped.txt
@@ -3999,7 +3999,7 @@ MetadataExtractor.StringValue.Encoding.get -> System.Text.Encoding?
 MetadataExtractor.StringValue.StringValue() -> void
 MetadataExtractor.StringValue.StringValue(byte[]! bytes, System.Text.Encoding? encoding = null) -> void
 MetadataExtractor.StringValue.ToString(int index, int count) -> string!
-MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoder) -> string!
+MetadataExtractor.StringValue.ToString(System.Text.Encoding! encoding) -> string!
 MetadataExtractor.Tag
 MetadataExtractor.Tag.Description.get -> string?
 MetadataExtractor.Tag.DirectoryName.get -> string!

--- a/MetadataExtractor/StringValue.cs
+++ b/MetadataExtractor/StringValue.cs
@@ -110,7 +110,7 @@ namespace MetadataExtractor
 
         public override string ToString() => ToString(Encoding ?? DefaultEncoding);
 
-        public string ToString(Encoding encoder) => encoder.GetString(Bytes, 0, Bytes.Length);
+        public string ToString(Encoding encoding) => encoding.GetString(Bytes, 0, Bytes.Length);
 
         public string ToString(int index, int count) => (Encoding ?? DefaultEncoding).GetString(Bytes, index, count);
 


### PR DESCRIPTION
Fix NikonPictureControl1Directory string reading. These fixed-width, null-terminated strings. We don't want those nulls in the string we return.

Also some minor tidying and adding a unit test.