### PR TITLE
Tidy up code and eliminate some allocations

### DIFF
--- a/MetadataExtractor.PowerShell/ShowJpegStructure.cs
+++ b/MetadataExtractor.PowerShell/ShowJpegStructure.cs
@@ -12,15 +12,16 @@ using MetadataExtractor.Formats.Xmp;
 
 namespace MetadataExtractor.PowerShell
 {
-    [SuppressMessage("ReSharper", "UnusedAutoPropertyAccessor.Global")]
-    [SuppressMessage("ReSharper", "MemberCanBePrivate.Global")]
-    [SuppressMessage("ReSharper", "AutoPropertyCanBeMadeGetOnly.Global")]
     public readonly struct JpegSegment(JpegSegmentType type, int length, int padding, long offset, string? preamble)
     {
         public JpegSegmentType Type { get; } = type;
+
         public int Length { get; } = length;
+
         public int Padding { get; } = padding;
+
         public long Offset { get; } = offset;
+
         public string? Preamble { get; } = preamble;
     }
 

--- a/MetadataExtractor/Age.cs
+++ b/MetadataExtractor/Age.cs
@@ -7,8 +7,20 @@ namespace MetadataExtractor
     /// Used by certain Panasonic cameras which have face recognition features.
     /// </remarks>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class Age
+    public sealed class Age(int years, int months, int days, int hours, int minutes, int seconds)
     {
+        public int Years { get; } = years;
+
+        public int Months { get; } = months;
+
+        public int Days { get; } = days;
+
+        public int Hours { get; } = hours;
+
+        public int Minutes { get; } = minutes;
+
+        public int Seconds { get; } = seconds;
+
         /// <summary>
         /// Parses an age object from the string format used by Panasonic cameras:
         /// <c>0031:07:15 00:00:00</c>
@@ -36,23 +48,6 @@ namespace MetadataExtractor
 
             return null;
         }
-
-        public Age(int years, int months, int days, int hours, int minutes, int seconds)
-        {
-            Years = years;
-            Months = months;
-            Days = days;
-            Hours = hours;
-            Minutes = minutes;
-            Seconds = seconds;
-        }
-
-        public int Years { get; }
-        public int Months { get; }
-        public int Days { get; }
-        public int Hours { get; }
-        public int Minutes { get; }
-        public int Seconds { get; }
 
         public override string ToString()
         {

--- a/MetadataExtractor/Directory.cs
+++ b/MetadataExtractor/Directory.cs
@@ -20,10 +20,10 @@ namespace MetadataExtractor
         private readonly Dictionary<int, string>? _tagNameMap;
 
         /// <summary>Map of values hashed by type identifiers.</summary>
-        private readonly Dictionary<int, object> _tagMap = new();
+        private readonly Dictionary<int, object> _tagMap = [];
 
         /// <summary>Holds tags in the order in which they were stored.</summary>
-        private readonly List<Tag> _definedTagList = new();
+        private readonly List<Tag> _definedTagList = [];
 
         private readonly List<string> _errorList = new(capacity: 4);
 

--- a/MetadataExtractor/Face.cs
+++ b/MetadataExtractor/Face.cs
@@ -13,29 +13,19 @@ namespace MetadataExtractor
     /// Currently this is only used by <see cref="PanasonicMakernoteDirectory"/>.
     /// </remarks>
     /// <author>Philipp Sandhaus, Drew Noakes</author>
-    public sealed class Face
+    public sealed class Face(int x, int y, int width, int height, string? name = null, Age? age = null)
     {
-        public Face(int x, int y, int width, int height, string? name = null, Age? age = null)
-        {
-            X = x;
-            Y = y;
-            Width = width;
-            Height = height;
-            Name = name;
-            Age = age;
-        }
+        public int X { get; } = x;
 
-        public int X { get; }
+        public int Y { get; } = y;
 
-        public int Y { get; }
+        public int Width { get; } = width;
 
-        public int Width { get; }
+        public int Height { get; } = height;
 
-        public int Height { get; }
+        public string? Name { get; } = name;
 
-        public string? Name { get; }
-
-        public Age? Age { get; }
+        public Age? Age { get; } = age;
 
         #region Equality and hashing
 

--- a/MetadataExtractor/Formats/Apple/BplistReader.cs
+++ b/MetadataExtractor/Formats/Apple/BplistReader.cs
@@ -59,7 +59,7 @@ public sealed class BplistReader
             }
         }
 
-        List<object> objects = new();
+        List<object> objects = [];
 
         for (int i = 0; i < offsets.Length; i++)
         {
@@ -127,7 +127,7 @@ public sealed class BplistReader
                 keyRefs[j] = reader.GetByte();
             }
 
-            Dictionary<byte, byte> map = new();
+            Dictionary<byte, byte> map = [];
 
             for (int j = 0; j < count; j++)
             {

--- a/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
+++ b/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
@@ -29,7 +29,7 @@ namespace MetadataExtractor.Formats.Avi
             _directories = directories;
         }
 
-        public bool ShouldAcceptRiffIdentifier(string identifier) => identifier == "AVI ";
+        public bool ShouldAcceptRiffIdentifier(ReadOnlySpan<byte> identifier) => identifier.SequenceEqual("AVI "u8);
 
         public bool ShouldAcceptChunk(string fourCc) => fourCc switch
         {

--- a/MetadataExtractor/Formats/Bmp/BmpReader.cs
+++ b/MetadataExtractor/Formats/Bmp/BmpReader.cs
@@ -260,7 +260,7 @@ namespace MetadataExtractor.Formats.Bmp
                     directory.Set(BmpHeaderDirectory.TagColourPlanes, reader.GetUInt16());
                     directory.Set(BmpHeaderDirectory.TagBitsPerPixel, reader.GetUInt16());
                 }
-                else if (headerSize == 16 || headerSize == 64)
+                else if (headerSize is 16 or 64)
                 {
                     // OS22XBITMAPHEADER
                     directory.Set(BmpHeaderDirectory.TagImageWidth, reader.GetInt32());
@@ -286,9 +286,7 @@ namespace MetadataExtractor.Formats.Bmp
                         reader.Skip(4); // Skip Identifier
                     }
                 }
