### PR TITLE
Spanify various things and use UTF-8 literals

### DIFF
--- a/MetadataExtractor/Formats/Apple/BplistReader.cs
+++ b/MetadataExtractor/Formats/Apple/BplistReader.cs
@@ -11,21 +11,21 @@ public sealed class BplistReader
     // https://opensource.apple.com/source/CF/CF-550/CFBinaryPList.c
     // https://synalysis.com/how-to-decode-apple-binary-property-list-files/
 
-    private static readonly byte[] _bplistHeader = [(byte)'b', (byte)'p', (byte)'l', (byte)'i', (byte)'s', (byte)'t', (byte)'0', (byte)'0'];
+    private static ReadOnlySpan<byte> BplistHeader => "bplist00"u8;
 
     /// <summary>
     /// Gets whether <paramref name="bplist"/> starts with the expected header bytes.
     /// </summary>
     public static bool IsValid(byte[] bplist)
     {
-        if (bplist.Length < _bplistHeader.Length)
+        if (bplist.Length < BplistHeader.Length)
         {
             return false;
         }
 
-        for (int i = 0; i < _bplistHeader.Length; i++)
+        for (int i = 0; i < BplistHeader.Length; i++)
         {
-            if (bplist[i] != _bplistHeader[i])
+            if (bplist[i] != BplistHeader[i])
             {
                 return false;
             }

--- a/MetadataExtractor/Formats/Eps/EpsReader.cs
+++ b/MetadataExtractor/Formats/Eps/EpsReader.cs
@@ -254,7 +254,7 @@ namespace MetadataExtractor.Formats.Eps
         /// </summary>
         private static void ExtractXmpData(List<Directory> directories, SequentialReader reader)
         {
-            byte[] xmp = ReadUntil(reader, Encoding.UTF8.GetBytes("<?xpacket end=\"w\"?>"));
+            byte[] xmp = ReadUntil(reader, "<?xpacket end=\"w\"?>"u8);
             directories.Add(new XmpReader().Extract(xmp));
         }
 
@@ -262,7 +262,7 @@ namespace MetadataExtractor.Formats.Eps
         /// Reads all bytes until the given sentinel is observed.
         /// The sentinel will be included in the returned bytes.
         /// </summary>
-        private static byte[] ReadUntil(SequentialReader reader, byte[] sentinel)
+        private static byte[] ReadUntil(SequentialReader reader, ReadOnlySpan<byte> sentinel)
         {
             var bytes = new MemoryStream();
 

--- a/MetadataExtractor/Formats/Exif/ExifReader.cs
+++ b/MetadataExtractor/Formats/Exif/ExifReader.cs
@@ -15,16 +15,16 @@ namespace MetadataExtractor.Formats.Exif
     {
         public const string JpegSegmentPreamble = "Exif\x0\x0";
 
-        private static readonly byte[] _preambleBytes = Encoding.ASCII.GetBytes(JpegSegmentPreamble);
+        private static ReadOnlySpan<byte> ExifPreamble => "Exif\x0\x0"u8;
 
-        public static bool StartsWithJpegExifPreamble(byte[] bytes) => bytes.StartsWith(_preambleBytes);
+        public static bool StartsWithJpegExifPreamble(byte[] bytes) => bytes.AsSpan().StartsWith(ExifPreamble);
 
-        public static int JpegSegmentPreambleLength => _preambleBytes.Length;
+        public static int JpegSegmentPreambleLength => ExifPreamble.Length;
 
         /// <summary>Exif data stored in JPEG files' APP1 segment are preceded by this six character preamble "Exif\0\0".</summary>
-        protected override byte[] PreambleBytes => _preambleBytes;
+        protected override ReadOnlySpan<byte> PreambleBytes => ExifPreamble;
 
-        public override ICollection<JpegSegmentType> SegmentTypes { get; } = new[] { JpegSegmentType.App1 };
+        public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.App1];
 
         protected override IEnumerable<Directory> Extract(byte[] segmentBytes, int preambleLength)
         {

--- a/MetadataExtractor/Formats/Icc/IccReader.cs
+++ b/MetadataExtractor/Formats/Icc/IccReader.cs
@@ -18,19 +18,19 @@ namespace MetadataExtractor.Formats.Icc
     public sealed class IccReader : IJpegSegmentMetadataReader
     {
         public const string JpegSegmentPreamble = "ICC_PROFILE"; // TODO what are the extra three bytes here? are they always the same?
-        private static readonly byte[] _jpegSegmentPreambleBytes = Encoding.UTF8.GetBytes(JpegSegmentPreamble);
+        private static ReadOnlySpan<byte> JpegSegmentPreambleBytes => "ICC_PROFILE"u8;
 
         // NOTE the header is 14 bytes, while "ICC_PROFILE" is 11
         private const int JpegSegmentPreambleLength = 14;
 
-        ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes { get; } = new[] { JpegSegmentType.App2 };
+        ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes { get; } = [JpegSegmentType.App2];
 
         public IEnumerable<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
             // ICC data can be spread across multiple JPEG segments.
 
             // Skip any segments that do not contain the required preamble
-            var iccSegments = segments.Where(segment => segment.Bytes.Length > JpegSegmentPreambleLength && segment.Bytes.StartsWith(_jpegSegmentPreambleBytes)).ToList();
+            var iccSegments = segments.Where(segment => segment.Bytes.Length > JpegSegmentPreambleLength && segment.Bytes.AsSpan().StartsWith(JpegSegmentPreambleBytes)).ToList();
 
             if (iccSegments.Count == 0)
                 return Enumerable.Empty<Directory>();

--- a/MetadataExtractor/Formats/Iso14496/Boxes/ColorInformationBox.cs
+++ b/MetadataExtractor/Formats/Iso14496/Boxes/ColorInformationBox.cs
@@ -4,8 +4,6 @@ namespace MetadataExtractor.Formats.Iso14496.Boxes
 {
     internal sealed class ColorInformationBox : Box
     {
-        private static readonly byte[] _emptyByteArray = [];
-
         public const uint NclxTag = 0x6E636C78; // nclx
         public const uint RICCTag = 0x72494343; // rICC
         public const uint ProfTag = 0x70726F66; // prof
@@ -30,7 +28,7 @@ namespace MetadataExtractor.Formats.Iso14496.Boxes
                     TransferCharacteristics = sr.GetUInt16();
                     MatrixCharacteristics = sr.GetUInt16();
                     FullRangeFlag = (sr.GetByte() & 128) == 128;
-                    IccProfile = _emptyByteArray;
+                    IccProfile = [];
                     break;
                 }
                 case RICCTag:
@@ -41,7 +39,7 @@ namespace MetadataExtractor.Formats.Iso14496.Boxes
                 }
                 default:
                 {
-                    IccProfile = _emptyByteArray;
+                    IccProfile = [];
                     break;
                 }
             }

--- a/MetadataExtractor/Formats/Jfif/JfifReader.cs
+++ b/MetadataExtractor/Formats/Jfif/JfifReader.cs
@@ -17,9 +17,9 @@ namespace MetadataExtractor.Formats.Jfif
     {
         public const string JpegSegmentPreamble = "JFIF";
 
-        protected override byte[] PreambleBytes { get; } = Encoding.ASCII.GetBytes(JpegSegmentPreamble);
+        protected override ReadOnlySpan<byte> PreambleBytes => "JFIF"u8;
 
-        public override ICollection<JpegSegmentType> SegmentTypes { get; } = new[] { JpegSegmentType.App0 };
+        public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.App0];
 
         protected override IEnumerable<Directory> Extract(byte[] segmentBytes, int preambleLength)
         {

--- a/MetadataExtractor/Formats/Jfxx/JfxxReader.cs
+++ b/MetadataExtractor/Formats/Jfxx/JfxxReader.cs
@@ -17,9 +17,9 @@ namespace MetadataExtractor.Formats.Jfxx
     {
         public const string JpegSegmentPreamble = "JFXX";
 
-        protected override byte[] PreambleBytes { get; } = Encoding.ASCII.GetBytes(JpegSegmentPreamble);
+        protected override ReadOnlySpan<byte> PreambleBytes => "JFXX"u8;
 
-        public override ICollection<JpegSegmentType> SegmentTypes { get; } = new[] { JpegSegmentType.App0 };
+        public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.App0];
 
         protected override IEnumerable<Directory> Extract(byte[] segmentBytes, int preambleLength)
         {

--- a/MetadataExtractor/Formats/Jpeg/JpegSegmentWithPreambleMetadataReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegSegmentWithPreambleMetadataReader.cs
@@ -4,18 +4,16 @@ namespace MetadataExtractor.Formats.Jpeg
 {
     public abstract class JpegSegmentWithPreambleMetadataReader : IJpegSegmentMetadataReader
     {
-        protected abstract byte[] PreambleBytes { get; }
+        protected abstract ReadOnlySpan<byte> PreambleBytes { get; }
 
         public abstract ICollection<JpegSegmentType> SegmentTypes { get; }
 
         public IEnumerable<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {
-            var preamble = PreambleBytes;
-
             // Skip segments not starting with the required preamble
             return segments
-                .Where(segment => segment.Bytes.StartsWith(preamble))
-                .SelectMany(segment => Extract(segment.Bytes, preambleLength: preamble.Length));
+                .Where(segment => segment.Bytes.AsSpan().StartsWith(PreambleBytes))
+                .SelectMany(segment => Extract(segment.Bytes, preambleLength: PreambleBytes.Length));
         }
 
         protected abstract IEnumerable<Directory> Extract(byte[] segmentBytes, int preambleLength);

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
@@ -20,9 +20,9 @@ namespace MetadataExtractor.Formats.Photoshop
     {
         public const string JpegSegmentPreamble = "Photoshop 3.0";
 
-        protected override byte[] PreambleBytes { get; } = Encoding.ASCII.GetBytes(JpegSegmentPreamble);
+        protected override ReadOnlySpan<byte> PreambleBytes => "Photoshop 3.0"u8;
 
-        public override ICollection<JpegSegmentType> SegmentTypes { get; } = new[] { JpegSegmentType.AppD };
+        public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.AppD];
 
         protected override IEnumerable<Directory> Extract(byte[] segmentBytes, int preambleLength)
         {

--- a/MetadataExtractor/Formats/Png/PngChunkReader.cs
+++ b/MetadataExtractor/Formats/Png/PngChunkReader.cs
@@ -5,7 +5,7 @@ namespace MetadataExtractor.Formats.Png
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class PngChunkReader
     {
-        private static readonly byte[] _pngSignatureBytes = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+        private static ReadOnlySpan<byte> PngSignatureBytes => [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
 
         /// <exception cref="PngProcessingException"/>
         /// <exception cref="IOException"/>
@@ -54,7 +54,7 @@ namespace MetadataExtractor.Formats.Png
             // network byte order
             reader = reader.WithByteOrder(isMotorolaByteOrder: true);
 
-            if (!_pngSignatureBytes.SequenceEqual(reader.GetBytes(_pngSignatureBytes.Length)))
+            if (!PngSignatureBytes.SequenceEqual(reader.GetBytes(PngSignatureBytes.Length)))
                 throw new PngProcessingException("PNG signature mismatch");
 
             var seenImageHeader = false;

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
@@ -10,61 +10,61 @@ namespace MetadataExtractor.Formats.QuickTime
             // http://www.ftyps.com
 
             // QuickTime Mov
-            { Util.FileType.QuickTime, Encoding.UTF8.GetBytes("moov") },
-            { Util.FileType.QuickTime, Encoding.UTF8.GetBytes("wide") },
-            { Util.FileType.QuickTime, Encoding.UTF8.GetBytes("mdat") },
-            { Util.FileType.QuickTime, Encoding.UTF8.GetBytes("free") },
-            { Util.FileType.QuickTime, Encoding.UTF8.GetBytes("qt  ") },
-            { Util.FileType.QuickTime, Encoding.UTF8.GetBytes("3g2a") },
+            { Util.FileType.QuickTime, "moov"u8 },
+            { Util.FileType.QuickTime, "wide"u8 },
+            { Util.FileType.QuickTime, "mdat"u8 },
+            { Util.FileType.QuickTime, "free"u8 },
+            { Util.FileType.QuickTime, "qt  "u8 },
+            { Util.FileType.QuickTime, "3g2a"u8 },
 
             // MP4
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("3gp5") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("avc1") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("iso2") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("isom") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("M4A ") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("M4B ") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("M4P ") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("M4V ") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("M4VH") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("M4VP") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("mmp4") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("mp41") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("mp42") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("mp71") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("MSNV") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDAS") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDSC") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDSH") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDSM") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDSP") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDSS") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDXC") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDXH") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDXM") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDXP") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("NDXS") },
-            { Util.FileType.Mp4, Encoding.UTF8.GetBytes("nvr1") },
+            { Util.FileType.Mp4, "3gp5"u8 },
+            { Util.FileType.Mp4, "avc1"u8 },
+            { Util.FileType.Mp4, "iso2"u8 },
+            { Util.FileType.Mp4, "isom"u8 },
+            { Util.FileType.Mp4, "M4A "u8 },
+            { Util.FileType.Mp4, "M4B "u8 },
+            { Util.FileType.Mp4, "M4P "u8 },
+            { Util.FileType.Mp4, "M4V "u8 },
+            { Util.FileType.Mp4, "M4VH"u8 },
+            { Util.FileType.Mp4, "M4VP"u8 },
+            { Util.FileType.Mp4, "mmp4"u8 },
+            { Util.FileType.Mp4, "mp41"u8 },
+            { Util.FileType.Mp4, "mp42"u8 },
+            { Util.FileType.Mp4, "mp71"u8 },
+            { Util.FileType.Mp4, "MSNV"u8 },
+            { Util.FileType.Mp4, "NDAS"u8 },
+            { Util.FileType.Mp4, "NDSC"u8 },
+            { Util.FileType.Mp4, "NDSH"u8 },
+            { Util.FileType.Mp4, "NDSM"u8 },
+            { Util.FileType.Mp4, "NDSP"u8 },
+            { Util.FileType.Mp4, "NDSS"u8 },
+            { Util.FileType.Mp4, "NDXC"u8 },
+            { Util.FileType.Mp4, "NDXH"u8 },
+            { Util.FileType.Mp4, "NDXM"u8 },
+            { Util.FileType.Mp4, "NDXP"u8 },
+            { Util.FileType.Mp4, "NDXS"u8 },
+            { Util.FileType.Mp4, "nvr1"u8 },
 
             // HEIF
-            { Util.FileType.Heif, Encoding.UTF8.GetBytes("mif1") },
-            { Util.FileType.Heif, Encoding.UTF8.GetBytes("msf1") },
-            { Util.FileType.Heif, Encoding.UTF8.GetBytes("heic") },
-            { Util.FileType.Heif, Encoding.UTF8.GetBytes("heix") },
-            { Util.FileType.Heif, Encoding.UTF8.GetBytes("hevc") },
-            { Util.FileType.Heif, Encoding.UTF8.GetBytes("hevx") },
+            { Util.FileType.Heif, "mif1"u8 },
+            { Util.FileType.Heif, "msf1"u8 },
+            { Util.FileType.Heif, "heic"u8 },
+            { Util.FileType.Heif, "heix"u8 },
+            { Util.FileType.Heif, "hevc"u8 },
+            { Util.FileType.Heif, "hevx"u8 },
 
             // CRX
-            { Util.FileType.Crx, Encoding.UTF8.GetBytes("crx ") }
+            { Util.FileType.Crx, "crx "u8 }
         };
 
-        private static readonly byte[] _ftypBytes = Encoding.UTF8.GetBytes("ftyp");
+        private static ReadOnlySpan<byte> FtypBytes => "ftyp"u8;
 
         public int ByteCount => 12;
 
         public Util.FileType CheckType(byte[] bytes)
         {
-            return bytes.RegionEquals(4, 4, _ftypBytes)
+            return bytes.RegionEquals(4, 4, FtypBytes)
                 ? _ftypTrie.Find(bytes, 8, 4)
                 : Util.FileType.Unknown;
         }

--- a/MetadataExtractor/Formats/Riff/RiffTypeChecker.cs
+++ b/MetadataExtractor/Formats/Riff/RiffTypeChecker.cs
@@ -9,7 +9,7 @@ namespace MetadataExtractor.Formats.Riff
 
         public Util.FileType CheckType(byte[] bytes)
         {
-            if (!bytes.RegionEquals(0, 4, Encoding.UTF8.GetBytes("RIFF")))
+            if (!bytes.RegionEquals(0, 4, "RIFF"u8))
                 return Util.FileType.Unknown;
             var fourCC = Encoding.UTF8.GetString(bytes, index: 8, count: 4);
             return fourCC switch

--- a/MetadataExtractor/Formats/Tga/TgaFooterReader.cs
+++ b/MetadataExtractor/Formats/Tga/TgaFooterReader.cs
@@ -2,18 +2,11 @@
 
 namespace MetadataExtractor.Formats.Tga
 {
-    internal readonly struct TgaFooter
+    internal readonly struct TgaFooter(int extOffset, int devOffset, byte[] signature)
     {
-        public int ExtOffset { get; }
-        public int DevOffset { get; }
-        public byte[] Signature { get; }
-
-        public TgaFooter(int extOffset, int devOffset, byte[] signature)
-        {
-            ExtOffset = extOffset;
-            DevOffset = devOffset;
-            Signature = signature;
-        }
+        public int ExtOffset { get; } = extOffset;
+        public int DevOffset { get; } = devOffset;
+        public byte[] Signature { get; } = signature;
     }
 
     /// <summary>Reads TGA image file footer.</summary>
@@ -22,12 +15,12 @@ namespace MetadataExtractor.Formats.Tga
     {
         private const int FooterSize = 26;
 
-        private static readonly byte[] _footerSignature = Encoding.ASCII.GetBytes("TRUEVISION-XFILE.\0");
+        private static ReadOnlySpan<byte> FooterSignature => "TRUEVISION-XFILE.\0"u8;
 
         public bool TryGetOffsets(Stream stream, out int extOffset, out int devOffset)
         {
             var footer = Extract(stream, -FooterSize, SeekOrigin.End);
-            if (footer.Signature.RegionEquals(0, _footerSignature.Length, _footerSignature))
+            if (footer.Signature.RegionEquals(0, FooterSignature.Length, FooterSignature))
             {
                 extOffset = footer.ExtOffset;
                 devOffset = footer.DevOffset;
@@ -45,7 +38,7 @@ namespace MetadataExtractor.Formats.Tga
             return new TgaFooter(
                 extOffset: reader.GetInt32(),
                 devOffset: reader.GetInt32(),
-                signature: reader.GetBytes(_footerSignature.Length));
+                signature: reader.GetBytes(FooterSignature.Length));
         }
     }
 }

--- a/MetadataExtractor/Util/ByteArrayExtensions.cs
+++ b/MetadataExtractor/Util/ByteArrayExtensions.cs
@@ -4,7 +4,7 @@ namespace MetadataExtractor.Util
 {
     internal static class ByteArrayExtensions
     {
-        public static bool RegionEquals(this byte[] bytes, int offset, int count, byte[] comparand)
+        public static bool RegionEquals(this byte[] bytes, int offset, int count, ReadOnlySpan<byte> comparand)
         {
             if (offset < 0 ||                   // invalid arg
                 count < 0 ||                    // invalid arg

--- a/MetadataExtractor/Util/ByteTrie.cs
+++ b/MetadataExtractor/Util/ByteTrie.cs
@@ -89,6 +89,27 @@ namespace MetadataExtractor.Util
             MaxDepth = Math.Max(MaxDepth, depth);
         }
 
+        /// <summary>Store the given value at the specified path.</summary>
+        internal void Add(T value, ReadOnlySpan<byte> part)
+        {
+            var depth = 0;
+            var node = _root;
+
+            foreach (var b in part)
+            {
+                if (!node.Children.TryGetValue(b, out ByteTrieNode? child))
+                {
+                    child = new ByteTrieNode();
+                    node.Children[b] = child;
+                }
+                node = child;
+                depth++;
+            }
+
+            node.SetValue(value);
+            MaxDepth = Math.Max(MaxDepth, depth);
+        }
+
         IEnumerator<T> IEnumerable<T>.GetEnumerator() => throw new NotSupportedException();
 
         IEnumerator IEnumerable.GetEnumerator() => throw new NotSupportedException();

--- a/MetadataExtractor/Util/FileTypeDetector.cs
+++ b/MetadataExtractor/Util/FileTypeDetector.cs
@@ -16,46 +16,46 @@ namespace MetadataExtractor.Util
         // https://en.wikipedia.org/wiki/List_of_file_signatures
         private static readonly ByteTrie<FileType> _root = new(defaultValue: FileType.Unknown)
         {
-            { FileType.Jpeg, new byte[] { 0xff, 0xd8 } },
-            { FileType.Tiff, Encoding.UTF8.GetBytes("II"), new byte[] { 0x2a, 0x00 } },
-            { FileType.Tiff, Encoding.UTF8.GetBytes("MM"), new byte[] { 0x00, 0x2a } },
-            { FileType.Tiff, Encoding.UTF8.GetBytes("II"), new byte[] { 0x2b, 0x00 } }, // BigTIFF
-            { FileType.Tiff, Encoding.UTF8.GetBytes("MM"), new byte[] { 0x00, 0x2b } }, // BigTIFF
-            { FileType.Psd, Encoding.UTF8.GetBytes("8BPS") },
-            { FileType.Png, new byte[] { 0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52 } },
-            { FileType.Bmp, Encoding.UTF8.GetBytes("BM") }, // Standard Bitmap Windows and OS/2
-            { FileType.Bmp, Encoding.UTF8.GetBytes("BA") }, // OS/2 Bitmap Array
-            { FileType.Bmp, Encoding.UTF8.GetBytes("CI") }, // OS/2 Color Icon
-            { FileType.Bmp, Encoding.UTF8.GetBytes("CP") }, // OS/2 Color Pointer
-            { FileType.Bmp, Encoding.UTF8.GetBytes("IC") }, // OS/2 Icon
-            { FileType.Bmp, Encoding.UTF8.GetBytes("PT") }, // OS/2 Pointer
-            { FileType.Gif, Encoding.UTF8.GetBytes("GIF87a") },
-            { FileType.Gif, Encoding.UTF8.GetBytes("GIF89a") },
-            { FileType.Ico, new byte[] { 0x00, 0x00, 0x01, 0x00 } },
-            { FileType.Netpbm, Encoding.UTF8.GetBytes("P1") }, // ASCII B
-            { FileType.Netpbm, Encoding.UTF8.GetBytes("P2") }, // ASCII greysca
-            { FileType.Netpbm, Encoding.UTF8.GetBytes("P3") }, // ASCII R
-            { FileType.Netpbm, Encoding.UTF8.GetBytes("P4") }, // RAW B
-            { FileType.Netpbm, Encoding.UTF8.GetBytes("P5") }, // RAW greysca
-            { FileType.Netpbm, Encoding.UTF8.GetBytes("P6") }, // RAW R
-            { FileType.Netpbm, Encoding.UTF8.GetBytes("P7") }, // P
-            { FileType.Pcx, new byte[] { 0x0A, 0x00, 0x01 } },
+            { FileType.Jpeg, [0xff, 0xd8] },
+            { FileType.Tiff, "II"u8.ToArray(), [0x2a, 0x00] },
+            { FileType.Tiff, "MM"u8.ToArray(), [0x00, 0x2a] },
+            { FileType.Tiff, "II"u8.ToArray(), [0x2b, 0x00] }, // BigTIFF
+            { FileType.Tiff, "MM"u8.ToArray(), [0x00, 0x2b] }, // BigTIFF
+            { FileType.Psd, "8BPS"u8 },
+            { FileType.Png, [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52] },
+            { FileType.Bmp, "BM"u8 }, // Standard Bitmap Windows and OS/2
+            { FileType.Bmp, "BA"u8 }, // OS/2 Bitmap Array
+            { FileType.Bmp, "CI"u8 }, // OS/2 Color Icon
+            { FileType.Bmp, "CP"u8 }, // OS/2 Color Pointer
+            { FileType.Bmp, "IC"u8 }, // OS/2 Icon
+            { FileType.Bmp, "PT"u8 }, // OS/2 Pointer
+            { FileType.Gif, "GIF87a"u8 },
+            { FileType.Gif, "GIF89a"u8 },
+            { FileType.Ico, [0x00, 0x00, 0x01, 0x00] },
+            { FileType.Netpbm, "P1"u8 }, // ASCII B
+            { FileType.Netpbm, "P2"u8 }, // ASCII greysca
+            { FileType.Netpbm, "P3"u8 }, // ASCII R
+            { FileType.Netpbm, "P4"u8 }, // RAW B
+            { FileType.Netpbm, "P5"u8 }, // RAW greysca
+            { FileType.Netpbm, "P6"u8 }, // RAW R
+            { FileType.Netpbm, "P7"u8 }, // P
+            { FileType.Pcx, [0x0A, 0x00, 0x01] },
             // multiple PCX versions, explicitly list
-            { FileType.Pcx, new byte[] { 0x0A, 0x02, 0x01 } },
-            { FileType.Pcx, new byte[] { 0x0A, 0x03, 0x01 } },
-            { FileType.Pcx, new byte[] { 0x0A, 0x05, 0x01 } },
-            { FileType.Eps, Encoding.UTF8.GetBytes("%!PS") },
-            { FileType.Eps, new byte[] { 0xC5, 0xD0, 0xD3, 0xC6 } },
-            { FileType.Arw, Encoding.UTF8.GetBytes("II"), new byte[] { 0x2a, 0x00, 0x08, 0x00 } },
-            { FileType.Crw, Encoding.UTF8.GetBytes("II"), new byte[] { 0x1a, 0x00, 0x00, 0x00 }, Encoding.UTF8.GetBytes("HEAPCCDR") },
-            { FileType.Cr2, Encoding.UTF8.GetBytes("II"), new byte[] { 0x2a, 0x00, 0x10, 0x00, 0x00, 0x00, 0x43, 0x52 } },
+            { FileType.Pcx, [0x0A, 0x02, 0x01] },
+            { FileType.Pcx, [0x0A, 0x03, 0x01] },
+            { FileType.Pcx, [0x0A, 0x05, 0x01] },
+            { FileType.Eps, "%!PS"u8 },
+            { FileType.Eps, [0xC5, 0xD0, 0xD3, 0xC6] },
+            { FileType.Arw, "II"u8.ToArray(), [0x2a, 0x00, 0x08, 0x00] },
+            { FileType.Crw, "II"u8.ToArray(), [0x1a, 0x00, 0x00, 0x00], "HEAPCCDR"u8.ToArray() },
+            { FileType.Cr2, "II"u8.ToArray(), [0x2a, 0x00, 0x10, 0x00, 0x00, 0x00, 0x43, 0x52] },
             // NOTE this doesn't work for NEF as it incorrectly flags many other TIFF files as being NEF
-//            { FileType.Nef, Encoding.UTF8.GetBytes("MM"), new byte[] { 0x00, 0x2a, 0x00, 0x00, 0x00, 0x08, 0x00 } },
-            { FileType.Orf, Encoding.UTF8.GetBytes("IIRO"), new byte[] { 0x08, 0x00 } },
-            { FileType.Orf, Encoding.UTF8.GetBytes("MMOR"), new byte[] { 0x00, 0x00 } },
-            { FileType.Orf, Encoding.UTF8.GetBytes("IIRS"), new byte[] { 0x08, 0x00 } },
-            { FileType.Raf, Encoding.UTF8.GetBytes("FUJIFILMCCD-RAW") },
-            { FileType.Rw2, Encoding.UTF8.GetBytes("II"), new byte[] { 0x55, 0x00 } },
+//            { FileType.Nef, "MM"u8.ToArray(), [0x00, 0x2a, 0x00, 0x00, 0x00, 0x08, 0x00] },
+            { FileType.Orf, "IIRO"u8.ToArray(), [0x08, 0x00] },
+            { FileType.Orf, "MMOR"u8.ToArray(), [0x00, 0x00] },
+            { FileType.Orf, "IIRS"u8.ToArray(), [0x08, 0x00] },
+            { FileType.Raf, "FUJIFILMCCD-RAW"u8 },
+            { FileType.Rw2, "II"u8.ToArray(), [0x55, 0x00] },
         };
 
         private static readonly IEnumerable<ITypeChecker> _fixedCheckers = new ITypeChecker[]


### PR DESCRIPTION
Posting for early feedback. 

There is one public API change, which I'm happy to revert if we have a no-breaking changes policy.

`protected byte[] PreambleBytes` was changed to `protected ReadOnlySpan<byte> PreambleBytes`

This also prevents the mutation of the underlying data.