### PR TITLE
Improve Code Quality / Tiding

### DIFF
--- a/MetadataExtractor/DirectoryExtensions.cs
+++ b/MetadataExtractor/DirectoryExtensions.cs
@@ -929,7 +929,7 @@ namespace MetadataExtractor
         {
             var bytes = directory.GetByteArray(tagType);
             return bytes is null ? null
-                : encoding.GetString(bytes, 0, bytes.Length);
+                : encoding.GetString(bytes);
         }
 
         public static StringValue GetStringValue(this Directory directory, int tagType)

--- a/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
+++ b/MetadataExtractor/Formats/Avi/AviRiffHandler.cs
@@ -39,13 +39,12 @@ namespace MetadataExtractor.Formats.Avi
             _ => false
         };
 
-        public bool ShouldAcceptList(string fourCc) => fourCc switch
+        public bool ShouldAcceptList(ReadOnlySpan<byte> fourCc)
         {
-            "hdrl" => true,
-            "strl" => true,
-            "AVI " => true,
-            _ => false
-        };
+            return fourCc.SequenceEqual("hdrl"u8)
+                || fourCc.SequenceEqual("strl"u8)
+                || fourCc.SequenceEqual("AVI "u8);
+        }
 
         public void ProcessChunk(string fourCc, byte[] payload)
         {

--- a/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
+++ b/MetadataExtractor/Formats/Exif/ExifDescriptorBase.cs
@@ -173,7 +173,7 @@ namespace MetadataExtractor.Formats.Exif
             try
             {
                 // Decode the Unicode string and trim the Unicode zero "\0" from the end.
-                return Encoding.Unicode.GetString(bytes, 0, bytes.Length).TrimEnd('\0');
+                return Encoding.Unicode.GetString(bytes).TrimEnd('\0');
             }
             catch
             {

--- a/MetadataExtractor/Formats/Exif/ExifReader.cs
+++ b/MetadataExtractor/Formats/Exif/ExifReader.cs
@@ -15,7 +15,7 @@ namespace MetadataExtractor.Formats.Exif
     {
         public static ReadOnlySpan<byte> JpegSegmentPreamble => "Exif\x0\x0"u8;
 
-        public static bool StartsWithJpegExifPreamble(byte[] bytes) => bytes.AsSpan().StartsWith(JpegSegmentPreamble);
+        public static bool StartsWithJpegExifPreamble(ReadOnlySpan<byte> bytes) => bytes.StartsWith(JpegSegmentPreamble);
 
         public static int JpegSegmentPreambleLength => JpegSegmentPreamble.Length;
 

--- a/MetadataExtractor/Formats/Exif/makernotes/LeicaType5MakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/LeicaType5MakernoteDescriptor.cs
@@ -30,15 +30,14 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(LeicaType5MakernoteDirectory.TagExposureMode) is not byte[] values || values.Length < 4)
                 return null;
 
-            var join = $"{values[0]} {values[1]} {values[2]} {values[3]}";
-            var ret = join switch
+            var ret = (values[0], values[1], values[2], values[3]) switch
             {
-                "0 0 0 0" => "Program AE",
-                "1 0 0 0" => "Aperture-priority AE",
-                "1 1 0 0" => "Aperture-priority AE (1)",
-                "2 0 0 0" => "Shutter speed priority AE",  // guess
-                "3 0 0 0" => "Manual",
-                _ => "Unknown (" + join + ")",
+                (0, 0, 0, 0) => "Program AE",
+                (1, 0, 0, 0) => "Aperture-priority AE",
+                (1, 1, 0, 0) => "Aperture-priority AE (1)",
+                (2, 0, 0, 0) => "Shutter speed priority AE",  // guess
+                (3, 0, 0, 0) => "Manual",
+                _ => $"Unknown ({values[0]} {values[1]} {values[2]} {values[3]})"
             };
             return ret;
         }

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
@@ -651,15 +651,15 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusCameraSettingsMakernoteDirectory.TagGradation) is not short[] values || values.Length < 3)
                 return null;
 
-            var join = $"{values[0]} {values[1]} {values[2]}";
-            var ret = join switch
+            var ret = (values[0], values[1], values[3]) switch
             {
-                "0 0 0" => "n/a",
-                "-1 -1 1" => "Low Key",
-                "0 -1 1" => "Normal",
-                "1 -1 1" => "High Key",
-                _ => "Unknown (" + join + ")",
+                (0, 0, 0) => "n/a",
+                (-1, -1, 1) => "Low Key",
+                (0, -1, 1) => "Normal",
+                (1, -1, 1) => "High Key",
+                _ => $"Unknown ({values[0]} {values[1]} {values[2]})"
             };