-                else if (
-                  headerSize == 40 || headerSize == 52 || headerSize == 56 ||
-                  headerSize == 108 || headerSize == 124)
+                else if (headerSize is 40 or 52 or 56 or 108 or 124)
                 {
                     // BITMAPINFOHEADER V1-5
                     directory.Set(BmpHeaderDirectory.TagImageWidth, reader.GetInt32());
@@ -333,7 +331,7 @@ namespace MetadataExtractor.Formats.Bmp
                         return;
                     }
                     directory.Set(BmpHeaderDirectory.TagIntent, reader.GetInt32());
-                    if (csType == (long)BmpHeaderDirectory.ColorSpaceType.ProfileEmbedded || csType == (long)BmpHeaderDirectory.ColorSpaceType.ProfileLinked)
+                    if (csType is (long)BmpHeaderDirectory.ColorSpaceType.ProfileEmbedded or (long)BmpHeaderDirectory.ColorSpaceType.ProfileLinked)
                     {
                         long profileOffset = reader.GetUInt32();
                         int profileSize = reader.GetInt32();

--- a/MetadataExtractor/Formats/Eps/EpsReader.cs
+++ b/MetadataExtractor/Formats/Eps/EpsReader.cs
@@ -159,10 +159,8 @@ namespace MetadataExtractor.Formats.Eps
         /// <param name="value">String that holds value of current comment</param>
         private void AddToDirectory(EpsDirectory directory, string name, string value)
         {
-            if (!EpsDirectory.TagIntegerMap.ContainsKey(name))
+            if (!EpsDirectory.TagIntegerMap.TryGetValue(name, out int tag))
                 return;
-
-            var tag = EpsDirectory.TagIntegerMap[name];
 
             switch (tag)
             {

--- a/MetadataExtractor/Formats/Eps/EpsReader.cs
+++ b/MetadataExtractor/Formats/Eps/EpsReader.cs
@@ -118,7 +118,7 @@ namespace MetadataExtractor.Formats.Eps
                 while (true)
                 {
                     char c = (char)reader.GetByte();
-                    if (c == '\r' || c == '\n')
+                    if (c is '\r' or '\n')
                         break;
                     line.Append(c);
                 }

--- a/MetadataExtractor/Formats/Exif/makernotes/FujifilmMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/FujifilmMakernoteDescriptor.cs
@@ -22,7 +22,8 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
     /// </item>
     /// </list>
     /// </summary>
-    /// <author>Drew Noakes https://drewnoakes.com</author>    public sealed class FujifilmMakernoteDescriptor : TagDescriptor<FujifilmMakernoteDirectory>
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public sealed class FujifilmMakernoteDescriptor : TagDescriptor<FujifilmMakernoteDirectory>
     {
         public FujifilmMakernoteDescriptor(FujifilmMakernoteDirectory directory)
             : base(directory)

--- a/MetadataExtractor/Formats/Exif/makernotes/KodakMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/KodakMakernoteDescriptor.cs
@@ -40,28 +40,17 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (!Directory.TryGetInt32(KodakMakernoteDirectory.TagColorMode, out int value))
                 return null;
 
-            switch (value)
+            return value switch
             {
-                case 0x0001:
-                case 0x2000:
-                    return "B&W";
-                case 0x0002:
-                case 0x4000:
-                    return "Sepia";
-                case 0x003:
-                    return "B&W Yellow Filter";
-                case 0x004:
-                    return "B&W Red Filter";
-                case 0x020:
-                    return "Saturated Color";
-                case 0x040:
-                case 0x200:
-                    return "Neutral Color";
-                case 0x100:
-                    return "Saturated Color";
-                default:
-                    return "Unknown (" + value + ")";
-            }
+                0x0001 or 0x2000 => "B&W",
+                0x0002 or 0x4000 => "Sepia",
+                0x003 => "B&W Yellow Filter",
+                0x004 => "B&W Red Filter",
+                0x020 => "Saturated Color",
+                0x040 or 0x200 => "Neutral Color",
+                0x100 => "Saturated Color",
+                _ => $"Unknown ({value})"
+            };
         }
 
         public string? GetFlashFiredDescription()
@@ -74,22 +63,14 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (!Directory.TryGetInt32(KodakMakernoteDirectory.TagFlashMode, out int value))
                 return null;
 
-            switch (value)
+            return value switch
             {
-                case 0x00:
-                    return "Auto";
-                case 0x10:
-                case 0x01:
-                    return "Fill Flash";
-                case 0x20:
-                case 0x02:
-                    return "Off";
-                case 0x40:
-                case 0x03:
-                    return "Red Eye";
-                default:
-                    return "Unknown (" + value + ")";
-            }
+                0x00 => "Auto",
+                0x10 or 0x01 => "Fill Flash",
+                0x20 or 0x02 => "Off",
+                0x40 or 0x03 => "Red Eye",
+                _ => $"Unknown ({value})"
+            };
         }
 
         public string? GetWhiteBalanceDescription()

--- a/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/NikonType2MakernoteDirectory.cs
@@ -19,7 +19,8 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
     /// later models, the IFD was given the standard prefix to indicate the camera models (most other manufacturers also
     /// provide this prefix to aid in software decoding).
     /// </remarks>
