### PR TITLE
Remove explicit Version MSBuild property

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,6 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>2.8.1</VersionPrefix>
     <DebugType>portable</DebugType>
     <LangVersion>preview</LangVersion>
     <Nullable>enable</Nullable>


### PR DESCRIPTION
Now that we're moving to building and pushing packages via GitHub actions, we will take the version from the release itself. This means we don't want it to be specified in the file directly.

I like this change as it means we don't have to keep the props file in sync with the current version, simplifying the release process somewhat. We only have to bump the version in the README which directs users to install the current version. That can always be done after release if missed.