### PR TITLE
Remove net3.5 target

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,7 +28,7 @@
     <PackageReference Include="JetBrains.Annotations" Version="2022.3.1" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
 
-    <!-- This avoids needing to have .NET targeting packs installed (e.g. for .NET 3.5) -->
+    <!-- Avoid needing to have targeting packs installed for .NET Framework. -->
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" PrivateAssets="All" />
   </ItemGroup>
 

--- a/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
+++ b/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net40</TargetFramework>
+    <TargetFramework>net45</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -10,11 +10,6 @@
 
   <ItemGroup>
     <PackageReference Include="System.Management.Automation" Version="6.1.7601.17515" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net40' ">
-    <Reference Include="System" />
-    <Reference Include="Microsoft.CSharp" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -1,11 +1,5 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor
 {
     /// <summary>
@@ -21,7 +15,7 @@ namespace MetadataExtractor
             Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
         }
 #endif
-        internal static readonly DirectoryList EmptyList = new Directory[0];
+        internal static readonly IReadOnlyList<Directory> EmptyList = [];
 
         private readonly Dictionary<int, string>? _tagNameMap;
 
@@ -75,13 +69,7 @@ namespace MetadataExtractor
 
         /// <summary>Returns all <see cref="Tag"/> objects that have been set in this <see cref="Directory"/>.</summary>
         /// <value>The list of <see cref="Tag"/> objects.</value>
-        public
-#if NET35
-            IEnumerable<Tag>
-#else
-            IReadOnlyList<Tag>
-#endif
-            Tags => _definedTagList;
+        public IReadOnlyList<Tag> Tags => _definedTagList;
 
         /// <summary>Returns the number of tags set in this Directory.</summary>
         /// <value>the number of tags set in this Directory</value>
@@ -107,13 +95,7 @@ namespace MetadataExtractor
 
         /// <summary>Used to iterate over any error messages contained in this directory.</summary>
         /// <value>The collection of error message strings.</value>
-        public
-#if NET35
-            IEnumerable<string>
-#else
-            IReadOnlyList<string>
-#endif
-            Errors => _errorList;
+        public IReadOnlyList<string> Errors => _errorList;
 
         #endregion
 

--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -939,20 +939,7 @@ namespace MetadataExtractor
             }
 
             if (o is IEnumerable<string> strings)
-            {
-#if NET35
-                var sb = new StringBuilder();
-                foreach (var s in strings)
-                {
-                    if (sb.Length != 0)
-                        sb.Append(' ');
-                    sb.Append(s);
-                }
-                return sb.ToString();
-#else
                 return string.Join(" ", strings);
-#endif
-            }
 
             if (o is double d)
                 return d.ToString("0.###");

