### PR TITLE
Make missing APIs an error

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -219,6 +219,8 @@ dotnet_diagnostic.CA1724.severity = suggestion                    # Type name co
 
 dotnet_diagnostic.CA1303.severity = none                          # Literal string should be localised
 
+dotnet_diagnostic.RS0016.severity = error                         # Symbol must be part of public API
+
 # working around bug
 dotnet_diagnostic.RS0041.severity = none                          # Public members should not use oblivious types
 

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Unshipped.txt
@@ -1,4 +1,5 @@
 ﻿#nullable enable
+abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 abstract MetadataExtractor.IO.IndexedReader.GetByteInternal(int index) -> byte
 abstract MetadataExtractor.IO.SequentialReader.GetBytes(System.Span<byte> bytes) -> void
 const MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.TagEpoch = 2 -> int
@@ -39,11 +40,14 @@ const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.Tag
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagPictureControl2 = 189 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagRetouchInfo = 187 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagToningEffect = 179 -> int
+const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
+const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagGdalProjLinearUnitsInterpCorrect = 3059 -> int
 MetadataExtractor.Formats.Apple.BplistReader
 MetadataExtractor.Formats.Apple.BplistReader.BplistReader() -> void
 MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults
 MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults.Get(byte key) -> object!
 MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults.GetTopObject() -> System.Collections.Generic.Dictionary<byte, byte>?
+MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor
 MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor.AppleRunTimeMakernoteDescriptor(MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory! directory) -> void
 MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor.GetFlagsDescription() -> string?
@@ -65,13 +69,17 @@ MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Descriptor.GetToni
 MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Descriptor.NikonPictureControl2Descriptor(MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Directory! directory) -> void
 MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Directory
 MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Directory.NikonPictureControl2Directory() -> void
+MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
+MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
+MetadataExtractor.KeyValuePair.KeyValuePair() -> void
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl1Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl1Directory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Descriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl2Directory.Name.get -> string!
+override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 override MetadataExtractor.IO.ByteArrayReader.GetByteInternal(int index) -> byte
 override MetadataExtractor.IO.IndexedSeekingReader.GetByteInternal(int index) -> byte
 override MetadataExtractor.IO.SequentialByteArrayReader.GetBytes(System.Span<byte> bytes) -> void

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -39,6 +39,8 @@ const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.Tag
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagPictureControl2 = 189 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagRetouchInfo = 187 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagToningEffect = 179 -> int
+const MetadataExtractor.Formats.Flir.FlirReader.JpegSegmentPreamble = "FLIR\0" -> string!
+const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagGdalProjLinearUnitsInterpCorrect = 3059 -> int
 MetadataExtractor.Formats.Apple.BplistReader
 MetadataExtractor.Formats.Apple.BplistReader.BplistReader() -> void
 MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -39,6 +39,7 @@ const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.Tag
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagPictureControl2 = 189 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagRetouchInfo = 187 -> int
 const MetadataExtractor.Formats.Exif.Makernotes.NikonType2MakernoteDirectory.TagToningEffect = 179 -> int
+const MetadataExtractor.Formats.GeoTiff.GeoTiffDirectory.TagGdalProjLinearUnitsInterpCorrect = 3059 -> int
 MetadataExtractor.Formats.Apple.BplistReader
 MetadataExtractor.Formats.Apple.BplistReader.BplistReader() -> void
 MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults
@@ -78,4 +79,10 @@ override MetadataExtractor.IO.SequentialByteArrayReader.GetBytes(System.Span<byt
 override MetadataExtractor.IO.SequentialStreamReader.GetBytes(System.Span<byte> bytes) -> void
 static MetadataExtractor.Formats.Apple.BplistReader.IsValid(byte[]! bplist) -> bool
 static MetadataExtractor.Formats.Apple.BplistReader.Parse(byte[]! bplist) -> MetadataExtractor.Formats.Apple.BplistReader.PropertyListResults!
+static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
 static MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Parse(byte[]! bytes) -> MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory!
+static MetadataExtractor.Formats.Icc.IccReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jfif.JfifReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Jfxx.JfxxReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Photoshop.DuckyReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>
+static MetadataExtractor.Formats.Photoshop.PhotoshopReader.JpegSegmentPreamble.get -> System.ReadOnlySpan<byte>


### PR DESCRIPTION
It's important that public API changes are flagged during code review, and the API files really help surface such changes. This diagnostic should be marked as an error.