+
             if (values.Length > 3)
             {
                 if (values[3] == 0)

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
@@ -77,13 +77,11 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusFocusInfoMakernoteDirectory.TagExternalFlash) is not ushort[] values || values.Length < 2)
                 return null;
 
-            var join = $"{values[0]} {values[1]}";
-
-            return join switch
+            return (values[0], values[1]) switch
             {
-                "0 0" => "Off",
-                "1 0" => "On",
-                _ => "Unknown (" + join + ")",
+                (0, 0) => "Off",
+                (1, 0) => "On",
+                _ => $"Unknown ({values[0]} {values[1]})"
             };
         }
 

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
@@ -30,7 +30,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 OlympusFocusInfoMakernoteDirectory.TagMacroLed => GetMacroLedDescription(),
                 OlympusFocusInfoMakernoteDirectory.TagSensorTemperature => GetSensorTemperatureDescription(),
                 OlympusFocusInfoMakernoteDirectory.TagImageStabilization => GetImageStabilizationDescription(),
-                _ => base.GetDescription(tagType),
+                _ => base.GetDescription(tagType)
             };
         }
 
@@ -107,15 +107,13 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (values.Length == 0)
                 return null;
 
-            var join = $"{values[0]}" + (values.Length > 1 ? $"{values[1]}" : "");
-
-            return join switch
+            return (values[0], values.Length > 1 ? values[1] : -1) switch
             {
-                "0" => "Off",
-                "1" => "On",
-                "0 0" => "Off",
-                "1 0" => "On",
-                _ => "Unknown (" + join + ")",
+                (0, -1) => "Off",
+                (1, -1) => "On",
+                (0, 0) => "Off",
+                (1, 0) => "On",
+                _ => $"Unknown ({string.Join(" ", values)})"
             };
         }
 

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusFocusInfoMakernoteDescriptor.cs
@@ -109,7 +109,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (values.Length == 0)
                 return null;
 
-            var join = $"{values[0]}" + (values.Length > 1 ? $"{ values[1]}" : "");
+            var join = $"{values[0]}" + (values.Length > 1 ? $"{values[1]}" : "");
 
             return join switch
             {

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusImageProcessingMakernoteDescriptor.cs
@@ -130,24 +130,23 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusImageProcessingMakernoteDirectory.TagAspectRatio) is not byte[] values || values.Length < 2)
                 return null;
 
-            var join = $"{values[0]} {values[1]}";
-            var ret = join switch
+            var ret = (values[0], values[1]) switch
             {
-                "1 1" => "4:3",
-                "1 4" => "1:1",
-                "2 1" => "3:2 (RAW)",
-                "2 2" => "3:2",
-                "3 1" => "16:9 (RAW)",
-                "3 3" => "16:9",
-                "4 1" => "1:1 (RAW)",
-                "4 4" => "6:6",
-                "5 5" => "5:4",
-                "6 6" => "7:6",
-                "7 7" => "6:5",
-                "8 8" => "7:5",
-                "9 1" => "3:4 (RAW)",
-                "9 9" => "3:4",
-                _ => "Unknown (" + join + ")",
+                (1, 1) => "4:3",
+                (1, 4) => "1:1",
+                (2, 1) => "3:2 (RAW)",
+                (2, 2) => "3:2",
+                (3, 1) => "16:9 (RAW)",
+                (3, 3) => "16:9",
+                (4, 1) => "1:1 (RAW)",
+                (4, 4) => "6:6",
+                (5, 5) => "5:4",
+                (6, 6) => "7:6",
+                (7, 7) => "6:5",
+                (8, 8) => "7:5",
+                (9, 1) => "3:4 (RAW)",
+                (9, 9) => "3:4",
+                _ => $"Unknown ({values[0]} {values[1]})"
             };
             return ret;
         }
@@ -157,14 +156,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusImageProcessingMakernoteDirectory.TagKeystoneCompensation) is not byte[] values || values.Length < 2)
                 return null;
 
-            var join = $"{values[0]} {values[1]}";
-            var ret = join switch
+            return (values[0], values[1]) switch
             {
-                "0 0" => "Off",
-                "0 1" => "On",
-                _ => "Unknown (" + join + ")",
+                (0, 0) => "Off",
+                (0, 1) => "On",
+                _ => $"Unknown ({values[0]} {values[1]})"
             };
-            return ret;
         }
 
         public string? GetKeystoneDirectionDescription()

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDescriptor.cs
@@ -471,7 +471,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusMakernoteDirectory.TagColourMatrix) is not short[] values)
                 return null;
 
-            return string.Join(" ", values.Select(b => b.ToString()).ToArray());
+            return string.Join(" ", values);
         }
 
         public string? GetWbModeDescription()
@@ -574,7 +574,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (bytes is null)
                 return null;
 
