### PR TITLE
Work around invalid XMP XML

### DIFF
--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -47,6 +47,7 @@ Camera manufacturer specific support exists for Agfa, Canon, Casio, DJI, Epson, 
   <!-- Analyzers -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.11.0-beta1.23364.2" PrivateAssets="All" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Fixes #356

Software that re-writes XMP can do so without changing the size of the XMP segment. If it overwrites the data with a shorter payload, there can be junk at the end which causes the XML parsing to fail.

This change adds a scan for known end-of-message markers, to avoid this problem.