### PR TITLE
Polyfill non-allocating encoding span->string without byte[]

### DIFF
--- a/MetadataExtractor/IO/IndexedReader.cs
+++ b/MetadataExtractor/IO/IndexedReader.cs
@@ -319,17 +319,15 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException"/>
         public string GetString(int index, int bytesRequested, Encoding encoding)
         {
-#if NET462 || NETSTANDARD1_3
-            var bytes = GetBytes(index, bytesRequested);
+            // This check is important on .NET Framework
+            if (bytesRequested is 0)
+                return "";
 
-            return encoding.GetString(bytes, 0, bytes.Length);
-#else
             Span<byte> bytes = bytesRequested < 256 ? stackalloc byte[bytesRequested] : new byte[bytesRequested];
 
             GetBytes(index, bytes);
 
             return encoding.GetString(bytes);
-#endif
         }
 
         /// <summary>

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -220,14 +220,15 @@ namespace MetadataExtractor.IO
         /// <exception cref="IOException"/>
         public string GetString(int bytesRequested, Encoding encoding)
         {
-#if NETSTANDARD2_1
-            Span<byte> bytes = bytesRequested > 2048 ? new byte[bytesRequested] : stackalloc byte[bytesRequested];
+            // This check is important on .NET Framework
+            if (bytesRequested is 0)
+                return "";
+
+            Span<byte> bytes = bytesRequested < 256 ? stackalloc byte[bytesRequested] : new byte[bytesRequested];
+
             GetBytes(bytes);
+
             return encoding.GetString(bytes);
-#else
-            var bytes = GetBytes(bytesRequested);
-            return encoding.GetString(bytes, 0, bytes.Length);
-#endif
         }
 
         public StringValue GetStringValue(int bytesRequested, Encoding? encoding = null)

--- a/MetadataExtractor/MetadataExtractor.csproj
+++ b/MetadataExtractor/MetadataExtractor.csproj
@@ -16,6 +16,8 @@ Camera manufacturer specific support exists for Agfa, Canon, Casio, DJI, Epson, 
     <SignAssembly>true</SignAssembly>
     <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
     <PackageReadmeFile>README.md</PackageReadmeFile>
+
+    <AllowUnsafeBlocks Condition=" '$(TargetFramework)' == 'net462' OR '$(TargetFramework)' == 'netstandard1.3' ">true</AllowUnsafeBlocks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MetadataExtractor/Util/EncodingExtensions.cs
+++ b/MetadataExtractor/Util/EncodingExtensions.cs
@@ -1,0 +1,24 @@
+﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+#if NETFRAMEWORK || NETSTANDARD1_3
+
+internal static class EncodingExtensions
+{
+    /// <summary>
+    /// Converts a span of bytes into a string, following the specified encoding's rules.
+    /// </summary>
+    /// <param name="encoding">The encoding to follow.</param>
+    /// <param name="bytes">The bytes to convert.</param>
+    /// <returns>The decoded string.</returns>
+    public unsafe static string GetString(this Encoding encoding, ReadOnlySpan<byte> bytes)
+    {
+        // Poly-fill for method available in newer versions of .NET
+
+        fixed (byte* pBytes = bytes)
+        {
+            return encoding.GetString(pBytes, bytes.Length);
+        }
+    }
+}
+
+#endif


### PR DESCRIPTION
Originally proposed by @iamcarbon in https://github.com/drewnoakes/metadata-extractor-dotnet/pull/380#discussion_r1468653528

This requires allowing unsafe blocks for `net462` and `netstandard1.3`.