-            return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+            return Encoding.UTF8.GetString(bytes);
         }
 
         public string? GetOneTouchWbDescription()

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusRawInfoMakernoteDescriptor.cs
@@ -32,7 +32,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusRawInfoMakernoteDirectory.TagColorMatrix2) is not short[] values)
                 return null;
 
-            return string.Join(" ", values.Select(b => b.ToString()).ToArray());
+            return string.Join(" ", values);
         }
 
         public string? GetYCbCrCoefficientsDescription()
@@ -46,7 +46,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 ret[i] = new Rational(values[2 * i], values[2 * i + 1]);
             }
 
-            return string.Join(" ", ret.Select(r => r.ToDecimal().ToString()).ToArray());
+            return string.Join(" ", ret.Select(r => r.ToDecimal()));
         }
 
         public string? GetOlympusLightSourceDescription()

--- a/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/PanasonicMakernoteDescriptor.cs
@@ -255,7 +255,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (bytes is null)
                 return null;
 
-            return string.Join(".", bytes.Select(b => b.ToString()).ToArray());
+            return string.Join(".", bytes);
         }
 
         public string? GetIntelligentDRangeDescription()

--- a/MetadataExtractor/Formats/Gif/GifReader.cs
+++ b/MetadataExtractor/Formats/Gif/GifReader.cs
@@ -190,35 +190,14 @@ namespace MetadataExtractor.Formats.Gif
             var blockSizeBytes = reader.GetByte();
             var blockStartPos = reader.Position;
 
-            Directory? directory;
-            switch (extensionLabel)
+            Directory? directory = extensionLabel switch
             {
-                case 0x01:
-                {
-                    directory = ReadPlainTextBlock(reader, blockSizeBytes);
-                    break;
-                }
-                case 0xf9:
-                {
-                    directory = ReadControlBlock(reader);
-                    break;
-                }
-                case 0xfe:
-                {
-                    directory = ReadCommentBlock(reader, blockSizeBytes);
-                    break;
-                }
-                case 0xff:
-                {
-                    directory = ReadApplicationExtensionBlock(reader, blockSizeBytes);
-                    break;
-                }
-                default:
-                {
-                    directory = new ErrorDirectory($"Unsupported GIF extension block with type 0x{extensionLabel:X2}.");
-                    break;
-                }
-            }
+                0x01 => ReadPlainTextBlock(reader, blockSizeBytes),
+                0xf9 => ReadControlBlock(reader),
+                0xfe => ReadCommentBlock(reader, blockSizeBytes),
+                0xff => ReadApplicationExtensionBlock(reader, blockSizeBytes),
+                _ => new ErrorDirectory($"Unsupported GIF extension block with type 0x{extensionLabel:X2}.")
+            };
 
             var skipCount = blockStartPos + blockSizeBytes - reader.Position;
             if (skipCount > 0)

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertyDescriptor.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertyDescriptor.cs
@@ -15,7 +15,7 @@ namespace MetadataExtractor.Formats.Heif
                     return Directory.GetString(tagType) + " degrees";
                 case HeicImagePropertiesDirectory.TagPixelDepths:
                     var o = Directory.GetObject(HeicImagePropertiesDirectory.TagPixelDepths);
-                    return o is null ? null : string.Join(" ", ((byte[])o).Select(i => i.ToString()).ToArray());
+                    return o is null ? null : string.Join(" ", ((byte[])o).Select(i => i.ToString()));
                 case HeicImagePropertiesDirectory.TagColorFormat:
                     return TypeStringConverter.ToTypeString(Directory.GetUInt32(HeicImagePropertiesDirectory.TagColorFormat));
                 case HeicImagePropertiesDirectory.TagColorPrimaries:

--- a/MetadataExtractor/Formats/Heif/HeicImagePropertyDescriptor.cs
+++ b/MetadataExtractor/Formats/Heif/HeicImagePropertyDescriptor.cs
@@ -15,7 +15,7 @@ namespace MetadataExtractor.Formats.Heif
                     return Directory.GetString(tagType) + " degrees";
                 case HeicImagePropertiesDirectory.TagPixelDepths:
                     var o = Directory.GetObject(HeicImagePropertiesDirectory.TagPixelDepths);
-                    return o is null ? null : string.Join(" ", ((byte[])o).Select(i => i.ToString()));
+                    return o is byte[] bytes ? string.Join(" ", bytes) : null;
                 case HeicImagePropertiesDirectory.TagColorFormat:
                     return TypeStringConverter.ToTypeString(Directory.GetUInt32(HeicImagePropertiesDirectory.TagColorFormat));
                 case HeicImagePropertiesDirectory.TagColorPrimaries:

--- a/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
+++ b/MetadataExtractor/Formats/Heif/HeifMetadataReader.cs
@@ -66,7 +66,7 @@ namespace MetadataExtractor.Formats.Heif
                     {
                         dir.Set(
                             QuickTimeFileTypeDirectory.TagCompatibleBrands,
-                            string.Join(", ", ftype.CompatibleBrandStrings.ToArray()));
+                            string.Join(", ", ftype.CompatibleBrandStrings));
                     }
 
                     directories.Add(dir);

--- a/MetadataExtractor/Formats/Icc/IccReader.cs
+++ b/MetadataExtractor/Formats/Icc/IccReader.cs
@@ -162,7 +162,7 @@ namespace MetadataExtractor.Formats.Icc
                 unchecked((byte)d)
             };
 
-            return Encoding.UTF8.GetString(b, 0, b.Length);
+            return Encoding.UTF8.GetString(b);
         }
     }
 }

--- a/MetadataExtractor/Formats/Iptc/IptcReader.cs
+++ b/MetadataExtractor/Formats/Iptc/IptcReader.cs
@@ -150,7 +150,7 @@ namespace MetadataExtractor.Formats.Iptc
                     if (charset is null)
                     {
                         // Unable to determine the charset, so fall through and treat tag as a regular string
-                        charset = Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+                        charset = Encoding.UTF8.GetString(bytes);
                     }
                     directory.Set(tagIdentifier, charset);
                     return;

--- a/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
+++ b/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
@@ -91,7 +91,7 @@ namespace MetadataExtractor.Formats.Iptc
             {
                 try
                 {
-                    var s = encoding.GetString(bytes, 0, bytes.Length);
+                    var s = encoding.GetString(bytes);
                     if (s.IndexOf((char)65533) != -1)
                         continue;
                     return encoding;

--- a/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
+++ b/MetadataExtractor/Formats/Iptc/Iso2022Converter.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Buffers;
+
 namespace MetadataExtractor.Formats.Iptc
 {
     public static class Iso2022Converter
@@ -89,16 +91,23 @@ namespace MetadataExtractor.Formats.Iptc
 
             foreach (var encoding in encodings)
             {
+                char[] charBuffer = ArrayPool<char>.Shared.Rent(encoding.GetMaxCharCount(bytes.Length));
+
                 try
                 {
-                    var s = encoding.GetString(bytes);
-                    if (s.IndexOf((char)65533) != -1)
+                    int charCount = encoding.GetChars(bytes, 0, bytes.Length, charBuffer, 0);
+
+                    if (charBuffer.AsSpan(0, charCount).IndexOf((char)65533) != -1)
                         continue;
                     return encoding;
                 }
                 catch
                 {
                     // fall through...
+                }
+                finally
+                {
+                    ArrayPool<char>.Shared.Return(charBuffer);
                 }
             }
 

--- a/MetadataExtractor/Formats/Iso14496/TypeStringConverter.cs
+++ b/MetadataExtractor/Formats/Iso14496/TypeStringConverter.cs
@@ -26,7 +26,7 @@ namespace MetadataExtractor.Formats.Iso14496
                 (((typeString[0] & 0xFF) << 24) |
                  ((typeString[1] & 0xFF) << 16) |
                  ((typeString[2] & 0xFF) << 8) |
-                 ( typeString[3] & 0xFF));
+                 (typeString[3] & 0xFF));
         }
     }
 }

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopDescriptor.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopDescriptor.cs
@@ -283,7 +283,7 @@ namespace MetadataExtractor.Formats.Photoshop
 
             return bytes is null
                 ? null
-                : Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+                : Encoding.UTF8.GetString(bytes);
         }
 
         private string? GetBinaryDataString(int tagType)

--- a/MetadataExtractor/Formats/Png/PngChunkType.cs
+++ b/MetadataExtractor/Formats/Png/PngChunkType.cs
@@ -146,7 +146,7 @@ namespace MetadataExtractor.Formats.Png
 
         private static bool IsValidByte(byte b) => b is >= 65 and <= 90 or >= 97 and <= 122;
 
-        public string Identifier => Encoding.UTF8.GetString(_bytes, 0, _bytes.Length);
+        public string Identifier => Encoding.UTF8.GetString(_bytes);
 
         public override string ToString() => Identifier;
 

