### PR TITLE
Spanify SequentialReader

### DIFF
--- a/MetadataExtractor/IO/SequentialByteArrayReader.cs
+++ b/MetadataExtractor/IO/SequentialByteArrayReader.cs
@@ -39,6 +39,15 @@ namespace MetadataExtractor.IO
             return bytes;
         }
 
+        public override void GetBytes(Span<byte> bytes)
+        {
+            if (_index + bytes.Length > _bytes.Length)
+                throw new IOException("End of data reached.");
+
+            _bytes.AsSpan(_index, bytes.Length).CopyTo(bytes);
+            _index += bytes.Length;
+        }
+
         public override void GetBytes(byte[] buffer, int offset, int count)
         {
             if (_index + count > _bytes.Length)

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Buffers.Binary;
+
 namespace MetadataExtractor.IO
 {
     /// <summary>Base class for reading sequentially through a sequence of data encoded in a byte stream.</summary>
@@ -13,13 +15,8 @@ namespace MetadataExtractor.IO
     /// <see cref="IsMotorolaByteOrder"/>.
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public abstract class SequentialReader
+    public abstract class SequentialReader(bool isMotorolaByteOrder)
     {
-        protected SequentialReader(bool isMotorolaByteOrder)
-        {
-            IsMotorolaByteOrder = isMotorolaByteOrder;
-        }
-
         /// <summary>Get and set the byte order of this reader. <c>true</c> by default.</summary>
         /// <remarks>
         /// <list type="bullet">
@@ -28,7 +25,7 @@ namespace MetadataExtractor.IO
         /// </list>
         /// </remarks>
         /// <value><c>true</c> for Motorola/big endian, <c>false</c> for Intel/little endian</value>
-        public bool IsMotorolaByteOrder { get; }
+        public bool IsMotorolaByteOrder { get; } = isMotorolaByteOrder;
 
         public abstract long Position { get; }
 
@@ -39,6 +36,8 @@ namespace MetadataExtractor.IO
         /// <returns>The requested bytes</returns>
         /// <exception cref="IOException"/>
         public abstract byte[] GetBytes(int count);
+
+        public abstract void GetBytes(Span<byte> bytes);
 
         /// <summary>Retrieves bytes, writing them into a caller-provided buffer.</summary>
         /// <param name="buffer">The array to write bytes to.</param>
@@ -100,17 +99,13 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException"/>
         public ushort GetUInt16()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return (ushort)
-                    (GetByte() << 8 |
-                     GetByte());
-            }
-            // Intel ordering - LSB first
-            return (ushort)
-                (GetByte() |
-                 GetByte() << 8);
+            Span<byte> bytes = stackalloc byte[2];
+
+            GetBytes(bytes);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadUInt16BigEndian(bytes)
+                : BinaryPrimitives.ReadUInt16LittleEndian(bytes);
         }
 
         /// <summary>Returns a signed 16-bit int calculated from two bytes of data (MSB, LSB).</summary>
@@ -118,17 +113,13 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException">the buffer does not contain enough bytes to service the request</exception>
         public short GetInt16()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return (short)
-                    (GetByte() << 8 |
-                     GetByte());
-            }
-            // Intel ordering - LSB first
-            return (short)
-                (GetByte() |
-                 GetByte() << 8);
+            Span<byte> bytes = stackalloc byte[2];
+
+            GetBytes(bytes);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadInt16BigEndian(bytes)
+                : BinaryPrimitives.ReadInt16LittleEndian(bytes);
         }
 
         /// <summary>Get a 32-bit unsigned integer from the buffer, returning it as a long.</summary>
@@ -136,21 +127,13 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException">the buffer does not contain enough bytes to service the request</exception>
         public uint GetUInt32()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first (big endian)
-                return (uint)
-                    (GetByte() << 24 |
-                     GetByte() << 16 |
-                     GetByte() << 8  |
-                     GetByte());
-            }
-            // Intel ordering - LSB first (little endian)
-            return (uint)
-                (GetByte()       |
-                 GetByte() << 8  |
-                 GetByte() << 16 |
-                 GetByte() << 24);
+            Span<byte> bytes = stackalloc byte[4];
+
+            GetBytes(bytes);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadUInt32BigEndian(bytes)
+                : BinaryPrimitives.ReadUInt32LittleEndian(bytes);
         }
 
         /// <summary>Returns a signed 32-bit integer from four bytes of data.</summary>
@@ -158,21 +141,13 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException">the buffer does not contain enough bytes to service the request</exception>
         public int GetInt32()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first (big endian)
-                return
-                    GetByte() << 24 |
-                    GetByte() << 16 |
-                    GetByte() << 8  |
-                    GetByte();
-            }
-            // Intel ordering - LSB first (little endian)
-            return
-                GetByte()       |
-                GetByte() <<  8 |
-                GetByte() << 16 |
-                GetByte() << 24;
+            Span<byte> bytes = stackalloc byte[4];
+
+            GetBytes(bytes);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadInt32BigEndian(bytes)
+                : BinaryPrimitives.ReadInt32LittleEndian(bytes);
         }
 
         /// <summary>Get a signed 64-bit integer from the buffer.</summary>
@@ -180,29 +155,12 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException">the buffer does not contain enough bytes to service the request</exception>
         public long GetInt64()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return
