### PR TITLE
Permit var and explicit types

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,11 +30,6 @@ csharp_indent_case_contents_when_block = false
 csharp_indent_switch_labels = true
 csharp_indent_labels = flush_left
 
-# Prefer "var" everywhere
-csharp_style_var_for_built_in_types = true:suggestion
-csharp_style_var_when_type_is_apparent = true:suggestion
-csharp_style_var_elsewhere = true:suggestion
-
 # Prefer method-like constructs to have a block body
 csharp_style_expression_bodied_methods = false:none
 csharp_style_expression_bodied_constructors = false:none


### PR DESCRIPTION
There are use cases for both. Leave it to the author rather than enforcing either way.