-    /// <author>Drew Noakes https://drewnoakes.com</author>    public class NikonType2MakernoteDirectory : Directory
+    /// <author>Drew Noakes https://drewnoakes.com</author>
+    public class NikonType2MakernoteDirectory : Directory
     {
         /// <summary>
         /// Values observed

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
@@ -800,7 +800,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             var sb = new StringBuilder();
             for (var i = 0; i < values.Length; i++)
             {
-                if (i == 0 || i == 4 || i == 8 || i == 12 || i == 16 || i == 20 || i == 24)
+                if (i is 0 or 4 or 8 or 12 or 16 or 20 or 24)
                     sb.Append(_toneLevelType[values[i]] + "; ");
                 else
                     sb.Append(values[i] + "; ");

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
@@ -58,7 +58,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
         {
             if (!Directory.TryGetRational(OlympusFocusInfoMakernoteDirectory.TagFocusDistance, out Rational value))
                 return "inf";
-            if (value.Numerator == 0xFFFFFFFF || value.Numerator == 0x00000000)
+            if (value.Numerator is 0xFFFFFFFF or 0x00000000)
                 return "inf";
 
             return value.Numerator / 1000.0 + " m";

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
@@ -482,19 +482,19 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusMakernoteDirectory.TagWbMode) is not short[] values)
                 return null;
 
-            return $"{values[0]} {values[1]}".Trim() switch
+            return ((int)values[0], (int)values[1]) switch
             {
-                "1" or "1 0" => "Auto",
-                "1 2" => "Auto (2)",
-                "1 4" => "Auto (4)",
-                "2 2" => "3000 Kelvin",
-                "2 3" => "3700 Kelvin",
-                "2 4" => "4000 Kelvin",
-                "2 5" => "4500 Kelvin",
-                "2 6" => "5500 Kelvin",
-                "2 7" => "6500 Kelvin",
-                "2 8" => "7500 Kelvin",
-                "3 0" => "One-touch",
+                (1, 0) => "Auto",
+                (1, 2) => "Auto (2)",
+                (1, 4) => "Auto (4)",
+                (2, 2) => "3000 Kelvin",
+                (2, 3) => "3700 Kelvin",
+                (2, 4) => "4000 Kelvin",
+                (2, 5) => "4500 Kelvin",
+                (2, 6) => "5500 Kelvin",
+                (2, 7) => "6500 Kelvin",
+                (2, 8) => "7500 Kelvin",
+                (3, 0) => "One-touch",
                 _ => $"Unknown ({values[0]} {values[1]})",
             };
         }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
@@ -482,34 +482,21 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusMakernoteDirectory.TagWbMode) is not short[] values)
                 return null;
 
-            switch ($"{values[0]} {values[1]}".Trim())
+            return $"{values[0]} {values[1]}".Trim() switch
             {
-                case "1":
-                case "1 0":
-                    return "Auto";
-                case "1 2":
-                    return "Auto (2)";
-                case "1 4":
-                    return "Auto (4)";
-                case "2 2":
-                    return "3000 Kelvin";
-                case "2 3":
-                    return "3700 Kelvin";
-                case "2 4":
-                    return "4000 Kelvin";
-                case "2 5":
-                    return "4500 Kelvin";
-                case "2 6":
-                    return "5500 Kelvin";
-                case "2 7":
-                    return "6500 Kelvin";
-                case "2 8":
-                    return "7500 Kelvin";
-                case "3 0":
-                    return "One-touch";
-                default:
-                    return $"Unknown ({values[0]} {values[1]})";
-            }
+                "1" or "1 0" => "Auto",
+                "1 2" => "Auto (2)",
+                "1 4" => "Auto (4)",
+                "2 2" => "3000 Kelvin",
+                "2 3" => "3700 Kelvin",
+                "2 4" => "4000 Kelvin",
+                "2 5" => "4500 Kelvin",
+                "2 6" => "5500 Kelvin",
+                "2 7" => "6500 Kelvin",
+                "2 8" => "7500 Kelvin",
+                "3 0" => "One-touch",
+                _ => $"Unknown ({values[0]} {values[1]})",
+            };
         }
 
         public string? GetRedBalanceDescription()

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawDevelopmentMakernoteDescriptor.cs
@@ -75,18 +75,13 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (!Directory.TryGetInt32(OlympusRawDevelopmentMakernoteDirectory.TagRawDevEditStatus, out int value))
                 return null;
 
-            switch (value)
+            return value switch
             {
-                case 0:
-                    return "Original";
-                case 1:
-                    return "Edited (Landscape)";
-                case 6:
-                case 8:
-                    return "Edited (Portrait)";
-                default:
-                    return "Unknown (" + value + ")";
-            }
+                0 => "Original",
+                1 => "Edited (Landscape)",
+                6 or 8 => "Edited (Portrait)",
+                _ => $"Unknown ({value})",
+            };
         }
 
         public string? GetRawDevSettingsDescription()

--- a/MetadataExtractor/Formats/Exif/makernotes/SonyType1MakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/SonyType1MakernoteDescriptor.cs
@@ -165,47 +165,26 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (!Directory.TryGetInt32(SonyType1MakernoteDirectory.TagColorMode, out int value))
                 return null;
 
-            switch (value)
+            return value switch
             {
-                case 0:
-                    return "Standard";
-                case 1:
-                    return "Vivid";
-                case 2:
-                    return "Portrait";
-                case 3:
-                    return "Landscape";
-                case 4:
-                    return "Sunset";
-                case 5:
-                    return "Night Portrait";
-                case 6:
-                    return "Black & White";
-                case 7:
-                    return "Adobe RGB";
-                case 12:
-                case 100:
-                    return "Neutral";
-                case 13:
-                case 101:
-                    return "Clear";
-                case 14:
-                case 102:
-                    return "Deep";
-                case 15:
-                case 103:
-                    return "Light";
-                case 16:
-                    return "Autumn";
-                case 17:
-                    return "Sepia";
-                case 104:
-                    return "Night View";
-                case 105:
-                    return "Autumn Leaves";
-                default:
-                    return $"Unknown ({value})";
-            }
+                0 => "Standard",
+                1 => "Vivid",
+                2 => "Portrait",
+                3 => "Landscape",
+                4 => "Sunset",
+                5 => "Night Portrait",
+                6 => "Black & White",
+                7 => "Adobe RGB",
+                12 or 100 => "Neutral",
+                13 or 101 => "Clear",
+                14 or 102 => "Deep",
+                15 or 103 => "Light",
+                16 => "Autumn",
+                17 => "Sepia",
+                104 => "Night View",
+                105 => "Autumn Leaves",
+                _ => $"Unknown ({value})"
+            };
         }
 
         public string? GetMacroDescription()