-                    (long)GetByte() << 56 |
-                    (long)GetByte() << 48 |
-                    (long)GetByte() << 40 |
-                    (long)GetByte() << 32 |
-                    (long)GetByte() << 24 |
-                    (long)GetByte() << 16 |
-                    (long)GetByte() << 8  |
-                          GetByte();
-            }
-            // Intel ordering - LSB first
-            return
-                      GetByte()       |
-                (long)GetByte() << 8  |
-                (long)GetByte() << 16 |
-                (long)GetByte() << 24 |
-                (long)GetByte() << 32 |
-                (long)GetByte() << 40 |
-                (long)GetByte() << 48 |
-                (long)GetByte() << 56;
+            Span<byte> bytes = stackalloc byte[8];
+            GetBytes(bytes);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadInt64BigEndian(bytes)
+                : BinaryPrimitives.ReadInt64LittleEndian(bytes);
         }
 
         /// <summary>Get an unsigned 64-bit integer from the buffer.</summary>
@@ -210,29 +168,12 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException">the buffer does not contain enough bytes to service the request</exception>
         public ulong GetUInt64()
         {
-            if (IsMotorolaByteOrder)
-            {
-                // Motorola - MSB first
-                return
-                    (ulong)GetByte() << 56 |
-                    (ulong)GetByte() << 48 |
-                    (ulong)GetByte() << 40 |
-                    (ulong)GetByte() << 32 |
-                    (ulong)GetByte() << 24 |
-                    (ulong)GetByte() << 16 |
-                    (ulong)GetByte() << 8  |
-                           GetByte();
-            }
-            // Intel ordering - LSB first
-            return
-                       GetByte()       |
-                (ulong)GetByte() << 8  |
-                (ulong)GetByte() << 16 |
-                (ulong)GetByte() << 24 |
-                (ulong)GetByte() << 32 |
-                (ulong)GetByte() << 40 |
-                (ulong)GetByte() << 48 |
-                (ulong)GetByte() << 56;
+            Span<byte> bytes = stackalloc byte[8];
+            GetBytes(bytes);
+
+            return IsMotorolaByteOrder
+                ? BinaryPrimitives.ReadUInt64BigEndian(bytes)
+                : BinaryPrimitives.ReadUInt64LittleEndian(bytes);
         }
 
 #pragma warning restore format
@@ -271,8 +212,14 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException"/>
         public string GetString(int bytesRequested, Encoding encoding)
         {
+#if NETSTANDARD2_1
+            Span<byte> bytes = bytesRequested > 2048 ? new byte[bytesRequested] : stackalloc byte[bytesRequested];
+            GetBytes(bytes);
+            return encoding.GetString(bytes);
+#else
             var bytes = GetBytes(bytesRequested);
             return encoding.GetString(bytes, 0, bytes.Length);
+#endif
         }
 
         public StringValue GetStringValue(int bytesRequested, Encoding? encoding = null)

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
+abstract MetadataExtractor.IO.SequentialReader.GetBytes(System.Span<byte> bytes) -> void
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagEpoch = 2 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagFlags = 1 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagScale = 3 -> int
@@ -73,6 +74,8 @@ override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Descripto
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Directory.Name.get -> string!
 override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte
+override MetadataExtractor.IO.SequentialByteArrayReader.GetBytes(System.Span<byte> bytes) -> void
+override MetadataExtractor.IO.SequentialStreamReader.GetBytes(System.Span<byte> bytes) -> void
 static MetadataExtractor.Formats.Apple.BplistReader.IsValid(byte[]! bplist) -> bool
 static MetadataExtractor.Formats.Apple.BplistReader.Parse(byte[]! bplist) -> MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults!
 static MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Parse(byte[]! bytes) -> MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
+abstract MetadataExtractor.IO.SequentialReader.GetBytes(System.Span<byte> bytes) -> void
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagEpoch = 2 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagFlags = 1 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagScale = 3 -> int
@@ -73,6 +74,8 @@ override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Descripto
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Directory.Name.get -> string!
 override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte
+override MetadataExtractor.IO.SequentialByteArrayReader.GetBytes(System.Span<byte> bytes) -> void
+override MetadataExtractor.IO.SequentialStreamReader.GetBytes(System.Span<byte> bytes) -> void
 static MetadataExtractor.Formats.Apple.BplistReader.IsValid(byte[]! bplist) -> bool
 static MetadataExtractor.Formats.Apple.BplistReader.Parse(byte[]! bplist) -> MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults!
 static MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Parse(byte[]! bytes) -> MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory!

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -1,5 +1,6 @@
 ﻿#nullable enable
 abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
+abstract MetadataExtractor.IO.SequentialReader.GetBytes(System.Span<byte> bytes) -> void
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagEpoch = 2 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagFlags = 1 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagScale = 3 -> int
@@ -73,6 +74,8 @@ override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Descripto
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Directory.Name.get -> string!
 override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte
+override MetadataExtractor.IO.SequentialByteArrayReader.GetBytes(System.Span<byte> bytes) -> void
+override MetadataExtractor.IO.SequentialStreamReader.GetBytes(System.Span<byte> bytes) -> void
 static MetadataExtractor.Formats.Apple.BplistReader.IsValid(byte[]! bplist) -> bool
 static MetadataExtractor.Formats.Apple.BplistReader.Parse(byte[]! bplist) -> MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults!
 static MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Parse(byte[]! bytes) -> MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory!


### PR DESCRIPTION
Read all required bytes in one go, and use `BinaryPrimitives` class for faster conversion to built-in types.