--- a/MetadataExtractor/Formats/Png/PngDescriptor.cs
+++ b/MetadataExtractor/Formats/Png/PngDescriptor.cs
@@ -73,9 +73,7 @@ namespace MetadataExtractor.Formats.Png
         {
             return Directory.GetObject(PngDirectory.TagTextualData) is not IList<KeyValuePair> pairs
                 ? null
-                : string.Join(
-                    "\n",
-                    pairs.Select(kv => $"{kv.Key}: {kv.Value}"));
+                : string.Join("\n", pairs.Select(kv => $"{kv.Key}: {kv.Value}"));
         }
 
         public string? GetBackgroundColorDescription()

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -318,7 +318,9 @@ namespace MetadataExtractor.Formats.QuickTime
                         ReadOnlySpan<byte> xmp = [0xbe, 0x7a, 0xcf, 0xcb, 0x97, 0xa9, 0x42, 0xe8, 0x9c, 0x71, 0x99, 0x94, 0x91, 0xe3, 0xaf, 0xac];
                         if (a.BytesLeft >= xmp.Length)
                         {
-                            var uuid = a.Reader.GetBytes(xmp.Length);
+                            Span<byte> uuid = stackalloc byte[16]; // xmp length is 16
+
+                            a.Reader.GetBytes(uuid);
                             if (xmp.SequenceEqual(uuid))
                             {
                                 var xmpBytes = a.Reader.GetNullTerminatedBytes((int)a.BytesLeft);

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeMetadataReader.cs
@@ -296,7 +296,7 @@ namespace MetadataExtractor.Formats.QuickTime
                         a.Reader.Skip(4L);
                         var partId = a.Reader.GetUInt32();
                         var featureCode = a.Reader.GetUInt32();
-                        var featureValue = string.Join(" ", a.Reader.GetBytes(4).Select(v => v.ToString("X2")).ToArray());
+                        var featureValue = string.Join(" ", a.Reader.GetBytes(4).Select(v => v.ToString("X2")));
                         Debug.WriteLine($"PartId={partId} FeatureCode={featureCode} FeatureValue={featureValue}");
                         break;
                     }

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReader.cs
@@ -50,7 +50,7 @@ namespace MetadataExtractor.Formats.QuickTime
                 var bytes = BitConverter.GetBytes(Type);
                 Array.Reverse(bytes);
 #if NETSTANDARD1_3
-                return Encoding.UTF8.GetString(bytes, 0, bytes.Length);
+                return Encoding.UTF8.GetString(bytes);
 #else
                 return Encoding.ASCII.GetString(bytes);
 #endif

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
@@ -9,12 +9,11 @@ namespace MetadataExtractor.Formats.QuickTime
     {
         public static string Get4ccString(this SequentialReader reader)
         {
-            var sb = new StringBuilder(4);
-            sb.Append((char)reader.GetByte());
-            sb.Append((char)reader.GetByte());
-            sb.Append((char)reader.GetByte());
-            sb.Append((char)reader.GetByte());
-            return sb.ToString();
+            Span<byte> bytes = stackalloc byte[4];
+
+            reader.GetBytes(bytes);
+
+            return new string([(char)bytes[0], (char)bytes[1], (char)bytes[2], (char)bytes[3]]);
         }
 
         public static decimal Get16BitFixedPoint(this SequentialReader reader)

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
@@ -13,7 +13,7 @@ namespace MetadataExtractor.Formats.QuickTime
 
             reader.GetBytes(bytes);
 
-            return new string([(char)bytes[0], (char)bytes[1], (char)bytes[2], (char)bytes[3]]);
+            return Encoding.ASCII.GetString(bytes);
         }
 
         public static decimal Get16BitFixedPoint(this SequentialReader reader)

--- a/MetadataExtractor/Formats/Riff/IRiffHandler.cs
+++ b/MetadataExtractor/Formats/Riff/IRiffHandler.cs
@@ -33,7 +33,7 @@ namespace MetadataExtractor.Formats.Riff
         /// </remarks>
         /// <param name="fourCc">the four character code of this chunk</param>
         /// <returns><see langword="true"/> if <see cref="ProcessChunk(string, byte[])"/> should be called, otherwise <see langword="false"/>.</returns>
-        bool ShouldAcceptList(string fourCc);
+        bool ShouldAcceptList(ReadOnlySpan<byte> fourCc);
 
         /// <summary>Perform whatever processing is necessary for the type of chunk with its payload.</summary>
         /// <remarks>This is only called if a previous call to <see cref="ShouldAcceptChunk(string)"/> with the same <c>fourCC</c> returned <see langword="true"/>.</remarks>

--- a/MetadataExtractor/Formats/Riff/RiffHandler.cs
+++ b/MetadataExtractor/Formats/Riff/RiffHandler.cs
@@ -30,7 +30,7 @@ namespace MetadataExtractor.Formats.Riff
 
         public abstract bool ShouldAcceptRiffIdentifier(ReadOnlySpan<byte> identifier);
 
-        public abstract bool ShouldAcceptList(string fourCc);
+        public abstract bool ShouldAcceptList(ReadOnlySpan<byte> fourCc);
 
         public void AddError(string errorMessage)
         {

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -57,6 +57,8 @@ namespace MetadataExtractor.Formats.Riff
         {
             // Processing chunks. Each chunk is 8 bytes header (4 bytes CC code + 4 bytes length of chunk) + data of the chunk
 
+            Span<byte> listName = stackalloc byte[4];
+
             while (reader.Position < maxPosition - 8)
             {
                 string chunkFourCc = reader.GetString(4, Encoding.ASCII);
@@ -70,7 +72,7 @@ namespace MetadataExtractor.Formats.Riff
                 {
                     if (chunkSize < 4)
                         break;
-                    ReadOnlySpan<byte> listName = reader.GetBytes(4);
+                    listName = reader.GetBytes(4);
                     if (handler.ShouldAcceptList(listName))
                         ProcessChunks(reader, reader.Position + chunkSize - 4, handler);
                     else

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -31,7 +31,7 @@ namespace MetadataExtractor.Formats.Riff
                 Span<byte> fileFourCc = stackalloc byte[4];
                 reader.GetBytes(fileFourCc);
                 if (!fileFourCc.SequenceEqual("RIFF"u8))
-                    throw new RiffProcessingException("Invalid RIFF header: " + Encoding.ASCII.GetString(fileFourCc.ToArray()));
+                    throw new RiffProcessingException("Invalid RIFF header: " + Encoding.ASCII.GetString(fileFourCc));
 
                 // The total size of the chunks that follow plus 4 bytes for the 'WEBP' or 'AVI ' FourCC
                 int fileSize = reader.GetInt32();

--- a/MetadataExtractor/Formats/Riff/RiffReader.cs
+++ b/MetadataExtractor/Formats/Riff/RiffReader.cs
@@ -70,7 +70,7 @@ namespace MetadataExtractor.Formats.Riff
                 {
                     if (chunkSize < 4)
                         break;
-                    string listName = reader.GetString(4, Encoding.ASCII);
+                    ReadOnlySpan<byte> listName = reader.GetBytes(4);
                     if (handler.ShouldAcceptList(listName))
                         ProcessChunks(reader, reader.Position + chunkSize - 4, handler);
                     else

--- a/MetadataExtractor/Formats/Wav/WavFormatDescriptor.cs
+++ b/MetadataExtractor/Formats/Wav/WavFormatDescriptor.cs
@@ -14,7 +14,7 @@ namespace MetadataExtractor.Formats.Wav
                 TagFormat => GetFormatDescription(),
                 TagSamplesPerSec => Directory.GetUInt32(tag).ToString("0 bps"),
                 TagBytesPerSec => Directory.GetUInt32(tag).ToString("0 bps"),
-                TagSubformat => BitConverter.ToString(Directory.GetByteArray(tag) ?? Empty.ByteArray).Replace("-", ""),
+                TagSubformat => BitConverter.ToString(Directory.GetByteArray(tag) ?? []).Replace("-", ""),
                 _ => base.GetDescription(tag),
             };
         }

--- a/MetadataExtractor/Formats/Wav/WavRiffHandler.cs
+++ b/MetadataExtractor/Formats/Wav/WavRiffHandler.cs
@@ -30,6 +30,6 @@ namespace MetadataExtractor.Formats.Wav
 
         public override bool ShouldAcceptRiffIdentifier(ReadOnlySpan<byte> identifier) => identifier.SequenceEqual("WAVE"u8);
 
-        public override bool ShouldAcceptList(string fourCc) => false;
+        public override bool ShouldAcceptList(ReadOnlySpan<byte> fourCc) => false;
     }
 }

--- a/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
+++ b/MetadataExtractor/Formats/WebP/WebpRiffHandler.cs
@@ -39,7 +39,7 @@ namespace MetadataExtractor.Formats.WebP
                                                         fourCc == "ICCP" ||
                                                         fourCc == "XMP ";
 
-        public bool ShouldAcceptList(string fourCc) => false;
+        public bool ShouldAcceptList(ReadOnlySpan<byte> fourCc) => false;
 
         public void ProcessChunk(string fourCc, byte[] payload)
         {

--- a/MetadataExtractor/IO/IndexedReader.cs
+++ b/MetadataExtractor/IO/IndexedReader.cs
@@ -388,7 +388,7 @@ namespace MetadataExtractor.IO
                 length++;
 
             if (length == 0)
-                return Empty.ByteArray;
+                return [];
             if (length == maxLengthBytes)
                 return buffer;
 

--- a/MetadataExtractor/IO/IndexedReader.cs
+++ b/MetadataExtractor/IO/IndexedReader.cs
@@ -346,7 +346,7 @@ namespace MetadataExtractor.IO
         {
             var bytes = GetNullTerminatedBytes(index, maxLengthBytes);
 
-            return (encoding ?? Encoding.UTF8).GetString(bytes, 0, bytes.Length);
+            return (encoding ?? Encoding.UTF8).GetString(bytes);
         }
 
         /// <summary>

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -320,7 +320,7 @@ namespace MetadataExtractor.IO
             }
 
             if (length == 0)
-                return Empty.ByteArray;
+                return [];
             if (length == maxLengthBytes)
                 return buffer;
             var bytes = new byte[length];

--- a/MetadataExtractor/IO/SequentialReader.cs
+++ b/MetadataExtractor/IO/SequentialReader.cs
@@ -255,7 +255,7 @@ namespace MetadataExtractor.IO
         {
             var bytes = GetNullTerminatedBytes(maxLengthBytes, moveToMaxLength);
 
-            return (encoding ?? Encoding.UTF8).GetString(bytes, 0, bytes.Length);
+            return (encoding ?? Encoding.UTF8).GetString(bytes);
         }
 
         /// <summary>

--- a/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -4333,7 +4333,7 @@ static MetadataExtractor.Formats.Eps.EpsMetadataReader.ReadMetadata(string! file
 static MetadataExtractor.Formats.Eps.EpsMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Exif.ExifDirectoryBase.AddExifTagNames(System.Collections.Generic.Dictionary<int, string!>! map) -> void
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
-static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(byte[]! bytes) -> bool
+static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(System.ReadOnlySpan<byte> bytes) -> bool
 static MetadataExtractor.Formats.Gif.GifMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Gif.GifMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Heif.HeifMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!

--- a/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -5,7 +5,7 @@ abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Pr
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.IReadOnlyCollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
-abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
+abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(in MetadataExtractor.Formats.Tiff.TiffReaderContext context, int tagId, int valueOffset, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
@@ -2387,7 +2387,7 @@ MetadataExtractor.Formats.Avi.AviRiffHandler.AddError(string! errorMessage) -> v
 MetadataExtractor.Formats.Avi.AviRiffHandler.AviRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.BmpHeaderDescriptor(MetadataExtractor.Formats.Bmp.BmpHeaderDirectory! directory) -> void
@@ -3699,7 +3699,7 @@ MetadataExtractor.Formats.Riff.IRiffHandler
 MetadataExtractor.Formats.Riff.IRiffHandler.AddError(string! errorMessage) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.ProcessChunk(string! fourCc, byte[]! payload) -> void
@@ -3864,7 +3864,7 @@ MetadataExtractor.Formats.WebP.WebPRiffHandler
 MetadataExtractor.Formats.WebP.WebPRiffHandler.AddError(string! errorMessage) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.WebPRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Xmp.Schema
@@ -4248,7 +4248,7 @@ override MetadataExtractor.Formats.Tiff.TiffDataFormat.ToString() -> string!
 override MetadataExtractor.Formats.Wav.WavFactDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavFormatDescriptor.GetDescription(int tag) -> string?
 override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -4326,7 +4326,7 @@ static MetadataExtractor.Formats.Eps.EpsMetadataReader.ReadMetadata(string! file
 static MetadataExtractor.Formats.Eps.EpsMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Exif.ExifDirectoryBase.AddExifTagNames(System.Collections.Generic.Dictionary<int, string!>! map) -> void
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
-static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(byte[]! bytes) -> bool
+static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(System.ReadOnlySpan<byte> bytes) -> bool
 static MetadataExtractor.Formats.Gif.GifMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Gif.GifMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Heif.HeifMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -5,7 +5,7 @@ abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Pr
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.IReadOnlyCollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
-abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
+abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(in MetadataExtractor.Formats.Tiff.TiffReaderContext context, int tagId, int valueOffset, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
@@ -2387,7 +2387,7 @@ MetadataExtractor.Formats.Avi.AviRiffHandler.AddError(string! errorMessage) -> v
 MetadataExtractor.Formats.Avi.AviRiffHandler.AviRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.BmpHeaderDescriptor(MetadataExtractor.Formats.Bmp.BmpHeaderDirectory! directory) -> void
@@ -3697,7 +3697,7 @@ MetadataExtractor.Formats.Riff.IRiffHandler
 MetadataExtractor.Formats.Riff.IRiffHandler.AddError(string! errorMessage) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.ProcessChunk(string! fourCc, byte[]! payload) -> void
@@ -3860,7 +3860,7 @@ MetadataExtractor.Formats.WebP.WebPRiffHandler
 MetadataExtractor.Formats.WebP.WebPRiffHandler.AddError(string! errorMessage) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.WebPRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Xmp.Schema
@@ -4241,7 +4241,7 @@ override MetadataExtractor.Formats.Tiff.TiffDataFormat.ToString() -> string!
 override MetadataExtractor.Formats.Wav.WavFactDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavFormatDescriptor.GetDescription(int tag) -> string?
 override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -4328,7 +4328,7 @@ static MetadataExtractor.Formats.Eps.EpsMetadataReader.ReadMetadata(string! file
 static MetadataExtractor.Formats.Eps.EpsMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Exif.ExifDirectoryBase.AddExifTagNames(System.Collections.Generic.Dictionary<int, string!>! map) -> void
 static MetadataExtractor.Formats.Exif.ExifReader.JpegSegmentPreambleLength.get -> int
-static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(byte[]! bytes) -> bool
+static MetadataExtractor.Formats.Exif.ExifReader.StartsWithJpegExifPreamble(System.ReadOnlySpan<byte> bytes) -> bool
 static MetadataExtractor.Formats.Gif.GifMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Gif.GifMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Formats.Heif.HeifMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -5,7 +5,7 @@ abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.Pr
 abstract MetadataExtractor.Formats.Jpeg.JpegSegmentWithPreambleMetadataReader.SegmentTypes.get -> System.Collections.Generic.IReadOnlyCollection<MetadataExtractor.Formats.Jpeg.JpegSegmentType>!
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.MinSize.get -> int
 abstract MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.Populate(T! directory, byte[]! payload) -> void
-abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(string! fourCc) -> bool
+abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 abstract MetadataExtractor.Formats.Riff.RiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.CustomProcessTag(in MetadataExtractor.Formats.Tiff.TiffReaderContext context, int tagId, int valueOffset, int byteCount) -> bool
 abstract MetadataExtractor.Formats.Tiff.DirectoryTiffHandler.HasFollowerIfd() -> bool
@@ -2382,7 +2382,7 @@ MetadataExtractor.Formats.Avi.AviRiffHandler.AddError(string! errorMessage) -> v
 MetadataExtractor.Formats.Avi.AviRiffHandler.AviRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.Avi.AviRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor
 MetadataExtractor.Formats.Bmp.BmpHeaderDescriptor.BmpHeaderDescriptor(MetadataExtractor.Formats.Bmp.BmpHeaderDirectory! directory) -> void
@@ -3694,7 +3694,7 @@ MetadataExtractor.Formats.Riff.IRiffHandler
 MetadataExtractor.Formats.Riff.IRiffHandler.AddError(string! errorMessage) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.Riff.IRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>
 MetadataExtractor.Formats.Riff.RiffChunkHandler<T>.ProcessChunk(string! fourCc, byte[]! payload) -> void
@@ -3859,7 +3859,7 @@ MetadataExtractor.Formats.WebP.WebPRiffHandler
 MetadataExtractor.Formats.WebP.WebPRiffHandler.AddError(string! errorMessage) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ProcessChunk(string! fourCc, byte[]! payload) -> void
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptChunk(string! fourCc) -> bool
-MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 MetadataExtractor.Formats.WebP.WebPRiffHandler.WebPRiffHandler(System.Collections.Generic.List<MetadataExtractor.Directory!>! directories) -> void
 MetadataExtractor.Formats.Xmp.Schema
@@ -4243,7 +4243,7 @@ override MetadataExtractor.Formats.Tiff.TiffDataFormat.ToString() -> string!
 override MetadataExtractor.Formats.Wav.WavFactDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Wav.WavFormatDescriptor.GetDescription(int tag) -> string?
 override MetadataExtractor.Formats.Wav.WavFormatDirectory.Name.get -> string!
-override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(string! fourCc) -> bool
+override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptList(System.ReadOnlySpan<byte> fourCc) -> bool
 override MetadataExtractor.Formats.Wav.WavRiffHandler.ShouldAcceptRiffIdentifier(System.ReadOnlySpan<byte> identifier) -> bool
 override MetadataExtractor.Formats.WebP.WebPDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Xmp.XmpDirectory.Name.get -> string!

--- a/MetadataExtractor/TagDescriptor.cs
+++ b/MetadataExtractor/TagDescriptor.cs
@@ -221,8 +221,7 @@ namespace MetadataExtractor
 
             try
             {
-                return Encoding.UTF8
-                    .GetString(values, 0, values.Length)
+                return Encoding.UTF8.GetString(values)
                     .Trim('\0', ' ', '\r', '\n', '\t');
             }
             catch

--- a/MetadataExtractor/Util/Empty.cs
+++ b/MetadataExtractor/Util/Empty.cs
@@ -1,8 +1,0 @@
-﻿// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
-
-namespace MetadataExtractor;
-
-internal static class Empty
-{
-    public static readonly byte[] ByteArray = [];
-}


### PR DESCRIPTION
- Simplifies string.Join calls (eliminates various array allocations)
- Uses new GetString polyfill
- Removes Empty class (using empty collection expression instead)
- Eliminates various byte allocation
- Updates ShouldAcceptList to use utf-8 bytes
- Updates StartsWithJpegPreamble to accept ReadOnlySpan<byte>
- Switches on integer values to avoid a string allocation