### PR TITLE
Update JpegSegmentPreamble to UTF-8 spans

### DIFF
--- a/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
+++ b/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net45</TargetFramework>
+    <TargetFramework>net48</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
+++ b/MetadataExtractor.PowerShell/MetadataExtractor.PowerShell.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net48</TargetFramework>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MetadataExtractor.PowerShell/ShowJpegStructure.cs
+++ b/MetadataExtractor.PowerShell/ShowJpegStructure.cs
@@ -2,7 +2,6 @@
 
 using System.Management.Automation;
 using JetBrains.Annotations;
-using MetadataExtractor.Formats.Adobe;
 using MetadataExtractor.Formats.Exif;
 using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.Jfif;
@@ -16,22 +15,13 @@ namespace MetadataExtractor.PowerShell
     [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
     [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
     [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
-    public readonly struct JpegSegment
+    public readonly struct JpegSegment(JpegSegmentType type, int length, int padding, long offset, string? preamble)
     {
-        public JpegSegmentType Type { get; }
-        public int Length { get; }
-        public int Padding { get; }
-        public long Offset { get; }
-        public string? Preamble { get; }
-
-        public JpegSegment(JpegSegmentType type, int length, int padding, long offset, string? preamble)
-        {
-            Type = type;
-            Length = length;
-            Padding = padding;
-            Offset = offset;
-            Preamble = preamble;
-        }
+        public JpegSegmentType Type { get; } = type;
+        public int Length { get; } = length;
+        public int Padding { get; } = padding;
+        public long Offset { get; } = offset;
+        public string? Preamble { get; } = preamble;
     }
 
     [Cmdlet(VerbsCommon.Show, "JpegStructure")]
@@ -40,15 +30,15 @@ namespace MetadataExtractor.PowerShell
     {
         private static readonly ByteTrie<string?> _appSegmentByPreambleBytes = new ByteTrie<string?>(null)
         {
-            { "Adobe",          Encoding.UTF8.GetBytes(AdobeJpegReader.JpegSegmentPreamble) },
-            { "Ducky",          Encoding.UTF8.GetBytes(DuckyReader.JpegSegmentPreamble) },
-            { "Exif",           Encoding.UTF8.GetBytes(ExifReader.JpegSegmentPreamble) },
-            { "ICC",            Encoding.UTF8.GetBytes(IccReader.JpegSegmentPreamble) },
-            { "JFIF",           Encoding.UTF8.GetBytes(JfifReader.JpegSegmentPreamble) },
-            { "JFXX",           Encoding.UTF8.GetBytes(JfxxReader.JpegSegmentPreamble) },
-            { "Photoshop",      Encoding.UTF8.GetBytes(PhotoshopReader.JpegSegmentPreamble) },
-            { "XMP",            Encoding.UTF8.GetBytes(XmpReader.JpegSegmentPreamble) },
-            { "XMP (Extended)", Encoding.UTF8.GetBytes(XmpReader.JpegSegmentPreambleExtension) }
+            { "Adobe",          "Adobe"u8 },
+            { "Ducky",          DuckyReader.JpegSegmentPreamble },
+            { "Exif",           ExifReader.JpegSegmentPreamble },
+            { "ICC",            IccReader.JpegSegmentPreamble },
+            { "JFIF",           JfifReader.JpegSegmentPreamble },
+            { "JFXX",           JfxxReader.JpegSegmentPreamble },
+            { "Photoshop",      PhotoshopReader.JpegSegmentPreamble },
+            { "XMP",            XmpReader.JpegSegmentPreamble },
+            { "XMP (Extended)", XmpReader.JpegSegmentPreambleExtension }
         };
 
         [Parameter(Position = 0, Mandatory = true, HelpMessage = "Path to the file to process")]

--- a/MetadataExtractor/Formats/Adobe/AdobeJpegReader.cs
+++ b/MetadataExtractor/Formats/Adobe/AdobeJpegReader.cs
@@ -11,7 +11,7 @@ namespace MetadataExtractor.Formats.Adobe
     {
         public const string JpegSegmentPreamble = "Adobe";
 
-        ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes { get; } = new[] { JpegSegmentType.AppE };
+        ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes { get; } = [JpegSegmentType.AppE];
 
         public IEnumerable<Directory> ReadJpegSegments(IEnumerable<JpegSegment> segments)
         {

--- a/MetadataExtractor/Formats/Exif/ExifReader.cs
+++ b/MetadataExtractor/Formats/Exif/ExifReader.cs
@@ -13,16 +13,14 @@ namespace MetadataExtractor.Formats.Exif
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class ExifReader : JpegSegmentWithPreambleMetadataReader
     {
-        public const string JpegSegmentPreamble = "Exif\x0\x0";
+        public static ReadOnlySpan<byte> JpegSegmentPreamble => "Exif\x0\x0"u8;
 
-        private static ReadOnlySpan<byte> ExifPreamble => "Exif\x0\x0"u8;
+        public static bool StartsWithJpegExifPreamble(byte[] bytes) => bytes.AsSpan().StartsWith(JpegSegmentPreamble);
 
-        public static bool StartsWithJpegExifPreamble(byte[] bytes) => bytes.AsSpan().StartsWith(ExifPreamble);
-
-        public static int JpegSegmentPreambleLength => ExifPreamble.Length;
+        public static int JpegSegmentPreambleLength => JpegSegmentPreamble.Length;
 
         /// <summary>Exif data stored in JPEG files' APP1 segment are preceded by this six character preamble "Exif\0\0".</summary>
-        protected override ReadOnlySpan<byte> PreambleBytes => ExifPreamble;
+        protected override ReadOnlySpan<byte> PreambleBytes => JpegSegmentPreamble;
 
         public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.App1];
 

--- a/MetadataExtractor/Formats/Icc/IccReader.cs
+++ b/MetadataExtractor/Formats/Icc/IccReader.cs
@@ -17,8 +17,7 @@ namespace MetadataExtractor.Formats.Icc
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class IccReader : IJpegSegmentMetadataReader
     {
-        public const string JpegSegmentPreamble = "ICC_PROFILE"; // TODO what are the extra three bytes here? are they always the same?
-        private static ReadOnlySpan<byte> JpegSegmentPreambleBytes => "ICC_PROFILE"u8;
+        public static ReadOnlySpan<byte> JpegSegmentPreamble => "ICC_PROFILE"u8; // TODO what are the extra three bytes here? are they always the same?
 
         // NOTE the header is 14 bytes, while "ICC_PROFILE" is 11
         private const int JpegSegmentPreambleLength = 14;
@@ -30,7 +29,7 @@ namespace MetadataExtractor.Formats.Icc
             // ICC data can be spread across multiple JPEG segments.
 
             // Skip any segments that do not contain the required preamble
-            var iccSegments = segments.Where(segment => segment.Span.StartsWith(JpegSegmentPreambleBytes)).ToList();
+            var iccSegments = segments.Where(segment => segment.Span.StartsWith(JpegSegmentPreamble)).ToList();
 
             if (iccSegments.Count == 0)
                 return Enumerable.Empty<Directory>();

--- a/MetadataExtractor/Formats/Jfif/JfifReader.cs
+++ b/MetadataExtractor/Formats/Jfif/JfifReader.cs
@@ -15,9 +15,9 @@ namespace MetadataExtractor.Formats.Jfif
     /// <author>Yuri Binev, Drew Noakes, Markus Meyer</author>
     public sealed class JfifReader : JpegSegmentWithPreambleMetadataReader
     {
-        public const string JpegSegmentPreamble = "JFIF";
+        public static ReadOnlySpan<byte> JpegSegmentPreamble => "JFIF"u8;
 
-        protected override ReadOnlySpan<byte> PreambleBytes => "JFIF"u8;
+        protected override ReadOnlySpan<byte> PreambleBytes => JpegSegmentPreamble;
 
         public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.App0];
 

--- a/MetadataExtractor/Formats/Jfxx/JfxxReader.cs
+++ b/MetadataExtractor/Formats/Jfxx/JfxxReader.cs
@@ -15,9 +15,9 @@ namespace MetadataExtractor.Formats.Jfxx
     /// <author>Drew Noakes</author>
     public sealed class JfxxReader : JpegSegmentWithPreambleMetadataReader
     {
-        public const string JpegSegmentPreamble = "JFXX";
+        public static ReadOnlySpan<byte> JpegSegmentPreamble => "JFXX"u8;
 
-        protected override ReadOnlySpan<byte> PreambleBytes => "JFXX"u8;
+        protected override ReadOnlySpan<byte> PreambleBytes => JpegSegmentPreamble;
 
         public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.App0];
 

--- a/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/DuckyReader.cs
@@ -8,8 +8,7 @@ namespace MetadataExtractor.Formats.Photoshop
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class DuckyReader : IJpegSegmentMetadataReader
     {
-        public const string JpegSegmentPreamble = "Ducky";
-        internal static ReadOnlySpan<byte> JpegSegmentPreambleBytes => "Ducky"u8;
+        public static ReadOnlySpan<byte> JpegSegmentPreamble => "Ducky"u8;
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes { get; } = [JpegSegmentType.AppC];
 
@@ -17,7 +16,7 @@ namespace MetadataExtractor.Formats.Photoshop
         {
             // Skip segments not starting with the required header
             return segments
-                .Where(static segment => segment.Span.StartsWith(JpegSegmentPreambleBytes))
+                .Where(static segment => segment.Span.StartsWith(JpegSegmentPreamble))
                 .Select(segment => (Directory)Extract(new SequentialByteArrayReader(segment.Bytes, JpegSegmentPreamble.Length)));
         }
 

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
@@ -18,9 +18,9 @@ namespace MetadataExtractor.Formats.Photoshop
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class PhotoshopReader : JpegSegmentWithPreambleMetadataReader
     {
-        public const string JpegSegmentPreamble = "Photoshop 3.0";
+        public static ReadOnlySpan<byte> JpegSegmentPreamble => "Photoshop 3.0"u8;
 
-        protected override ReadOnlySpan<byte> PreambleBytes => "Photoshop 3.0"u8;
+        protected override ReadOnlySpan<byte> PreambleBytes => JpegSegmentPreamble;
 
         public override ICollection<JpegSegmentType> SegmentTypes { get; } = [JpegSegmentType.AppD];
 

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeTypeChecker.cs
@@ -65,7 +65,7 @@ namespace MetadataExtractor.Formats.QuickTime
         public Util.FileType CheckType(byte[] bytes)
         {
             return bytes.AsSpan(4, 4).SequenceEqual(FtypBytes)
-                ? _ftypTrie.Find(bytes, 8, 4)
+                ? _ftypTrie.Find(bytes.AsSpan(8, 4))
                 : Util.FileType.Unknown;
         }
     }

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -19,11 +19,8 @@ namespace MetadataExtractor.Formats.Xmp
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class XmpReader : IJpegSegmentMetadataReader
     {
-        public const string JpegSegmentPreamble = "http://ns.adobe.com/xap/1.0/\0";
-        public const string JpegSegmentPreambleExtension = "http://ns.adobe.com/xmp/extension/\0";
-
-        private static ReadOnlySpan<byte> JpegSegmentPreambleBytes => "http://ns.adobe.com/xap/1.0/\0"u8;
-        private static ReadOnlySpan<byte> JpegSegmentPreambleExtensionBytes => "http://ns.adobe.com/xmp/extension/\0"u8;
+        public static ReadOnlySpan<byte> JpegSegmentPreamble=> "http://ns.adobe.com/xap/1.0/\0"u8;
+        public static ReadOnlySpan<byte> JpegSegmentPreambleExtension => "http://ns.adobe.com/xmp/extension/\0"u8;
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes { get; } = [JpegSegmentType.App1];
 
@@ -36,7 +33,7 @@ namespace MetadataExtractor.Formats.Xmp
             {
                 if (IsXmpSegment(segment))
                 {
-                    yield return Extract(segment.Bytes, JpegSegmentPreambleBytes.Length, segment.Bytes.Length - JpegSegmentPreambleBytes.Length);
+                    yield return Extract(segment.Bytes, JpegSegmentPreamble.Length, segment.Bytes.Length - JpegSegmentPreamble.Length);
                 }
             }
 
@@ -47,7 +44,7 @@ namespace MetadataExtractor.Formats.Xmp
                 var buffer = new MemoryStream();
                 foreach (var segment in extensionGroup)
                 {
-                    var n = JpegSegmentPreambleExtensionBytes.Length + 32 + 4 + 4;
+                    var n = JpegSegmentPreambleExtension.Length + 32 + 4 + 4;
                     buffer.Write(segment.Bytes, n, segment.Bytes.Length - n);
                 }
 
@@ -59,10 +56,10 @@ namespace MetadataExtractor.Formats.Xmp
             }
         }
 
-        private static string GetExtendedDataGuid(JpegSegment segment) => Encoding.UTF8.GetString(segment.Bytes, JpegSegmentPreambleExtensionBytes.Length, 32);
+        private static string GetExtendedDataGuid(JpegSegment segment) => Encoding.UTF8.GetString(segment.Bytes, JpegSegmentPreambleExtension.Length, 32);
 
-        private static bool IsXmpSegment(JpegSegment segment) => segment.Span.StartsWith(JpegSegmentPreambleBytes);
-        private static bool IsExtendedXmpSegment(JpegSegment segment) => segment.Span.StartsWith(JpegSegmentPreambleExtensionBytes);
+        private static bool IsXmpSegment(JpegSegment segment) => segment.Span.StartsWith(JpegSegmentPreamble);
+        private static bool IsExtendedXmpSegment(JpegSegment segment) => segment.Span.StartsWith(JpegSegmentPreambleExtension);
 
         public XmpDirectory Extract(byte[] xmpBytes) => Extract(xmpBytes, 0, xmpBytes.Length);
 

--- a/MetadataExtractor/Formats/Xmp/XmpReader.cs
+++ b/MetadataExtractor/Formats/Xmp/XmpReader.cs
@@ -19,7 +19,7 @@ namespace MetadataExtractor.Formats.Xmp
     /// <author>Drew Noakes https://drewnoakes.com</author>
     public sealed class XmpReader : IJpegSegmentMetadataReader
     {
-        public static ReadOnlySpan<byte> JpegSegmentPreamble=> "http://ns.adobe.com/xap/1.0/\0"u8;
+        public static ReadOnlySpan<byte> JpegSegmentPreamble => "http://ns.adobe.com/xap/1.0/\0"u8;
         public static ReadOnlySpan<byte> JpegSegmentPreambleExtension => "http://ns.adobe.com/xmp/extension/\0"u8;
 
         ICollection<JpegSegmentType> IJpegSegmentMetadataReader.SegmentTypes { get; } = [JpegSegmentType.App1];

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -276,7 +276,7 @@ const MetadataExtractor.Formats.Exif.ExifDirectoryBase.TagYCbCrSubsampling = 530
 const MetadataExtractor.Formats.Exif.ExifDirectoryBase.TagYResolution = 283 -> int
 const MetadataExtractor.Formats.Exif.ExifIfd0Directory.TagExifSubIfdOffset = 34665 -> int
 const MetadataExtractor.Formats.Exif.ExifIfd0Directory.TagGpsInfoOffset = 34853 -> int
-const MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreamble = "Exif\0\0" -> string!
+static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.TagInteropOffset = 40965 -> int
 const MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.TagThumbnailLength = 514 -> int
 const MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.TagThumbnailOffset = 513 -> int
@@ -1768,7 +1768,7 @@ const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImage = 1
 const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageHeight = 4 -> int
 const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageType = 34 -> int
 const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageWidth = 2 -> int
-const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
+static MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagChartContourInterval = 47017 -> int
 const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagChartCorrDate = 47005 -> int
 const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagChartCountryOrigin = 47006 -> int
@@ -1953,7 +1953,7 @@ const MetadataExtractor.Formats.Icc.IccDirectory.TagTag_KTrc = 1800688195 -> int
 const MetadataExtractor.Formats.Icc.IccDirectory.TagTag_RTrc = 1918128707 -> int
 const MetadataExtractor.Formats.Icc.IccDirectory.TagTag_RXyz = 1918392666 -> int
 const MetadataExtractor.Formats.Icc.IccDirectory.TagXyzValues = 68 -> int
-const MetadataExtractor.Formats.Icc.IccReader.JpegSegmentPreamble = "ICC_PROFILE" -> string!
+static MetadataExtractor.Formats.Icc.IccReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Ico.IcoDirectory.TagBitsPerPixel = 7 -> int
 const MetadataExtractor.Formats.Ico.IcoDirectory.TagColourPaletteSize = 4 -> int
 const MetadataExtractor.Formats.Ico.IcoDirectory.TagColourPlanes = 5 -> int
@@ -2047,9 +2047,9 @@ const MetadataExtractor.Formats.Jfif.JfifDirectory.TagThumbHeight = 13 -> int
 const MetadataExtractor.Formats.Jfif.JfifDirectory.TagThumbWidth = 12 -> int
 const MetadataExtractor.Formats.Jfif.JfifDirectory.TagUnits = 7 -> int
 const MetadataExtractor.Formats.Jfif.JfifDirectory.TagVersion = 5 -> int
-const MetadataExtractor.Formats.Jfif.JfifReader.JpegSegmentPreamble = "JFIF" -> string!
+static MetadataExtractor.Formats.Jfif.JfifReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Jfxx.JfxxDirectory.TagExtensionCode = 5 -> int
-const MetadataExtractor.Formats.Jfxx.JfxxReader.JpegSegmentPreamble = "JFXX" -> string!
+static MetadataExtractor.Formats.Jfxx.JfxxReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TagNumberOfTables = 1 -> int
 const MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.TagComment = 0 -> int
 const MetadataExtractor.Formats.Jpeg.JpegDirectory.TagComponentData1 = 6 -> int
@@ -2091,7 +2091,7 @@ const MetadataExtractor.Formats.Pcx.PcxDirectory.TagYMin = 4 -> int
 const MetadataExtractor.Formats.Photoshop.DuckyDirectory.TagComment = 2 -> int
 const MetadataExtractor.Formats.Photoshop.DuckyDirectory.TagCopyright = 3 -> int
 const MetadataExtractor.Formats.Photoshop.DuckyDirectory.TagQuality = 1 -> int
-const MetadataExtractor.Formats.Photoshop.DuckyReader.JpegSegmentPreamble = "Ducky" -> string!
+static MetadataExtractor.Formats.Photoshop.DuckyReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagAlphaChannels = 1006 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagAlphaIdentifiers = 1053 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagAlternateDuotoneColors = 1066 -> int
@@ -2180,7 +2180,7 @@ const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagWinDevmode = 108
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagWorkflowUrl = 1051 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagXml = 1002 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagXmpData = 1060 -> int
-const MetadataExtractor.Formats.Photoshop.PhotoshopReader.JpegSegmentPreamble = "Photoshop 3.0" -> string!
+static MetadataExtractor.Formats.Photoshop.PhotoshopReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TagBitsPerChannel = 4 -> int
 const MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TagChannelCount = 1 -> int
 const MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TagColorMode = 5 -> int
@@ -2331,8 +2331,8 @@ const MetadataExtractor.Formats.Xmp.Schema.ExifSpecificProperties = "http://ns.a
 const MetadataExtractor.Formats.Xmp.Schema.ExifTiffProperties = "http://ns.adobe.com/tiff/1.0/" -> string!
 const MetadataExtractor.Formats.Xmp.Schema.XmpProperties = "http://ns.adobe.com/xap/1.0/" -> string!
 const MetadataExtractor.Formats.Xmp.XmpDirectory.TagXmpValueCount = 65535 -> int
-const MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreamble = "http://ns.adobe.com/xap/1.0/\0" -> string!
-const MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreambleExtension = "http://ns.adobe.com/xmp/extension/\0" -> string!
+static MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreambleExtension.get -> System.ReadOnlySpan<byte>
 MetadataExtractor.Age
 MetadataExtractor.Age.Age(int years, int months, int days, int hours, int minutes, int seconds) -> void
 MetadataExtractor.Age.Days.get -> int
@@ -4034,9 +4034,9 @@ MetadataExtractor.TagDescriptor<T>.TagDescriptor(T! directory) -> void
 MetadataExtractor.Util.ByteConvert
 MetadataExtractor.Util.ByteTrie<T>
 MetadataExtractor.Util.ByteTrie<T>.Add(T value, params byte[]![]! parts) -> void
+MetadataExtractor.Util.ByteTrie<T>.Add(T value, System.ReadOnlySpan<byte> part) -> void
 MetadataExtractor.Util.ByteTrie<T>.ByteTrie(T defaultValue) -> void
-MetadataExtractor.Util.ByteTrie<T>.Find(byte[]! bytes) -> T
-MetadataExtractor.Util.ByteTrie<T>.Find(byte[]! bytes, int offset, int count) -> T
+MetadataExtractor.Util.ByteTrie<T>.Find(System.ReadOnlySpan<byte> bytes) -> T
 MetadataExtractor.Util.ByteTrie<T>.MaxDepth.get -> int
 MetadataExtractor.Util.FileType
 MetadataExtractor.Util.FileType.Arw = 13 -> MetadataExtractor.Util.FileType
@@ -4418,14 +4418,14 @@ static readonly MetadataExtractor.Formats.Exif.Makernotes.OlympusMakernoteDirect
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.MakernoteVersion -> ushort
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernoteId -> uint
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernotePublicId -> uint
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcValues -> byte[]!
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcValues.get -> System.ReadOnlySpan<byte>
 static readonly MetadataExtractor.Formats.Png.PngChunkType.bKGD -> MetadataExtractor.Formats.Png.PngChunkType!
 static readonly MetadataExtractor.Formats.Png.PngChunkType.cHRM -> MetadataExtractor.Formats.Png.PngChunkType!
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -276,7 +276,7 @@ const MetadataExtractor.Formats.Exif.ExifDirectoryBase.TagYCbCrSubsampling = 530
 const MetadataExtractor.Formats.Exif.ExifDirectoryBase.TagYResolution = 283 -> int
 const MetadataExtractor.Formats.Exif.ExifIfd0Directory.TagExifSubIfdOffset = 34665 -> int
 const MetadataExtractor.Formats.Exif.ExifIfd0Directory.TagGpsInfoOffset = 34853 -> int
-const MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreamble = "Exif\0\0" -> string!
+static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Exif.ExifSubIfdDirectory.TagInteropOffset = 40965 -> int
 const MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.TagThumbnailLength = 514 -> int
 const MetadataExtractor.Formats.Exif.ExifThumbnailDirectory.TagThumbnailOffset = 513 -> int
@@ -1768,7 +1768,7 @@ const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImage = 1
 const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageHeight = 4 -> int
 const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageType = 34 -> int
 const MetadataExtractor.Formats.Flir.FlirRawDataDirectory.TagRawThermalImageWidth = 2 -> int
-const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
+static MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagChartContourInterval = 47017 -> int
 const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagChartCorrDate = 47005 -> int
 const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagChartCountryOrigin = 47006 -> int
@@ -1953,7 +1953,7 @@ const MetadataExtractor.Formats.Icc.IccDirectory.TagTag_KTrc = 1800688195 -> int
 const MetadataExtractor.Formats.Icc.IccDirectory.TagTag_RTrc = 1918128707 -> int
 const MetadataExtractor.Formats.Icc.IccDirectory.TagTag_RXyz = 1918392666 -> int
 const MetadataExtractor.Formats.Icc.IccDirectory.TagXyzValues = 68 -> int
-const MetadataExtractor.Formats.Icc.IccReader.JpegSegmentPreamble = "ICC_PROFILE" -> string!
+static MetadataExtractor.Formats.Icc.IccReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Ico.IcoDirectory.TagBitsPerPixel = 7 -> int
 const MetadataExtractor.Formats.Ico.IcoDirectory.TagColourPaletteSize = 4 -> int
 const MetadataExtractor.Formats.Ico.IcoDirectory.TagColourPlanes = 5 -> int
@@ -2047,9 +2047,9 @@ const MetadataExtractor.Formats.Jfif.JfifDirectory.TagThumbHeight = 13 -> int
 const MetadataExtractor.Formats.Jfif.JfifDirectory.TagThumbWidth = 12 -> int
 const MetadataExtractor.Formats.Jfif.JfifDirectory.TagUnits = 7 -> int
 const MetadataExtractor.Formats.Jfif.JfifDirectory.TagVersion = 5 -> int
-const MetadataExtractor.Formats.Jfif.JfifReader.JpegSegmentPreamble = "JFIF" -> string!
+static MetadataExtractor.Formats.Jfif.JfifReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Jfxx.JfxxDirectory.TagExtensionCode = 5 -> int
-const MetadataExtractor.Formats.Jfxx.JfxxReader.JpegSegmentPreamble = "JFXX" -> string!
+static MetadataExtractor.Formats.Jfxx.JfxxReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TagNumberOfTables = 1 -> int
 const MetadataExtractor.Formats.Jpeg.JpegCommentDirectory.TagComment = 0 -> int
 const MetadataExtractor.Formats.Jpeg.JpegDirectory.TagComponentData1 = 6 -> int
@@ -2091,7 +2091,7 @@ const MetadataExtractor.Formats.Pcx.PcxDirectory.TagYMin = 4 -> int
 const MetadataExtractor.Formats.Photoshop.DuckyDirectory.TagComment = 2 -> int
 const MetadataExtractor.Formats.Photoshop.DuckyDirectory.TagCopyright = 3 -> int
 const MetadataExtractor.Formats.Photoshop.DuckyDirectory.TagQuality = 1 -> int
-const MetadataExtractor.Formats.Photoshop.DuckyReader.JpegSegmentPreamble = "Ducky" -> string!
+static MetadataExtractor.Formats.Photoshop.DuckyReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagAlphaChannels = 1006 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagAlphaIdentifiers = 1053 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagAlternateDuotoneColors = 1066 -> int
@@ -2180,7 +2180,7 @@ const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagWinDevmode = 108
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagWorkflowUrl = 1051 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagXml = 1002 -> int
 const MetadataExtractor.Formats.Photoshop.PhotoshopDirectory.TagXmpData = 1060 -> int
-const MetadataExtractor.Formats.Photoshop.PhotoshopReader.JpegSegmentPreamble = "Photoshop 3.0" -> string!
+static MetadataExtractor.Formats.Photoshop.PhotoshopReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 const MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TagBitsPerChannel = 4 -> int
 const MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TagChannelCount = 1 -> int
 const MetadataExtractor.Formats.Photoshop.PsdHeaderDirectory.TagColorMode = 5 -> int
@@ -2331,8 +2331,8 @@ const MetadataExtractor.Formats.Xmp.Schema.ExifSpecificProperties = "http://ns.a
 const MetadataExtractor.Formats.Xmp.Schema.ExifTiffProperties = "http://ns.adobe.com/tiff/1.0/" -> string!
 const MetadataExtractor.Formats.Xmp.Schema.XmpProperties = "http://ns.adobe.com/xap/1.0/" -> string!
 const MetadataExtractor.Formats.Xmp.XmpDirectory.TagXmpValueCount = 65535 -> int
-const MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreamble = "http://ns.adobe.com/xap/1.0/\0" -> string!
-const MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreambleExtension = "http://ns.adobe.com/xmp/extension/\0" -> string!
+static MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreambleExtension.get -> System.ReadOnlySpan<byte>
 MetadataExtractor.Age
 MetadataExtractor.Age.Age(int years, int months, int days, int hours, int minutes, int seconds) -> void
 MetadataExtractor.Age.Days.get -> int
@@ -4027,9 +4027,9 @@ MetadataExtractor.TagDescriptor<T>.TagDescriptor(T! directory) -> void
 MetadataExtractor.Util.ByteConvert
 MetadataExtractor.Util.ByteTrie<T>
 MetadataExtractor.Util.ByteTrie<T>.Add(T value, params byte[]![]! parts) -> void
+MetadataExtractor.Util.ByteTrie<T>.Add(T value, System.ReadOnlySpan<byte> part) -> void
 MetadataExtractor.Util.ByteTrie<T>.ByteTrie(T defaultValue) -> void
-MetadataExtractor.Util.ByteTrie<T>.Find(byte[]! bytes) -> T
-MetadataExtractor.Util.ByteTrie<T>.Find(byte[]! bytes, int offset, int count) -> T
+MetadataExtractor.Util.ByteTrie<T>.Find(ReadOnlySpan<byte> bytes) -> T
 MetadataExtractor.Util.ByteTrie<T>.MaxDepth.get -> int
 MetadataExtractor.Util.FileType
 MetadataExtractor.Util.FileType.Arw = 13 -> MetadataExtractor.Util.FileType
@@ -4411,14 +4411,14 @@ static readonly MetadataExtractor.Formats.Exif.Makernotes.OlympusMakernoteDirect
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.MakernoteVersion -> ushort
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernoteId -> uint
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernotePublicId -> uint
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcValues -> byte[]!
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcValues.get -> System.ReadOnlySpan<byte>
 static readonly MetadataExtractor.Formats.Png.PngChunkType.bKGD -> MetadataExtractor.Formats.Png.PngChunkType!
 static readonly MetadataExtractor.Formats.Png.PngChunkType.cHRM -> MetadataExtractor.Formats.Png.PngChunkType!
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -2331,8 +2331,8 @@ const MetadataExtractor.Formats.Xmp.Schema.ExifSpecificProperties = "http://ns.a
 const MetadataExtractor.Formats.Xmp.Schema.ExifTiffProperties = "http://ns.adobe.com/tiff/1.0/" -> string!
 const MetadataExtractor.Formats.Xmp.Schema.XmpProperties = "http://ns.adobe.com/xap/1.0/" -> string!
 const MetadataExtractor.Formats.Xmp.XmpDirectory.TagXmpValueCount = 65535 -> int
-const MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreamble = "http://ns.adobe.com/xap/1.0/\0" -> string!
-const MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreambleExtension = "http://ns.adobe.com/xmp/extension/\0" -> string!
+static MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Xmp.XmpReader.JpegSegmentPreambleExtension.get -> System.ReadOnlySpan<byte>
 MetadataExtractor.Age
 MetadataExtractor.Age.Age(int years, int months, int days, int hours, int minutes, int seconds) -> void
 MetadataExtractor.Age.Days.get -> int

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -4034,9 +4034,9 @@ MetadataExtractor.TagDescriptor<T>.TagDescriptor(T! directory) -> void
 MetadataExtractor.Util.ByteConvert
 MetadataExtractor.Util.ByteTrie<T>
 MetadataExtractor.Util.ByteTrie<T>.Add(T value, params byte[]![]! parts) -> void
+MetadataExtractor.Util.ByteTrie<T>.Add(T value, System.ReadOnlySpan<byte> part) -> void
 MetadataExtractor.Util.ByteTrie<T>.ByteTrie(T defaultValue) -> void
-MetadataExtractor.Util.ByteTrie<T>.Find(byte[]! bytes) -> T
-MetadataExtractor.Util.ByteTrie<T>.Find(byte[]! bytes, int offset, int count) -> T
+MetadataExtractor.Util.ByteTrie<T>.Find(System.ReadOnlySpan<byte> bytes) -> T
 MetadataExtractor.Util.ByteTrie<T>.MaxDepth.get -> int
 MetadataExtractor.Util.FileType
 MetadataExtractor.Util.FileType.Arw = 13 -> MetadataExtractor.Util.FileType
@@ -4418,14 +4418,14 @@ static readonly MetadataExtractor.Formats.Exif.Makernotes.OlympusMakernoteDirect
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxHyperFireMakernoteDirectory.MakernoteVersion -> ushort
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernoteId -> uint
 static readonly MetadataExtractor.Formats.Exif.Makernotes.ReconyxUltraFireMakernoteDirectory.MakernotePublicId -> uint
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcValues -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcLengths -> byte[]!
-static readonly MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcValues -> byte[]!
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceAcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalChrominanceDcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceAcValues.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcLengths.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jpeg.HuffmanTablesDirectory.TypicalLuminanceDcValues.get -> System.ReadOnlySpan<byte>
 static readonly MetadataExtractor.Formats.Png.PngChunkType.bKGD -> MetadataExtractor.Formats.Png.PngChunkType!
 static readonly MetadataExtractor.Formats.Png.PngChunkType.cHRM -> MetadataExtractor.Formats.Png.PngChunkType!
 static readonly MetadataExtractor.Formats.Png.PngChunkType.eXIf -> MetadataExtractor.Formats.Png.PngChunkType!

--- a/MetadataExtractor/Util/ByteTrie.cs
+++ b/MetadataExtractor/Util/ByteTrie.cs
@@ -90,7 +90,7 @@ namespace MetadataExtractor.Util
         }
 
         /// <summary>Store the given value at the specified path.</summary>
-        internal void Add(T value, ReadOnlySpan<byte> part)
+        public void Add(T value, ReadOnlySpan<byte> part)
         {
             var depth = 0;
             var node = _root;

--- a/MetadataExtractor/Util/ByteTrie.cs
+++ b/MetadataExtractor/Util/ByteTrie.cs
@@ -30,10 +30,10 @@ namespace MetadataExtractor.Util
         public int MaxDepth { get; private set; }
 
         /// <summary>
-        /// Initialises a new instance of <see cref="ByteTrie{T}"/> with specified default value.
+        /// Initializes a new instance of <see cref="ByteTrie{T}"/> with specified default value.
         /// </summary>
         /// <param name="defaultValue">
-        /// The default value to use in <see cref="ByteTrie{T}.Find(byte[])"/> when no path matches.
+        /// The default value to use in <see cref="ByteTrie{T}.Find(ReadOnlySpan{byte})"/> when no path matches.
         /// </param>
         public ByteTrie(T defaultValue) => _root.SetValue(defaultValue);
 
@@ -41,23 +41,12 @@ namespace MetadataExtractor.Util
         /// <remarks>
         /// If not found, returns the default value specified in the constructor.
         /// </remarks>
-        public T Find(byte[] bytes) => Find(bytes, 0, bytes.Length);
-
-        /// <summary>Return the most specific value stored for this byte sequence.</summary>
-        /// <remarks>
-        /// If not found, returns the default value specified in the constructor.
-        /// </remarks>
-        public T Find(byte[] bytes, int offset, int count)
+        public T Find(ReadOnlySpan<byte> bytes)
         {
-            var maxIndex = offset + count;
-            if (maxIndex > bytes.Length)
-                throw new ArgumentOutOfRangeException(nameof(offset), "Offset and length are not in bounds for byte array.");
-
             var node = _root;
             var value = node.Value;
-            for (var i = offset; i < maxIndex; i++)
+            foreach (var b in bytes)
             {
-                var b = bytes[i];
                 if (!node.Children.TryGetValue(b, out node))
                     break;
                 if (node.HasValue)


### PR DESCRIPTION
@drewnoakes Ready for review / feedback.

Note: The AdobeJpegReader compares the Preamble using a case-insensitive comparer in ReadJpegSegments, while it uses an ordinal comparer when reading segments. From what I can tell in the specifications, this should be exact, but I didn't want to change behavior here.