--- a/MetadataExtractor/Formats/Gif/GifControlDescriptor.cs
+++ b/MetadataExtractor/Formats/Gif/GifControlDescriptor.cs
@@ -25,24 +25,15 @@ namespace MetadataExtractor.Formats.Gif
             if (!Directory.TryGetInt32(GifControlDirectory.TagDisposalMethod, out int value))
                 return null;
 
-            switch (value)
+            return value switch
             {
-                case 0:
-                    return "Not Specified";
-                case 1:
-                    return "Don't Dispose";
-                case 2:
-                    return "Restore to Background Color";
-                case 3:
-                    return "Restore to Previous";
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                    return "To Be Defined";
-                default:
-                    return $"Invalid value ({value})";
-            }
+                0 => "Not Specified",
+                1 => "Don't Dispose",
+                2 => "Restore to Background Color",
+                3 => "Restore to Previous",
+                4 or 5 or 6 or 7 => "To Be Defined",
+                _ => $"Invalid value ({value})"
+            };
         }
     }
 }

--- a/MetadataExtractor/Formats/Gif/GifReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifReader.cs
@@ -131,8 +131,10 @@ namespace MetadataExtractor.Formats.Gif
 
             var headerDirectory = new GifHeaderDirectory();
 
-            var signature = reader.GetString(3, Encoding.UTF8);
-            if (signature != "GIF")
+            Span<byte> signature = stackalloc byte[3];
+            reader.GetBytes(signature);
+
+            if (!signature.SequenceEqual("GIF"u8))
             {
                 headerDirectory.AddError("Invalid GIF file signature");
                 return headerDirectory;

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -35,7 +35,7 @@ namespace MetadataExtractor.Formats.Heif
 
             uint primaryItem = boxes.Descendant<PrimaryItemBox>()?.PrimaryItem ?? uint.MaxValue;
             var itemRefs = (boxes.Descendant<ItemReferenceBox>()?.Boxes ?? new SingleItemTypeReferenceBox[0])
-                .Where(i => i.Type == BoxTypes.ThmbTag || i.Type == BoxTypes.CdscTag || i.Type == BoxTypes.MimeTag).ToList();
+                .Where(i => i.Type is BoxTypes.ThmbTag or BoxTypes.CdscTag or BoxTypes.MimeTag).ToList();
 
             ParseImageProperties();
 
@@ -111,7 +111,7 @@ namespace MetadataExtractor.Formats.Heif
                             (from associationBox in associations.Entries.Where(i => secondary.Contains(i.ItemId))
                              from propIndex in associationBox.Properties
                              let i = props.ElementAt(propIndex.Index - 1)
-                             where i is DecoderConfigurationBox || i is ColorInformationBox
+                             where i is DecoderConfigurationBox or ColorInformationBox
                              select i)
                             .Distinct());
 

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -1,9 +1,9 @@
 ﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
 using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.Iso14496;
 using MetadataExtractor.Formats.Iso14496.Boxes;
-using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.QuickTime;
 using MetadataExtractor.Formats.Xmp;
 

--- a/MetadataExtractor/Formats/Ico/IcoDescriptor.cs
+++ b/MetadataExtractor/Formats/Ico/IcoDescriptor.cs
@@ -12,33 +12,14 @@ namespace MetadataExtractor.Formats.Ico
 
         public override string? GetDescription(int tagType)
         {
-            switch (tagType)
+            return tagType switch
             {
-                case IcoDirectory.TagImageType:
-                {
-                    return GetImageTypeDescription();
-                }
-
-                case IcoDirectory.TagImageWidth:
-                {
-                    return GetImageWidthDescription();
-                }
-
-                case IcoDirectory.TagImageHeight:
-                {
-                    return GetImageHeightDescription();
-                }
-
-                case IcoDirectory.TagColourPaletteSize:
-                {
-                    return GetColourPaletteSizeDescription();
-                }
-
-                default:
-                {
-                    return base.GetDescription(tagType);
-                }
-            }
+                IcoDirectory.TagImageType => GetImageTypeDescription(),
+                IcoDirectory.TagImageWidth => GetImageWidthDescription(),
+                IcoDirectory.TagImageHeight => GetImageHeightDescription(),
+                IcoDirectory.TagColourPaletteSize => GetColourPaletteSizeDescription(),
+                _ => base.GetDescription(tagType)
+            };
         }
 
         public string? GetImageTypeDescription()

--- a/MetadataExtractor/Formats/Iso14496/Boxes/ItemLocationBox.cs
+++ b/MetadataExtractor/Formats/Iso14496/Boxes/ItemLocationBox.cs
@@ -18,7 +18,7 @@ namespace MetadataExtractor.Formats.Iso14496.Boxes
             OffsetSize = bitReader.GetByte(4);
             LengthSize = bitReader.GetByte(4);
             BaseOffsetSize = bitReader.GetByte(4);
-            if (Version == 1 || Version == 2)
+            if (Version is 1 or 2)
             {
                 IndexSize = bitReader.GetByte(4);
             }
@@ -52,7 +52,7 @@ namespace MetadataExtractor.Formats.Iso14496.Boxes
         private uint ReadItemNumber(SequentialReader sr) => Version < 2 ? sr.GetUInt16() : sr.GetUInt32();
 
         private ConstructionMethod ReadConstructionMethod(SequentialReader sr) =>
-            (ConstructionMethod)((Version == 1 || Version == 2) ? (sr.GetUInt16() & 0x0F) : 0);
+            (ConstructionMethod)((Version is 1 or 2) ? (sr.GetUInt16() & 0x0F) : 0);
 
         private static ulong ReadSizedPointer(SequentialReader sr, byte pointerSize) =>
             pointerSize switch
@@ -80,7 +80,7 @@ namespace MetadataExtractor.Formats.Iso14496.Boxes
                 ReadSizedPointer(sr, LengthSize));
 
         private ulong ReadItemIndex(SequentialReader sr) =>