--- a/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
+++ b/MetadataExtractor/Formats/Avi/AviMetadataReader.cs
@@ -3,12 +3,6 @@
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Riff;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Avi
 {
     /// <summary>Obtains metadata from Avi files.</summary>
@@ -17,7 +11,7 @@ namespace MetadataExtractor.Formats.Avi
     {
         /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -31,7 +25,7 @@ namespace MetadataExtractor.Formats.Avi
 
         /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             var directories = new List<Directory>();
             new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new AviRiffHandler(directories));

--- a/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Bmp
 {
     /// <summary>Obtains metadata from BMP files.</summary>
@@ -16,7 +10,7 @@ namespace MetadataExtractor.Formats.Bmp
     public static class BmpMetadataReader
     {
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>(2);
 
@@ -28,7 +22,7 @@ namespace MetadataExtractor.Formats.Bmp
             return directories;
         }
 
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             return new BmpReader().Extract(new SequentialStreamReader(stream)).ToList();
         }

--- a/MetadataExtractor/Formats/Bmp/BmpReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpReader.cs
@@ -2,18 +2,12 @@
 
 using MetadataExtractor.Formats.Icc;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Bmp
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class BmpReader
     {
-        public DirectoryList Extract(SequentialReader reader)
+        public IReadOnlyList<Directory> Extract(SequentialReader reader)
         {
             var directories = new List<Directory>();
             reader = reader.WithByteOrder(isMotorolaByteOrder: false);

--- a/MetadataExtractor/Formats/Eps/EpsMetadataReader.cs
+++ b/MetadataExtractor/Formats/Eps/EpsMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Eps
 {
     /// <summary>Obtains metadata from EPS files.</summary>
@@ -15,7 +9,7 @@ namespace MetadataExtractor.Formats.Eps
     /// <author>Kevin Mott https://github.com/kwhopper</author>
     public static class EpsMetadataReader
     {
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -27,7 +21,7 @@ namespace MetadataExtractor.Formats.Eps
             return directories;
         }
 
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             return new EpsReader().Extract(stream);
         }

--- a/MetadataExtractor/Formats/Eps/EpsReader.cs
+++ b/MetadataExtractor/Formats/Eps/EpsReader.cs
@@ -5,12 +5,6 @@ using MetadataExtractor.Formats.Photoshop;
 using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.Formats.Xmp;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Eps
 {
     /// <summary>Reads file passed in through SequentialReader and parses encountered data:</summary>
@@ -41,7 +35,7 @@ namespace MetadataExtractor.Formats.Eps
     {
         private int _previousTag;
 
-        public DirectoryList Extract(Stream inputStream)
+        public IReadOnlyList<Directory> Extract(Stream inputStream)
         {
             IndexedReader reader = new IndexedSeekingReader(inputStream);
             var directory = new EpsDirectory();

--- a/MetadataExtractor/Formats/Exif/ExifReader.cs
+++ b/MetadataExtractor/Formats/Exif/ExifReader.cs
@@ -2,11 +2,6 @@
 
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Tiff;
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
 
 namespace MetadataExtractor.Formats.Exif
 {
@@ -39,7 +34,7 @@ namespace MetadataExtractor.Formats.Exif
         /// <summary>
         /// Reads TIFF formatted Exif data a specified offset within a <see cref="IndexedReader"/>.
         /// </summary>
-        public DirectoryList Extract(IndexedReader reader, int exifStartOffset)
+        public IReadOnlyList<Directory> Extract(IndexedReader reader, int exifStartOffset)
         {
             var directories = new List<Directory>();
             var exifTiffHandler = new ExifTiffHandler(directories, exifStartOffset);

--- a/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
@@ -531,12 +531,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (faces is null)
                 return null;
 
-            var description = string.Join(Environment.NewLine,
-                faces.Select((f, i) => $"Face {i + 1}: {f}")
-#if NET35
-                .ToArray()
-#endif
-                );
+            var description = string.Join(Environment.NewLine, faces.Select((f, i) => $"Face {i + 1}: {f}"));
 
             return description.Length == 0 ? null : description;
         }

--- a/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Gif
 {
     /// <summary>Obtains metadata from GIF files.</summary>
@@ -15,7 +9,7 @@ namespace MetadataExtractor.Formats.Gif
     public static class GifMetadataReader
     {
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>(2);
 
@@ -27,7 +21,7 @@ namespace MetadataExtractor.Formats.Gif
             return directories;
         }
 
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             return new GifReader().Extract(new SequentialStreamReader(stream)).ToList();
         }

--- a/MetadataExtractor/Formats/Gif/GifReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifReader.cs
@@ -3,12 +3,6 @@
 using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.Xmp;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Gif
 {
     /// <summary>Reader of GIF encoded data.</summary>
@@ -27,7 +21,7 @@ namespace MetadataExtractor.Formats.Gif
         private const string Gif87AVersionIdentifier = "87a";
         private const string Gif89AVersionIdentifier = "89a";
 
-        public DirectoryList Extract(SequentialReader reader)
+        public IReadOnlyList<Directory> Extract(SequentialReader reader)
         {
             reader = reader.WithByteOrder(isMotorolaByteOrder: false);
 

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -6,11 +6,6 @@ using MetadataExtractor.Formats.Iso14496.Boxes;
 using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.QuickTime;
 using MetadataExtractor.Formats.Xmp;
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
 
 namespace MetadataExtractor.Formats.Heif
 {
@@ -20,7 +15,7 @@ namespace MetadataExtractor.Formats.Heif
         private const int ExifTag = 0x45786966; // "Exif"
         private const int MimeTag = 0x6D696D65; // "mime"
 
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
+++ b/MetadataExtractor/Formats/Ico/IcoMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Ico
 {
     /// <summary>Obtains metadata from ICO (Windows Icon) files.</summary>
@@ -15,7 +9,7 @@ namespace MetadataExtractor.Formats.Ico
     public static class IcoMetadataReader
     {
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -27,7 +21,7 @@ namespace MetadataExtractor.Formats.Ico
             return directories;
         }
 
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             return new IcoReader().Extract(new SequentialStreamReader(stream));
         }

--- a/MetadataExtractor/Formats/Ico/IcoReader.cs
+++ b/MetadataExtractor/Formats/Ico/IcoReader.cs
@@ -1,12 +1,5 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Ico
 {
     /// <summary>Reads ICO (Windows Icon) file metadata.</summary>
@@ -18,7 +11,7 @@ namespace MetadataExtractor.Formats.Ico
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class IcoReader
     {
-        public DirectoryList Extract(SequentialReader reader)
+        public IReadOnlyList<Directory> Extract(SequentialReader reader)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Iso14496/Boxes/ItemReferenceBox.cs
+++ b/MetadataExtractor/Formats/Iso14496/Boxes/ItemReferenceBox.cs
@@ -19,10 +19,6 @@ namespace MetadataExtractor.Formats.Iso14496.Boxes
             Boxes = list;
         }
 
-#if NET35
-        public override IEnumerable<Box> Children() => Boxes.OfType<Box>();
-#else
         public override IEnumerable<Box> Children() => Boxes;
-#endif
     }
 }

--- a/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
@@ -11,12 +11,6 @@ using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Flir;
 using MetadataExtractor.Formats.Xmp;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Jpeg
 {
     /// <summary>Obtains all available metadata from JPEG formatted files.</summary>
@@ -48,14 +42,14 @@ namespace MetadataExtractor.Formats.Jpeg
 
         /// <exception cref="JpegProcessingException"/>
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(Stream stream, ICollection<IJpegSegmentMetadataReader>? readers = null)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream, ICollection<IJpegSegmentMetadataReader>? readers = null)
         {
             return Process(stream, readers);
         }
 
         /// <exception cref="JpegProcessingException"/>
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath, ICollection<IJpegSegmentMetadataReader>? readers = null)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath, ICollection<IJpegSegmentMetadataReader>? readers = null)
         {
             var directories = new List<Directory>();
 
@@ -69,7 +63,7 @@ namespace MetadataExtractor.Formats.Jpeg
 
         /// <exception cref="JpegProcessingException"/>
         /// <exception cref="IOException"/>
-        public static DirectoryList Process(Stream stream, ICollection<IJpegSegmentMetadataReader>? readers = null)
+        public static IReadOnlyList<Directory> Process(Stream stream, ICollection<IJpegSegmentMetadataReader>? readers = null)
         {
             readers ??= _allReaders;
 
@@ -83,7 +77,7 @@ namespace MetadataExtractor.Formats.Jpeg
             return ProcessJpegSegments(readers, segments.ToList());
         }
 
-        public static DirectoryList ProcessJpegSegments(IEnumerable<IJpegSegmentMetadataReader> readers, ICollection<JpegSegment> segments)
+        public static IReadOnlyList<Directory> ProcessJpegSegments(IEnumerable<IJpegSegmentMetadataReader> readers, ICollection<JpegSegment> segments)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Jpeg/JpegSegmentReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegSegmentReader.cs
@@ -1,12 +1,5 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-
-#if NET35
-using JpegSegmentList = System.Collections.Generic.IList<MetadataExtractor.Formats.Jpeg.JpegSegment>;
-#else
-using JpegSegmentList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Formats.Jpeg.JpegSegment>;
-#endif
-
 namespace MetadataExtractor.Formats.Jpeg
 {
     /// <summary>Parses the structure of JPEG data, returning contained segments.</summary>
@@ -35,7 +28,7 @@ namespace MetadataExtractor.Formats.Jpeg
         /// <param name="segmentTypes">the set of JPEG segments types that are to be returned. If this argument is <see langword="null" /> then all found segment types are returned.</param>
         /// <exception cref="JpegProcessingException"/>
         /// <exception cref="IOException"/>
-        public static JpegSegmentList ReadSegments(string filePath, ICollection<JpegSegmentType>? segmentTypes = null)
+        public static IReadOnlyList<JpegSegment> ReadSegments(string filePath, ICollection<JpegSegmentType>? segmentTypes = null)
         {
             using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             return ReadSegments(new SequentialStreamReader(stream), segmentTypes).ToList();

--- a/MetadataExtractor/Formats/Jpeg/JpegSegmentType.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegSegmentType.cs
@@ -221,12 +221,7 @@ namespace MetadataExtractor.Formats.Jpeg
         }
 
         /// <summary>Gets JPEG segment types that might contain metadata.</summary>
-#if NET35
-        public static IEnumerable<JpegSegmentType> CanContainMetadataTypes { get; }
-#else
-        public static IReadOnlyList<JpegSegmentType> CanContainMetadataTypes { get; }
-#endif
-            = Enum.GetValues(typeof(JpegSegmentType)).Cast<JpegSegmentType>().Where(type => type.CanContainMetadata()).ToList();
+        public static IReadOnlyList<JpegSegmentType> CanContainMetadataTypes { get; } = Enum.GetValues(typeof(JpegSegmentType)).Cast<JpegSegmentType>().Where(type => type.CanContainMetadata()).ToList();
 
         /// <summary>Gets whether this JPEG segment type's marker is followed by a length indicator.</summary>
         public static bool ContainsPayload(this JpegSegmentType type)

--- a/MetadataExtractor/Formats/Mpeg/Mp3MetadataReader.cs
+++ b/MetadataExtractor/Formats/Mpeg/Mp3MetadataReader.cs
@@ -1,16 +1,10 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Mpeg
 {
     public static class Mp3MetadataReader
     {
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             return new[] { new Mp3Reader().Extract(new SequentialStreamReader(stream)) };
         }

--- a/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
+++ b/MetadataExtractor/Formats/Netpbm/NetpbmMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Netpbm
 {
     /// <summary>Obtains metadata from BMP files.</summary>
@@ -15,7 +9,7 @@ namespace MetadataExtractor.Formats.Netpbm
     public static class NetpbmMetadataReader
     {
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>(2);
 

--- a/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
+++ b/MetadataExtractor/Formats/Pcx/PcxMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Pcx
 {
     /// <summary>Obtains metadata from PCX image files.</summary>
@@ -15,7 +9,7 @@ namespace MetadataExtractor.Formats.Pcx
     public static class PcxMetadataReader
     {
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
@@ -6,12 +6,6 @@ using MetadataExtractor.Formats.Iptc;
 using MetadataExtractor.Formats.Jpeg;
 using MetadataExtractor.Formats.Xmp;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Reads metadata created by Photoshop and stored in the APPD segment of JPEG files.</summary>
@@ -42,7 +36,7 @@ namespace MetadataExtractor.Formats.Photoshop
             return Enumerable.Empty<Directory>();
         }
 
-        public DirectoryList Extract(SequentialReader reader, int length)
+        public IReadOnlyList<Directory> Extract(SequentialReader reader, int length)
         {
             var directory = new PhotoshopDirectory();
 

--- a/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Obtains metadata from Photoshop's PSD files.</summary>
@@ -15,7 +9,7 @@ namespace MetadataExtractor.Formats.Photoshop
     public static class PsdMetadataReader
     {
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -27,7 +21,7 @@ namespace MetadataExtractor.Formats.Photoshop
             return directories;
         }
 
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             return new PsdReader().Extract(new SequentialStreamReader(stream));
         }

--- a/MetadataExtractor/Formats/Photoshop/PsdReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PsdReader.cs
@@ -1,18 +1,12 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Photoshop
 {
     /// <summary>Reads metadata stored within PSD file format data.</summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class PsdReader
     {
-        public DirectoryList Extract(SequentialReader reader)
+        public IReadOnlyList<Directory> Extract(SequentialReader reader)
         {
             var directory = new PsdHeaderDirectory();
 

--- a/MetadataExtractor/Formats/Png/PngDescriptor.cs
+++ b/MetadataExtractor/Formats/Png/PngDescriptor.cs
@@ -79,11 +79,7 @@ namespace MetadataExtractor.Formats.Png
                 ? null
                 : string.Join(
                     "\n",
-                    pairs.Select(kv => $"{kv.Key}: {kv.Value}")
-#if NET35
-                    .ToArray()
-#endif
-                    );
+                    pairs.Select(kv => $"{kv.Key}: {kv.Value}"));
         }
 
         public string? GetBackgroundColorDescription()

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -9,12 +9,6 @@ using MetadataExtractor.Formats.Iptc;
 using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.Formats.Xmp;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Png
 {
     /// <author>Drew Noakes https://drewnoakes.com</author>
@@ -41,7 +35,7 @@ namespace MetadataExtractor.Formats.Png
 
         /// <exception cref="PngProcessingException"/>
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -55,7 +49,7 @@ namespace MetadataExtractor.Formats.Png
 
         /// <exception cref="PngProcessingException"/>
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             List<Directory>? directories = null;
 
@@ -592,14 +586,7 @@ namespace MetadataExtractor.Formats.Png
             {
                 var ms = new MemoryStream();
 
-#if !NET35
                 inflaterStream.CopyTo(ms);
-#else
-                var buffer = new byte[1024];
-                int count;
-                while ((count = inflaterStream.Read(buffer, 0, 256)) > 0)
-                    ms.Write(buffer, 0, count);
-#endif
 
                 textBytes = ms.ToArray();
             }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -4,11 +4,6 @@ using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.Exif.Makernotes;
 using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.Formats.Xmp;
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
 
 #pragma warning disable CS8602 // Dereference of a possibly null reference
 #pragma warning disable CS8604 // Dereference of a possibly null reference
@@ -20,7 +15,7 @@ namespace MetadataExtractor.Formats.QuickTime
         private static readonly DateTime _epoch = new(1904, 1, 1);
         private static readonly int[] _supportedAtomValueTypes = [1, 13, 14, 23, 27];
 
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             var directories = new List<Directory>();
             var metaDataKeys = new List<string>();

--- a/MetadataExtractor/Formats/Raf/RafMetadataReader.cs
+++ b/MetadataExtractor/Formats/Raf/RafMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.Jpeg;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Raf
 {
     /// <summary>Obtains metadata from RAF (Fujifilm camera raw) image files.</summary>
@@ -15,7 +9,7 @@ namespace MetadataExtractor.Formats.Raf
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public static class RafMetadataReader
     {
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             if (!stream.CanSeek)
                 throw new ArgumentException("Must support seek", nameof(stream));

--- a/MetadataExtractor/Formats/Tga/TgaMetadataReader.cs
+++ b/MetadataExtractor/Formats/Tga/TgaMetadataReader.cs
@@ -2,12 +2,6 @@
 
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Tga
 {
     /// <summary>Obtains metadata from TGA (Truevision) files.</summary>
@@ -16,7 +10,7 @@ namespace MetadataExtractor.Formats.Tga
     {
         /// <exception cref="IOException"/>
         /// <exception cref="ArgumentException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -30,7 +24,7 @@ namespace MetadataExtractor.Formats.Tga
 
         /// <exception cref="IOException"/>
         /// <exception cref="ArgumentException"/>
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             if (!stream.CanSeek)
                 throw new ArgumentException("Must support seek", nameof(stream));

--- a/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
@@ -3,12 +3,6 @@
 using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.FileSystem;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Tiff
 {
     /// <summary>Obtains all available metadata from TIFF formatted files.</summary>
@@ -22,7 +16,7 @@ namespace MetadataExtractor.Formats.Tiff
     {
         /// <exception cref="IOException"/>
         /// <exception cref="TiffProcessingException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -39,7 +33,7 @@ namespace MetadataExtractor.Formats.Tiff
 
         /// <exception cref="IOException"/>
         /// <exception cref="TiffProcessingException"/>
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             // TIFF processing requires random access, as directories can be scattered throughout the byte sequence.
             // Stream does not support seeking backwards, so we wrap it with IndexedCapturingReader, which

--- a/MetadataExtractor/Formats/Wav/WavMetadataReader.cs
+++ b/MetadataExtractor/Formats/Wav/WavMetadataReader.cs
@@ -3,12 +3,6 @@
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Riff;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.Wav
 {
     /// <summary>Obtains metadata from WAV files.</summary>
@@ -17,7 +11,7 @@ namespace MetadataExtractor.Formats.Wav
     {
         /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -31,7 +25,7 @@ namespace MetadataExtractor.Formats.Wav
 
         /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             var directories = new List<Directory>();
             new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new WavRiffHandler(directories));

--- a/MetadataExtractor/Formats/WebP/WebPMetadataReader.cs
+++ b/MetadataExtractor/Formats/WebP/WebPMetadataReader.cs
@@ -3,12 +3,6 @@
 using MetadataExtractor.Formats.FileSystem;
 using MetadataExtractor.Formats.Riff;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 namespace MetadataExtractor.Formats.WebP
 {
     /// <summary>Obtains metadata from WebP files.</summary>
@@ -17,7 +11,7 @@ namespace MetadataExtractor.Formats.WebP
     {
         /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 
@@ -31,7 +25,7 @@ namespace MetadataExtractor.Formats.WebP
 
         /// <exception cref="IOException"/>
         /// <exception cref="RiffProcessingException"/>
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             var directories = new List<Directory>();
             new RiffReader().ProcessRiff(new SequentialStreamReader(stream), new WebPRiffHandler(directories));

--- a/MetadataExtractor/IO/IndexedCapturingReader.cs
+++ b/MetadataExtractor/IO/IndexedCapturingReader.cs
@@ -133,7 +133,7 @@ namespace MetadataExtractor.IO
 
         private void GetPosition(int index, out int chunkIndex, out int innerIndex)
         {
-#if NET35 || NET45 || NETSTANDARD2_0
+#if NET45 || NETSTANDARD2_0
             chunkIndex = Math.DivRem(index, _chunkLength, out innerIndex);
 #elif NET5_0_OR_GREATER
             (chunkIndex, innerIndex) = Math.DivRem(index, _chunkLength);

--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -21,12 +21,6 @@ using MetadataExtractor.Formats.Tga;
 using MetadataExtractor.Formats.Wav;
 using MetadataExtractor.Formats.WebP;
 
-#if NET35
-using DirectoryList = System.Collections.Generic.IList<MetadataExtractor.Directory>;
-#else
-using DirectoryList = System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory>;
-#endif
-
 // ReSharper disable RedundantCaseLabel
 
 namespace MetadataExtractor
@@ -66,7 +60,7 @@ namespace MetadataExtractor
         /// <returns>A list of <see cref="Directory"/> instances containing the various types of metadata found within the file's data.</returns>
         /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
         {
             var fileType = FileTypeDetector.DetectFileType(stream);
 
@@ -119,7 +113,7 @@ namespace MetadataExtractor
         /// <returns>A list of <see cref="Directory"/> instances containing the various types of metadata found within the file's data.</returns>
         /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
         /// <exception cref="IOException"/>
-        public static DirectoryList ReadMetadata(string filePath)
+        public static IReadOnlyList<Directory> ReadMetadata(string filePath)
         {
             var directories = new List<Directory>();
 

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -8,7 +8,7 @@ MOV and related QuickTime video formats such as MP4, M4V, 3G2, 3GP are supported
 
 Camera manufacturer specific support exists for Agfa, Canon, Casio, DJI, Epson, Fujifilm, Kodak, Kyocera, Leica, Minolta, Nikon, Olympus, Panasonic, Pentax, Reconyx, Sanyo, Sigma/Foveon and Sony models.</Description>
     <AssemblyTitle>Metadata Extractor</AssemblyTitle>
-    <TargetFrameworks>netstandard1.3;netstandard2.0;net35;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard1.3;netstandard2.0;net45</TargetFrameworks>
     <NoWarn>$(NoWarn);1591</NoWarn>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <PackageTags>Metadata;Exif;IPTC;XMP;ICC;Photoshop;WebP;PNG;BMP;ICO;PCX;JPEG;TIFF;PSD;Photography;QuickTime;MOV;MP4;M4V;Video;MP3;WAV;Imaging;Video;Audio</PackageTags>
@@ -37,10 +37,6 @@ Camera manufacturer specific support exists for Agfa, Canon, Casio, DJI, Epson, 
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.0' ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net35' ">
-    <Reference Include="System" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">

--- a/MetadataExtractor/TagDescriptor.cs
+++ b/MetadataExtractor/TagDescriptor.cs
@@ -205,11 +205,7 @@ namespace MetadataExtractor
                 value >>= 1;
                 bitIndex++;
             }
-#if NET35
-            return string.Join(", ", parts.ToArray());
-#else
             return string.Join(", ", parts);
-#endif
         }
 
         [Pure]

--- a/README.md
+++ b/README.md
@@ -143,18 +143,21 @@ Camera-specific "makernote" data is decoded for cameras manufactured by:
 
 This library targets:
 
-- .NET Framework 3.5 (`net35`)
 - .NET Framework 4.5 (`net45`)
 - .NET Standard 1.3 (`netstandard1.3`)
 - .NET Standard 2.0 (`netstandard2.0`)
 
 All target frameworks are provided via the [one NuGet package](https://www.nuget.org/packages/MetadataExtractor).
 
-`net35` and `net45` target the full .NET Framework. `net45` uses the newer `IReadOnlyList<>` on some public APIs where `net35` uses `IList<>`. Internally `net45` also uses some newer library features for slightly improved performance.
-
 `netstandard1.3` implements version 1.3 of the [.NET Standard](https://docs.microsoft.com/en-us/dotnet/articles/standard/library) which covers .NET Core, Mono, Xamarin platforms, UWP, and future platforms. 
 
+`netstandard2.0` implements version 2.0 of the .NET Standard, which uses newer APIs where possible.
+
+`net45` targets the full .NET Framework, from version 4.5 onwards.
+
 A PCL build was supported until [version 1.5.3](https://www.nuget.org/packages/MetadataExtractor/1.5.3) which supported Silverlight 5.0, Windows 8.0, Windows Phone 8.1 and Windows Phone Silverlight 8.0. PCL versions did not support file-system metadata due to restricted IO APIs.
+
+A `net3.5` build was supported until [version 2.8.1](https://www.nuget.org/packages/MetadataExtractor/2.8.1). Support for this framework was dropped in early 2024 to enable use of newer, more efficient, .NET APIs.
 
 ## Building
 


### PR DESCRIPTION
.NET Framework 3.5 was released in 2007. Continued support of that target prohibits taking advantage of newer APIs, such as `Span<T>` (via the `System.Memory` package). Spans unlock the potential for better performance when parsing data.

It's been many years since I've heard of anyone using this target. Anyone who does still need it can remain on version 2.8.1 or earlier.