-            (Version == 1 || Version == 2) ? ReadSizedPointer(sr, IndexSize) : 0;
+            (Version is 1 or 2) ? ReadSizedPointer(sr, IndexSize) : 0;
     }
 
     internal enum ConstructionMethod

--- a/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegMetadataReader.cs
@@ -2,13 +2,13 @@
 
 using MetadataExtractor.Formats.Adobe;
 using MetadataExtractor.Formats.Exif;
+using MetadataExtractor.Formats.FileSystem;
+using MetadataExtractor.Formats.Flir;
 using MetadataExtractor.Formats.Icc;
 using MetadataExtractor.Formats.Iptc;
 using MetadataExtractor.Formats.Jfif;
 using MetadataExtractor.Formats.Jfxx;
 using MetadataExtractor.Formats.Photoshop;
-using MetadataExtractor.Formats.FileSystem;
-using MetadataExtractor.Formats.Flir;
 using MetadataExtractor.Formats.Xmp;
 
 namespace MetadataExtractor.Formats.Jpeg

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopDescriptor.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopDescriptor.cs
@@ -71,40 +71,20 @@ namespace MetadataExtractor.Formats.Photoshop
                     : q <= 8
                         ? q + 4
                         : q;
-
-                string quality;
-                switch (q)
+                string quality = q switch
                 {
-                    case 0xFFFD:
-                    case 0xFFFE:
-                    case 0xFFFF:
-                    case 0:
-                        quality = "Low";
-                        break;
-                    case 1:
-                    case 2:
-                    case 3:
-                        quality = "Medium";
-                        break;
-                    case 4:
-                    case 5:
-                        quality = "High";
-                        break;
-                    case 6:
-                    case 7:
-                    case 8:
-                        quality = "Maximum";
-                        break;
-                    default:
-                        quality = "Unknown";
-                        break;
-                }
+                    0xFFFD or 0xFFFE or 0xFFFF or 0 => "Low",
+                    1 or 2 or 3 => "Medium",
+                    4 or 5 => "High",
+                    6 or 7 or 8 => "Maximum",
+                    _ => "Unknown"
+                };
                 var format = f switch
                 {
                     0x0000 => "Standard",
                     0x0001 => "Optimised",
                     0x0101 => "Progressive",
-                    _ => $"Unknown (0x{f:X4})",
+                    _ => $"Unknown (0x{f:X4})"
                 };
                 var scans = s is >= 1 and <= 3
                     ? (s + 2).ToString()

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -373,7 +373,7 @@ namespace MetadataExtractor.Formats.Png
                         yield return ReadTextDirectory(keyword, textBytes, chunkType);
                     }
                 }
-                else if (keyword == "Raw profile type exif" || keyword == "Raw profile type APP1")
+                else if (keyword is "Raw profile type exif" or "Raw profile type APP1")
                 {
                     if (TryProcessRawProfile(out _))
                     {
@@ -389,7 +389,7 @@ namespace MetadataExtractor.Formats.Png
                         yield return ReadTextDirectory(keyword, textBytes, chunkType);
                     }
                 }
-                else if (keyword == "Raw profile type icc" || keyword == "Raw profile type icm")
+                else if (keyword is "Raw profile type icc" or "Raw profile type icm")
                 {
                     if (TryProcessRawProfile(out _))
                     {

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
@@ -5,27 +5,27 @@ namespace MetadataExtractor.Formats.QuickTime
     /// <summary>
     /// Models data provided to callbacks invoked when reading QuickTime atoms via <see cref="QuickTimeReader.ProcessAtoms"/>.
     /// </summary>
-    public sealed class AtomCallbackArgs
+    public sealed class AtomCallbackArgs(uint type, long size, Stream stream, long startPosition, SequentialStreamReader reader)
     {
         /// <summary>
         /// Gets the 32-bit unsigned integer that identifies the atom's type.
         /// </summary>
-        public uint Type { get; }
+        public uint Type { get; } = type;
 
         /// <summary>
         /// The length of the atom data, in bytes. If the atom extends to the end of the file, this value is zero.
         /// </summary>
-        public long Size { get; }
+        public long Size { get; } = size;
 
         /// <summary>
         /// Gets the stream from which atoms are being read.
         /// </summary>
-        public Stream Stream { get; }
+        public Stream Stream { get; } = stream;
 
         /// <summary>
         /// Gets the position within <see cref="Stream"/> at which this atom's data started.
         /// </summary>
-        public long StartPosition { get; }
+        public long StartPosition { get; } = startPosition;
 
         /// <summary>
         /// Gets a sequential reader from which this atom's contents may be read.
@@ -33,21 +33,12 @@ namespace MetadataExtractor.Formats.QuickTime
         /// <remarks>
         /// It is backed by <see cref="Stream"/>, so manipulating the stream's position will influence this reader.
         /// </remarks>
-        public SequentialStreamReader Reader { get; }
+        public SequentialStreamReader Reader { get; } = reader;
 
         /// <summary>
         /// Gets and sets whether the callback wishes processing to terminate.
         /// </summary>
         public bool Cancel { get; set; }
-
-        public AtomCallbackArgs(uint type, long size, Stream stream, long startPosition, SequentialStreamReader reader)
-        {
-            Type = type;
-            Size = size;
-            Stream = stream;
-            StartPosition = startPosition;
-            Reader = reader;
-        }
 
         /// <summary>
         /// Gets the string representation of this atom's type.

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
@@ -51,7 +51,7 @@ namespace MetadataExtractor.Formats.QuickTime
             {
                 var val = reader.GetS32BitFixedPoint();
                 // the right column is fixed 2.30 instead of 16.16
-                if (i == 2 || i == 5 || i == 8)
+                if (i is 2 or 5 or 8)
                 {
                     val /= 0x4000;
                 }

--- a/MetadataExtractor/Formats/Riff/IRiffHandler.cs
+++ b/MetadataExtractor/Formats/Riff/IRiffHandler.cs
@@ -13,7 +13,7 @@ namespace MetadataExtractor.Formats.Riff
         /// <remarks>Returning <c>false</c> causes processing to stop after reading only the first twelve bytes of data.</remarks>
         /// <param name="identifier">The four character code identifying the type of RIFF data</param>
         /// <returns>true if processing should continue, otherwise false</returns>
-        bool ShouldAcceptRiffIdentifier(string identifier);
+        bool ShouldAcceptRiffIdentifier(ReadOnlySpan<byte> identifier);
 
         /// <summary>Gets whether this handler is interested in the specific chunk type.</summary>
         /// <remarks>

--- a/MetadataExtractor/Formats/Riff/RiffHandler.cs
+++ b/MetadataExtractor/Formats/Riff/RiffHandler.cs
@@ -28,7 +28,7 @@ namespace MetadataExtractor.Formats.Riff
 
         public bool ShouldAcceptChunk(string fourCc) => _handlers.ContainsKey(fourCc);
 
-        public abstract bool ShouldAcceptRiffIdentifier(string identifier);
+        public abstract bool ShouldAcceptRiffIdentifier(ReadOnlySpan<byte> identifier);
 
         public abstract bool ShouldAcceptList(string fourCc);
 

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -28,14 +28,16 @@ namespace MetadataExtractor.Formats.Riff
 
                 // PROCESS FILE HEADER
 
-                var fileFourCc = reader.GetString(4, Encoding.ASCII);
-                if (fileFourCc != "RIFF")
-                    throw new RiffProcessingException("Invalid RIFF header: " + fileFourCc);
+                Span<byte> fileFourCc = stackalloc byte[4];
+                reader.GetBytes(fileFourCc);
+                if (!fileFourCc.SequenceEqual("RIFF"u8))
+                    throw new RiffProcessingException("Invalid RIFF header: " + Encoding.ASCII.GetString(fileFourCc.ToArray()));
 
                 // The total size of the chunks that follow plus 4 bytes for the 'WEBP' or 'AVI ' FourCC
                 int fileSize = reader.GetInt32();
                 int sizeLeft = fileSize;
-                string identifier = reader.GetString(4, Encoding.ASCII);
+                Span<byte> identifier = stackalloc byte[4];
+                reader.GetBytes(identifier);
                 sizeLeft -= 4;
 
                 if (!handler.ShouldAcceptRiffIdentifier(identifier))

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -66,7 +66,7 @@ namespace MetadataExtractor.Formats.Riff
                 if (chunkSize < 0 || chunkSize + reader.Position > maxPosition)
                     throw new RiffProcessingException("Invalid RIFF chunk size");
 
-                if (chunkFourCc == "LIST" || chunkFourCc == "RIFF")
+                if (chunkFourCc is "LIST" or "RIFF")
                 {
                     if (chunkSize < 4)
                         break;

--- a/MetadataExtractor/Formats/Tga/TgaFooterReader.cs
+++ b/MetadataExtractor/Formats/Tga/TgaFooterReader.cs
@@ -5,7 +5,9 @@ namespace MetadataExtractor.Formats.Tga
     internal readonly struct TgaFooter(int extOffset, int devOffset, byte[] signature)
     {
         public int ExtOffset { get; } = extOffset;
+
         public int DevOffset { get; } = devOffset;
+
         public byte[] Signature { get; } = signature;
     }
 

--- a/MetadataExtractor/Formats/Tga/TgaHeaderReader.cs
+++ b/MetadataExtractor/Formats/Tga/TgaHeaderReader.cs
@@ -6,20 +6,15 @@ namespace MetadataExtractor.Formats.Tga
     /// <author>Dmitry Shechtman</author>
     internal sealed class TgaHeaderReader : TgaDirectoryReader<TgaHeaderDirectory>
     {
-        private readonly struct ColormapInfo
+        private readonly struct ColormapInfo(byte type, int origin, int length, int depth)
         {
-            public byte Type { get; }
-            public int Origin { get; }
-            public int Length { get; }
-            public int Depth { get; }
+            public byte Type { get; } = type;
 
-            public ColormapInfo(byte type, int origin, int length, int depth)
-            {
-                Type = type;
-                Origin = origin;
-                Length = length;
-                Depth = depth;
-            }
+            public int Origin { get; } = origin;
+
+            public int Length { get; } = length;
+
+            public int Depth { get; } = depth;
         }
 
         public const int HeaderSize = 18;

--- a/MetadataExtractor/Formats/Tga/TgaTagReader.cs
+++ b/MetadataExtractor/Formats/Tga/TgaTagReader.cs
@@ -2,18 +2,13 @@
 
 namespace MetadataExtractor.Formats.Tga
 {
-    internal readonly struct TgaTagInfo
+    internal readonly struct TgaTagInfo(short id, int offset, int size)
     {
-        public short Id { get; }
-        public int Offset { get; }
-        public int Size { get; }
+        public short Id { get; } = id;
 
-        public TgaTagInfo(short id, int offset, int size)
-        {
-            Id = id;
-            Offset = offset;
-            Size = size;
-        }
+        public int Offset { get; } = offset;
+
+        public int Size { get; } = size;
     }
 
     internal sealed class TgaTagReader : TgaReader<TgaTagInfo[]>

--- a/MetadataExtractor/Formats/Wav/WavRiffHandler.cs
+++ b/MetadataExtractor/Formats/Wav/WavRiffHandler.cs
@@ -28,7 +28,7 @@ namespace MetadataExtractor.Formats.Wav
         {
         }
 
-        public override bool ShouldAcceptRiffIdentifier(string identifier) => identifier == "WAVE";
+        public override bool ShouldAcceptRiffIdentifier(ReadOnlySpan<byte> identifier) => identifier.SequenceEqual("WAVE"u8);
 
         public override bool ShouldAcceptList(string fourCc) => false;
     }

--- a/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
+++ b/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
@@ -30,7 +30,7 @@ namespace MetadataExtractor.Formats.WebP
             _directories = directories;
         }
 
-        public bool ShouldAcceptRiffIdentifier(string identifier) => identifier == "WEBP";
+        public bool ShouldAcceptRiffIdentifier(ReadOnlySpan<byte> identifier) => identifier.SequenceEqual("WEBP"u8);
 
         public bool ShouldAcceptChunk(string fourCc) => fourCc == "VP8X" ||
                                                         fourCc == "VP8L" ||

--- a/MetadataExtractor/IO/IndexedCapturingReader.cs
+++ b/MetadataExtractor/IO/IndexedCapturingReader.cs
@@ -9,7 +9,7 @@ namespace MetadataExtractor.IO
 
         private readonly Stream _stream;
         private readonly int _chunkLength;
-        private readonly List<byte[]> _chunks = new();
+        private readonly List<byte[]> _chunks = [];
         private bool _isStreamFinished;
         private int _streamLength;
         private bool _streamLengthThrewException;

--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -16,8 +16,8 @@ using MetadataExtractor.Formats.Photoshop;
 using MetadataExtractor.Formats.Png;
 using MetadataExtractor.Formats.QuickTime;
 using MetadataExtractor.Formats.Raf;
-using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.Formats.Tga;
+using MetadataExtractor.Formats.Tiff;
 using MetadataExtractor.Formats.Wav;
 using MetadataExtractor.Formats.WebP;
 

--- a/MetadataExtractor/KeyValuePair.cs
+++ b/MetadataExtractor/KeyValuePair.cs
@@ -6,7 +6,7 @@ namespace MetadataExtractor
     /// Models a key/value pair, where both are non-null <see cref="string"/> objects.
     /// </summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class KeyValuePair(string key, StringValue value)
+    public readonly struct KeyValuePair(string key, StringValue value)
     {
         public string Key { get; } = key;
 

--- a/MetadataExtractor/KeyValuePair.cs
+++ b/MetadataExtractor/KeyValuePair.cs
@@ -6,17 +6,11 @@ namespace MetadataExtractor
     /// Models a key/value pair, where both are non-null <see cref="string"/> objects.
     /// </summary>
     /// <author>Drew Noakes https://drewnoakes.com</author>
-    public sealed class KeyValuePair
+    public sealed class KeyValuePair(string key, StringValue value)
     {
-        public KeyValuePair(string key, StringValue value)
-        {
-            Key = key;
-            Value = value;
-        }
+        public string Key { get; } = key;
 
-        public string Key { get; }
-
-        public StringValue Value { get; }
+        public StringValue Value { get; } = value;
 
         public void Deconstruct(out string key, out StringValue value)
         {

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -35,6 +35,11 @@ Camera manufacturer specific support exists for Agfa, Canon, Casio, DJI, Epson, 
     <PackageReference Include="XmpCore" Version="6.1.10.1" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' OR '$(TargetFramework)' == 'netstandard1.3' ">
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.3' OR '$(TargetFramework)' == 'netstandard2.1' ">
     <PackageReference Include="System.Text.Encoding.CodePages" Version="4.5.1" />
   </ItemGroup>
@@ -47,7 +52,6 @@ Camera manufacturer specific support exists for Agfa, Canon, Casio, DJI, Epson, 
   <!-- Analyzers -->
   <ItemGroup>
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.11.0-beta1.23364.2" PrivateAssets="All" />
-    <PackageReference Include="System.Memory" Version="4.5.5" />
   </ItemGroup>
 
 </Project>

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -6,7 +6,7 @@ abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Se
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
-abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(in MetadataExtractor.Formats.Tiff.TiffReaderContext context, int tagId, int valueOffset, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
@@ -2391,7 +2391,7 @@ MetadataExtractor.Formats.Avi.AviRiffHandler.AviRiffHandler(System.Collections.G
 MetadataExtractor.Formats.Avi.AviRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.BmpHeaderDescriptor(MetadataExtractor.Formats.Bmp.BmpHeaderDirectory! directory) -> void
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.GetBitmapTypeDescription() -> string?
@@ -3703,7 +3703,7 @@ MetadataExtractor.Formats.Riff.IRiffHandler.AddError(string! errorMessage) -> vo
 MetadataExtractor.Formats.Riff.IRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.RiffChunkHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
@@ -3868,7 +3868,7 @@ MetadataExtractor.Formats.WebP.WebPRiffHandler.AddError(string! errorMessage) ->
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.WebPRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Xmp.Schema
 MetadataExtractor.Formats.Xmp.XmpDescriptor
@@ -4252,7 +4252,7 @@ override MetadataExtractor.Formats.Wav.WavFactDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavFormatDescriptor.GetDescription(int tag) -> string?
 override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool

--- a/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net45/PublicAPI.Shipped.txt
@@ -3959,6 +3959,7 @@ MetadataExtractor.ITagDescriptor.GetDescription(int tagType) -> string?
 MetadataExtractor.KeyValuePair
 MetadataExtractor.KeyValuePair.Deconstruct(out string! key, out MetadataExtractor.StringValue value) -> void
 MetadataExtractor.KeyValuePair.Key.get -> string!
+MetadataExtractor.KeyValuePair.KeyValuePair() -> void
 MetadataExtractor.KeyValuePair.KeyValuePair(string! key, MetadataExtractor.StringValue value) -> void
 MetadataExtractor.KeyValuePair.Value.get -> MetadataExtractor.StringValue
 MetadataExtractor.MetadataException

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -3953,6 +3953,7 @@ MetadataExtractor.ITagDescriptor.GetDescription(int tagType) -> string?
 MetadataExtractor.KeyValuePair
 MetadataExtractor.KeyValuePair.Deconstruct(out string! key, out MetadataExtractor.StringValue value) -> void
 MetadataExtractor.KeyValuePair.Key.get -> string!
+MetadataExtractor.KeyValuePair.KeyValuePair() -> void
 MetadataExtractor.KeyValuePair.KeyValuePair(string! key, MetadataExtractor.StringValue value) -> void
 MetadataExtractor.KeyValuePair.Value.get -> MetadataExtractor.StringValue
 MetadataExtractor.MetadataException

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -6,7 +6,7 @@ abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Se
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
-abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(in MetadataExtractor.Formats.Tiff.TiffReaderContext context, int tagId, int valueOffset, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
@@ -2391,7 +2391,7 @@ MetadataExtractor.Formats.Avi.AviRiffHandler.AviRiffHandler(System.Collections.G
 MetadataExtractor.Formats.Avi.AviRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.BmpHeaderDescriptor(MetadataExtractor.Formats.Bmp.BmpHeaderDirectory! directory) -> void
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.GetBitmapTypeDescription() -> string?
@@ -3701,7 +3701,7 @@ MetadataExtractor.Formats.Riff.IRiffHandler.AddError(string! errorMessage) -> vo
 MetadataExtractor.Formats.Riff.IRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.RiffChunkHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
@@ -3864,7 +3864,7 @@ MetadataExtractor.Formats.WebP.WebPRiffHandler.AddError(string! errorMessage) ->
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.WebPRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Xmp.Schema
 MetadataExtractor.Formats.Xmp.XmpDescriptor
@@ -4245,7 +4245,7 @@ override MetadataExtractor.Formats.Wav.WavFactDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavFormatDescriptor.GetDescription(int tag) -> string?
 override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -6,7 +6,7 @@ abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Se
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
-abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(in MetadataExtractor.Formats.Tiff.TiffReaderContext context, int tagId, int valueOffset, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.ProcessTiffMarker(ushort marker) -> MetadataExtractor.Formats.Tiff.TiffStandard
@@ -2391,7 +2391,7 @@ MetadataExtractor.Formats.Avi.AviRiffHandler.AviRiffHandler(System.Collections.G
 MetadataExtractor.Formats.Avi.AviRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.BmpHeaderDescriptor(MetadataExtractor.Formats.Bmp.BmpHeaderDirectory! directory) -> void
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.GetBitmapTypeDescription() -> string?
@@ -3703,7 +3703,7 @@ MetadataExtractor.Formats.Riff.IRiffHandler.AddError(string! errorMessage) -> vo
 MetadataExtractor.Formats.Riff.IRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.RiffChunkHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
@@ -3868,7 +3868,7 @@ MetadataExtractor.Formats.WebP.WebPRiffHandler.AddError(string! errorMessage) ->
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.WebPRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Xmp.Schema
 MetadataExtractor.Formats.Xmp.XmpDescriptor
@@ -4252,7 +4252,7 @@ override MetadataExtractor.Formats.Wav.WavFactDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavFormatDescriptor.GetDescription(int tag) -> string?
 override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
-override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(string! identifier) -> bool
+override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!
 override MetadataExtractor.GeoLocation.Equals(object? obj) -> bool

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -3959,6 +3959,7 @@ MetadataExtractor.ITagDescriptor.GetDescription(int tagType) -> string?
 MetadataExtractor.KeyValuePair
 MetadataExtractor.KeyValuePair.Deconstruct(out string! key, out MetadataExtractor.StringValue value) -> void
 MetadataExtractor.KeyValuePair.Key.get -> string!
+MetadataExtractor.KeyValuePair.KeyValuePair() -> void
 MetadataExtractor.KeyValuePair.KeyValuePair(string! key, MetadataExtractor.StringValue value) -> void
 MetadataExtractor.KeyValuePair.Value.get -> MetadataExtractor.StringValue
 MetadataExtractor.MetadataException

--- a/MetadataExtractor/Rational.cs
+++ b/MetadataExtractor/Rational.cs
@@ -27,7 +27,7 @@ namespace MetadataExtractor
         /// <summary>Gets the numerator.</summary>
         public long Numerator { get; }
 
-        /// <summary>Initialises a new instance with the <paramref name="numerator"/> and <paramref name="denominator"/>.</summary>
+        /// <summary>Initializes a new instance with the <paramref name="numerator"/> and <paramref name="denominator"/>.</summary>
         public Rational(long numerator, long denominator)
         {
             Numerator = numerator;

--- a/MetadataExtractor/StringValue.cs
+++ b/MetadataExtractor/StringValue.cs
@@ -13,22 +13,16 @@ namespace MetadataExtractor
     /// The introduction of this type allows full transparency and control over the use of string data extracted
     /// by the library during the read phase.
     /// </remarks>
-    public readonly struct StringValue : IConvertible
+    public readonly struct StringValue(byte[] bytes, Encoding? encoding = null) : IConvertible
     {
         /// <summary>
         /// The encoding used when decoding a <see cref="StringValue"/> that does not specify its encoding.
         /// </summary>
         public static readonly Encoding DefaultEncoding = Encoding.UTF8;
 
-        public StringValue(byte[] bytes, Encoding? encoding = null)
-        {
-            Bytes = bytes;
-            Encoding = encoding;
-        }
+        public byte[] Bytes { get; } = bytes;
 
-        public byte[] Bytes { get; }
-
-        public Encoding? Encoding { get; }
+        public Encoding? Encoding { get; } = encoding;
 
         #region IConvertible
 

--- a/MetadataExtractor/Util/ByteTrie.cs
+++ b/MetadataExtractor/Util/ByteTrie.cs
@@ -11,7 +11,7 @@ namespace MetadataExtractor.Util
         /// <remarks>Has children and may have an associated value.</remarks>
         private sealed class ByteTrieNode
         {
-            public readonly IDictionary<byte, ByteTrieNode> Children = new Dictionary<byte, ByteTrieNode>();
+            public readonly Dictionary<byte, ByteTrieNode> Children = [];
 
             public T Value { get; private set; } = default!;
             public bool HasValue { get; private set; }


### PR DESCRIPTION
- Eliminate a possible virtual call in ByteTrieNode
- Updates ShouldAcceptRiffIdentifier to accept utf-8 bytes (eliminating a string allocation)
- Eliminates an allocation in GifReader
- Updates a few classes to use primary constructors
- Replaces some || statements with pattern matching
- Avoids an extra dictionary lookup
- Organizes using statements
- Fixes a few files with mixed line endings