### PR TITLE
Introduce BufferReader and eliminate a bunch of allocations

### DIFF
--- a/MetadataExtractor/Formats/Apple/BplistReader.cs
+++ b/MetadataExtractor/Formats/Apple/BplistReader.cs
@@ -43,19 +43,20 @@ public sealed class BplistReader
 
         Trailer trailer = ReadTrailer();
 
-        var reader = new BufferReader(bplist.AsSpan(checked((int)(trailer.OffsetTableOffset + trailer.TopObject))), isBigEndian: true);
+        int offset = checked((int)(trailer.OffsetTableOffset + trailer.TopObject));
+        var reader = new BufferReader(bplist.AsSpan(offset), isBigEndian: true);
 
         int[] offsets = new int[(int)trailer.NumObjects];
 
-        for (long i = 0; i < trailer.NumObjects; i++)
+        for (int i = 0; i < (int)trailer.NumObjects; i++)
         {
             if (trailer.OffsetIntSize == 1)
             {
-                offsets[(int)i] = reader.GetByte();
+                offsets[i] = reader.GetByte();
             }
             else if (trailer.OffsetIntSize == 2)
             {
-                offsets[(int)i] = reader.GetUInt16();
+                offsets[i] = reader.GetUInt16();
             }
         }
 

--- a/MetadataExtractor/Formats/Apple/BplistReader.cs
+++ b/MetadataExtractor/Formats/Apple/BplistReader.cs
@@ -94,7 +94,7 @@ public sealed class BplistReader
             var reader = new BufferReader(bplist.AsSpan(bplist.Length - Trailer.SizeBytes), isBigEndian: true);
 
             // Skip 5-byte unused values, 1-byte sort version.
-            reader.Skip(6);
+            reader.Advance(6);
 
             return new Trailer
             {

--- a/MetadataExtractor/Formats/Apple/BplistReader.cs
+++ b/MetadataExtractor/Formats/Apple/BplistReader.cs
@@ -95,7 +95,7 @@ public sealed class BplistReader
             var reader = new BufferReader(bplist.AsSpan(bplist.Length - Trailer.SizeBytes), isBigEndian: true);
 
             // Skip 5-byte unused values, 1-byte sort version.
-            reader.Advance(6);
+            reader.Skip(5 + 1);
 
             return new Trailer
             {

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
@@ -367,10 +367,10 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
 
             sb.Append(values[0] switch
             {
-                0 => sb.Append("Off"),
-                3 => sb.Append("TTL"),
-                4 => sb.Append("Auto"),
-                5 => sb.Append("Manual"),
+                0 => "Off",
+                3 => "TTL",
+                4 => "Auto",
+                5 => "Manual",
                 _ => $"Unknown ({values[0]})"
             });
 

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
@@ -160,30 +160,16 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 return null;
 
             var sb = new StringBuilder();
-            switch (values[0])
+            sb.Append(values[0] switch
             {
-                case 0:
-                    sb.Append("Single AF");
-                    break;
-                case 1:
-                    sb.Append("Sequential shooting AF");
-                    break;
-                case 2:
-                    sb.Append("Continuous AF");
-                    break;
-                case 3:
-                    sb.Append("Multi AF");
-                    break;
-                case 4:
-                    sb.Append("Face detect");
-                    break;
-                case 10:
-                    sb.Append("MF");
-                    break;
-                default:
-                    sb.Append("Unknown (" + values[0] + ")");
-                    break;
-            }
+                0 => "Single AF",
+                1 => "Sequential shooting AF",
+                2 => "Continuous AF",
+                3 => "Multi AF",
+                4 => "Face detect",
+                10 => "MF",
+                _ => $"Unknown ({values[0]})"
+            });
 
             if (values.Length > 1)
             {
@@ -231,18 +217,12 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
 
             var sb = new StringBuilder();
 
-            switch (values[0])
+            sb.Append(values[0] switch
             {
-                case 0:
-                    sb.Append("AF not used");
-                    break;
-                case 1:
-                    sb.Append("AF used");
-                    break;
-                default:
-                    sb.Append("Unknown (" + values[0] + ")");
-                    break;
-            }
+                0 => "AF not used",
+                1 => "AF used",
+                _ => $"Unknown ({values[0]})"
+            });
 
             if (values.Length > 1)
                 sb.Append("; " + values[1]);
@@ -385,24 +365,14 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
 
             var sb = new StringBuilder();
 
-            switch (values[0])
+            sb.Append(values[0] switch
             {
-                case 0:
-                    sb.Append("Off");
-                    break;
-                case 3:
-                    sb.Append("TTL");
-                    break;
-                case 4:
-                    sb.Append("Auto");
-                    break;
-                case 5:
-                    sb.Append("Manual");
-                    break;
-                default:
-                    sb.Append("Unknown (" + values[0] + ")");
-                    break;
-            }
+                0 => sb.Append("Off"),
+                3 => sb.Append("TTL"),
+                4 => sb.Append("Auto"),
+                5 => sb.Append("Manual"),
+                _ => $"Unknown ({values[0]})"
+            });
 
             for (var i = 1; i < values.Length; i++)
                 sb.Append("; ").Append(values[i]);
@@ -692,33 +662,17 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 return null;
 
             var sb = new StringBuilder();
-            switch (values[0])
+            sb.Append(values[0] switch
             {
-                case 1:
-                    sb.Append("Vivid");
-                    break;
-                case 2:
-                    sb.Append("Natural");
-                    break;
-                case 3:
-                    sb.Append("Muted");
-                    break;
-                case 4:
-                    sb.Append("Portrait");
-                    break;
-                case 5:
-                    sb.Append("i-Enhance");
-                    break;
-                case 256:
-                    sb.Append("Monotone");
-                    break;
-                case 512:
-                    sb.Append("Sepia");
-                    break;
-                default:
-                    sb.Append("Unknown (").Append(values[0]).Append(')');
-                    break;
-            }
+                1 => "Vivid",
+                2 => "Natural",
+                3 => "Muted",
+                4 => "Portrait",
+                5 => "i-Enhance",
+                256 => "Monotone",
+                512 => "Sepia",
+                _ => $"Unknown ({values[0]})"
+            });
 
             if (values.Length > 1)
                 sb.Append("; ").Append(values[1]);
@@ -822,33 +776,18 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                     sb.Append("Partial Color " + values[i] + "; ");
                 else if (i == 4)
                 {
-                    switch (values[i])
+                    sb.Append(values[i] switch
                     {
-                        case 0x0000:
-                            sb.Append("No Effect");
-                            break;
-                        case 0x8010:
-                            sb.Append("Star Light");
-                            break;
-                        case 0x8020:
-                            sb.Append("Pin Hole");
-                            break;
-                        case 0x8030:
-                            sb.Append("Frame");
-                            break;
-                        case 0x8040:
-                            sb.Append("Soft Focus");
-                            break;
-                        case 0x8050:
-                            sb.Append("White Edge");
-                            break;
-                        case 0x8060:
-                            sb.Append("B&W");
-                            break;
-                        default:
-                            sb.Append("Unknown (").Append(values[i]).Append(')');
-                            break;
-                    }
+                        0x0000 => "No Effect",
+                        0x8010 => "Star Light",
+                        0x8020 => "Pin Hole",
+                        0x8030 => "Frame",
+                        0x8040 => "Soft Focus",
+                        0x8050 => "White Edge",
+                        0x8060 => "B&W",
+                        _ => $"Unknown ({values[i]})"
+                    });
+
                     sb.Append("; ");
                 }
                 else if (i == 6)

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusCameraSettingsMakernoteDescriptor.cs
@@ -621,7 +621,7 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
             if (Directory.GetObject(OlympusCameraSettingsMakernoteDirectory.TagGradation) is not short[] values || values.Length < 3)
                 return null;
 
-            var ret = (values[0], values[1], values[3]) switch
+            var ret = (values[0], values[1], values[2]) switch
             {
                 (0, 0, 0) => "n/a",
                 (-1, -1, 1) => "Low Key",

--- a/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
+++ b/MetadataExtractor/Formats/Exif/makernotes/OlympusMakernoteDirectory.cs
@@ -448,9 +448,9 @@ namespace MetadataExtractor.Formats.Exif.Makernotes
                 base.Set(tagType, value);
         }
 
-        private void ProcessCameraSettings(byte[] bytes)
+        private void ProcessCameraSettings(ReadOnlySpan<byte> bytes)
         {
-            var reader = new SequentialByteArrayReader(bytes);
+            var reader = new BufferReader(bytes, isBigEndian: true);
             var count = bytes.Length / 4;
 
             for (var i = 0; i < count; i++)

--- a/MetadataExtractor/Formats/Flir/FlirReader.cs
+++ b/MetadataExtractor/Formats/Flir/FlirReader.cs
@@ -153,8 +153,9 @@ namespace MetadataExtractor.Formats.Flir
                     directory.Set(TagRawValueMedian, reader2.GetUInt16(TagRawValueMedian));
                     directory.Set(TagRawValueRange, reader2.GetUInt16(TagRawValueRange));
 
-                    var dateTimeBytes = reader2.GetBytes(TagDateTimeOriginal, 10);
-                    var dateTimeReader = new SequentialByteArrayReader(dateTimeBytes, isMotorolaByteOrder: false);
+                    Span<byte> dateTimeBytes = stackalloc byte[10];
+                    reader2.GetBytes(TagDateTimeOriginal, dateTimeBytes);
+                    var dateTimeReader = new BufferReader(dateTimeBytes, isBigEndian: false);
                     var tm = dateTimeReader.GetUInt32();
                     var ss = dateTimeReader.GetUInt32() & 0xffff;
                     var tz = dateTimeReader.GetInt16();

--- a/MetadataExtractor/Formats/Jpeg/JpegReader.cs
+++ b/MetadataExtractor/Formats/Jpeg/JpegReader.cs
@@ -29,7 +29,7 @@ namespace MetadataExtractor.Formats.Jpeg
             // The value of TagCompressionType is determined by the segment type found
             directory.Set(JpegDirectory.TagCompressionType, (int)segment.Type - (int)JpegSegmentType.Sof0);
 
-            SequentialReader reader = new SequentialByteArrayReader(segment.Bytes);
+            var reader = new BufferReader(segment.Span, isBigEndian: true);
 
             try
             {

--- a/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
+++ b/MetadataExtractor/Formats/Photoshop/PhotoshopReader.cs
@@ -53,12 +53,15 @@ namespace MetadataExtractor.Formats.Photoshop
             // http://www.adobe.com/devnet-apps/photoshop/fileformatashtml/#50577409_pgfId-1037504
             var pos = 0;
             int clippingPathCount = 0;
+
+            Span<byte> signature = stackalloc byte[4];
+
             while (pos < length)
             {
                 try
                 {
                     // 4 bytes for the signature ("8BIM", "PHUT", etc.)
-                    var signature = reader.GetString(4, Encoding.UTF8);
+                    reader.GetBytes(signature);
                     pos += 4;
 
                     // 2 bytes for the resource identifier (tag type).
@@ -106,7 +109,7 @@ namespace MetadataExtractor.Formats.Photoshop
                     }
 
                     // Skip any unsupported IRBs
-                    if (signature != "8BIM")
+                    if (!signature.SequenceEqual("8BIM"u8))
                         continue;
 
                     switch (tagType)

--- a/MetadataExtractor/Formats/Png/PngChromaticities.cs
+++ b/MetadataExtractor/Formats/Png/PngChromaticities.cs
@@ -20,23 +20,16 @@ namespace MetadataExtractor.Formats.Png
             if (bytes.Length != 8 * 4)
                 throw new PngProcessingException("Invalid number of bytes");
 
-            var reader = new SequentialByteArrayReader(bytes);
+            var reader = new BufferReader(bytes, isBigEndian: true);
 
-            try
-            {
-                WhitePointX = reader.GetInt32();
-                WhitePointY = reader.GetInt32();
-                RedX = reader.GetInt32();
-                RedY = reader.GetInt32();
-                GreenX = reader.GetInt32();
-                GreenY = reader.GetInt32();
-                BlueX = reader.GetInt32();
-                BlueY = reader.GetInt32();
-            }
-            catch (IOException ex)
-            {
-                throw new PngProcessingException(ex);
-            }
+            WhitePointX = reader.GetInt32();
+            WhitePointY = reader.GetInt32();
+            RedX = reader.GetInt32();
+            RedY = reader.GetInt32();
+            GreenX = reader.GetInt32();
+            GreenY = reader.GetInt32();
+            BlueX = reader.GetInt32();
+            BlueY = reader.GetInt32();
         }
     }
 }

--- a/MetadataExtractor/Formats/Png/PngDescriptor.cs
+++ b/MetadataExtractor/Formats/Png/PngDescriptor.cs
@@ -82,10 +82,10 @@ namespace MetadataExtractor.Formats.Png
             if (bytes is null)
                 return null;
 
-            var reader = new SequentialByteArrayReader(bytes);
+            var reader = new BufferReader(bytes, isBigEndian: true);
             try
             {
-                // TODO do we need to normalise these based upon the bit depth?
+                // TODO do we need to normalize these based upon the bit depth?
                 switch (bytes.Length)
                 {
                     case 1:

--- a/MetadataExtractor/Formats/Png/PngHeader.cs
+++ b/MetadataExtractor/Formats/Png/PngHeader.cs
@@ -11,7 +11,7 @@ namespace MetadataExtractor.Formats.Png
             if (bytes.Length != 13)
                 throw new PngProcessingException("PNG header chunk must have exactly 13 data bytes");
 
-            var reader = new SequentialByteArrayReader(bytes);
+            var reader = new BufferReader(bytes, isBigEndian: true);
 
             ImageWidth = reader.GetInt32();
             ImageHeight = reader.GetInt32();

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -295,7 +295,7 @@ namespace MetadataExtractor.Formats.Png
             }
             else if (chunkType == PngChunkType.tIME)
             {
-                var reader = new SequentialByteArrayReader(bytes);
+                var reader = new BufferReader(bytes, isBigEndian: true);
                 var year = reader.GetUInt16();
                 var month = reader.GetByte();
                 int day = reader.GetByte();
@@ -316,7 +316,7 @@ namespace MetadataExtractor.Formats.Png
             }
             else if (chunkType == PngChunkType.pHYs)
             {
-                var reader = new SequentialByteArrayReader(bytes);
+                var reader = new BufferReader(bytes, isBigEndian: true);
                 var pixelsPerUnitX = reader.GetInt32();
                 var pixelsPerUnitY = reader.GetInt32();
                 var unitSpecifier = reader.GetSByte();

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -295,32 +295,50 @@ namespace MetadataExtractor.Formats.Png
             }
             else if (chunkType == PngChunkType.tIME)
             {
-                var reader = new BufferReader(bytes, isBigEndian: true);
-                var year = reader.GetUInt16();
-                var month = reader.GetByte();
-                int day = reader.GetByte();
-                int hour = reader.GetByte();
-                int minute = reader.GetByte();
-                int second = reader.GetByte();
                 var directory = new PngDirectory(PngChunkType.tIME);
-                if (DateUtil.IsValidDate(year, month, day) && DateUtil.IsValidTime(hour, minute, second))
+
+                if (bytes.Length < 2 + 1 + 1 + 1 + 1 + 1)
                 {
-                    var time = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Unspecified);
-                    directory.Set(PngDirectory.TagLastModificationTime, time);
+                    directory.AddError("Insufficient bytes for PNG tIME chunk.");
                 }
                 else
                 {
-                    directory.AddError($"PNG tIME data describes an invalid date/time: year={year} month={month} day={day} hour={hour} minute={minute} second={second}");
+                    var reader = new BufferReader(bytes, isBigEndian: true);
+
+                    var year = reader.GetUInt16();
+                    var month = reader.GetByte();
+                    int day = reader.GetByte();
+                    int hour = reader.GetByte();
+                    int minute = reader.GetByte();
+                    int second = reader.GetByte();
+
+                    if (DateUtil.IsValidDate(year, month, day) && DateUtil.IsValidTime(hour, minute, second))
+                    {
+                        var time = new DateTime(year, month, day, hour, minute, second, DateTimeKind.Unspecified);
+                        directory.Set(PngDirectory.TagLastModificationTime, time);
+                    }
+                    else
+                    {
+                        directory.AddError($"PNG tIME data describes an invalid date/time: year={year} month={month} day={day} hour={hour} minute={minute} second={second}");
+                    }
+                    yield return directory;
                 }
-                yield return directory;
             }
             else if (chunkType == PngChunkType.pHYs)
             {
+                var directory = new PngDirectory(PngChunkType.pHYs);
+
+                if (bytes.Length < 4 + 4 + 1)
+                {
+                    directory.AddError("Insufficient bytes for PNG pHYs chunk.");
+                }
+
                 var reader = new BufferReader(bytes, isBigEndian: true);
+
                 var pixelsPerUnitX = reader.GetInt32();
                 var pixelsPerUnitY = reader.GetInt32();
                 var unitSpecifier = reader.GetSByte();
-                var directory = new PngDirectory(PngChunkType.pHYs);
+
                 directory.Set(PngDirectory.TagPixelsPerUnitX, pixelsPerUnitX);
                 directory.Set(PngDirectory.TagPixelsPerUnitY, pixelsPerUnitY);
                 directory.Set(PngDirectory.TagUnitSpecifier, unitSpecifier);

--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -332,17 +332,19 @@ namespace MetadataExtractor.Formats.Png
                 {
                     directory.AddError("Insufficient bytes for PNG pHYs chunk.");
                 }
+                else
+                {
+                    var reader = new BufferReader(bytes, isBigEndian: true);
 
-                var reader = new BufferReader(bytes, isBigEndian: true);
+                    var pixelsPerUnitX = reader.GetInt32();
+                    var pixelsPerUnitY = reader.GetInt32();
+                    var unitSpecifier = reader.GetSByte();
 
-                var pixelsPerUnitX = reader.GetInt32();
-                var pixelsPerUnitY = reader.GetInt32();
-                var unitSpecifier = reader.GetSByte();
-
-                directory.Set(PngDirectory.TagPixelsPerUnitX, pixelsPerUnitX);
-                directory.Set(PngDirectory.TagPixelsPerUnitY, pixelsPerUnitY);
-                directory.Set(PngDirectory.TagUnitSpecifier, unitSpecifier);
-                yield return directory;
+                    directory.Set(PngDirectory.TagPixelsPerUnitX, pixelsPerUnitX);
+                    directory.Set(PngDirectory.TagPixelsPerUnitY, pixelsPerUnitY);
+                    directory.Set(PngDirectory.TagUnitSpecifier, unitSpecifier);
+                    yield return directory;
+                }
             }
             else if (chunkType.Equals(PngChunkType.sBIT))
             {

--- a/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
+++ b/MetadataExtractor/Formats/QuickTime/QuickTimeReaderExtensions.cs
@@ -7,13 +7,30 @@ namespace MetadataExtractor.Formats.QuickTime
     /// </summary>
     public static class QuickTimeReaderExtensions
     {
+#if NETSTANDARD2_1
         public static string Get4ccString(this SequentialReader reader)
+#else
+        public unsafe static string Get4ccString(this SequentialReader reader)
+#endif
         {
             Span<byte> bytes = stackalloc byte[4];
+            Span<char> chars = stackalloc char[4];
 
             reader.GetBytes(bytes);
 
-            return Encoding.ASCII.GetString(bytes);
+            chars[0] = (char)bytes[0];
+            chars[1] = (char)bytes[1];
+            chars[2] = (char)bytes[2];
+            chars[3] = (char)bytes[3];
+
+#if NETSTANDARD2_1
+            return new string(chars);
+#else
+            fixed (char* c = chars)
+            {
+                return new string(c, 0, 4);
+            }
+#endif
         }
 
         public static decimal Get16BitFixedPoint(this SequentialReader reader)

--- a/MetadataExtractor/Formats/Wav/WavFactHandler.cs
+++ b/MetadataExtractor/Formats/Wav/WavFactHandler.cs
@@ -25,7 +25,7 @@ namespace MetadataExtractor.Formats.Wav
 
         protected override void Populate(WavFactDirectory directory, byte[] payload)
         {
-            var reader = new SequentialByteArrayReader(payload, isMotorolaByteOrder: false);
+            var reader = new BufferReader(payload, isBigEndian: false);
             directory.Set(TagSampleLength, reader.GetUInt32());
         }
     }

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -40,7 +40,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public readonly int Available => _bytes.Length - _position;
 
-    public void Skip(int n)
+    public void Advance(int n)
     {
         Debug.Assert(n < 0, "n must be zero or greater");
         Debug.Assert(_position + n > _bytes.Length, "attempted to advance past end of data");
@@ -48,7 +48,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
         _position += n;
     }
 
-    public bool TrySkip(int n)
+    public bool TryAdvance(int n)
     {
         Debug.Assert(n < 0, "n must be zero or greater");
 

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -1,0 +1,157 @@
+// Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
+
+using System.Buffers.Binary;
+
+namespace MetadataExtractor.IO;
+
+internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
+{
+    private readonly ReadOnlySpan<byte> _bytes = bytes;
+    private int _position = 0;
+    private bool _isBigEndian = isBigEndian;
+
+    public long Position => _position;
+
+    public byte GetByte()
+    {
+        if (_position >= _bytes.Length)
+            throw new IOException("End of data reached.");
+
+        return _bytes[_position++];
+    }
+
+    public void GetBytes(scoped Span<byte> bytes)
+    {
+        if (_position + bytes.Length > _bytes.Length)
+            throw new IOException("End of data reached.");
+
+        _bytes.Slice(_position, bytes.Length).CopyTo(bytes);
+        _position += bytes.Length;
+    }
+
+    public byte[] GetBytes(int count)
+    {
+        if (_position + count > _bytes.Length)
+            throw new IOException("End of data reached.");
+
+        var bytes = new byte[count];
+
+        _bytes.Slice(0, count).CopyTo(bytes);
+        _position += count;
+        return bytes;
+    }
+
+    public int Available()
+    {
+        return _bytes.Length - _position;
+    }
+
+    public void Skip(long n)
+    {
+        if (n < 0)
+            throw new ArgumentException("n must be zero or greater.");
+
+        if (_position + n > _bytes.Length)
+            throw new IOException("End of data reached.");
+
+        _position += unchecked((int)n);
+    }
+
+    public bool TrySkip(long n)
+    {
+        if (n < 0)
+            throw new ArgumentException("n must be zero or greater.");
+
+        _position += unchecked((int)n);
+
+        if (_position > _bytes.Length)
+        {
+            _position = _bytes.Length;
+            return false;
+        }
+
+        return true;
+    }
+
+    public sbyte GetSByte()
+    {
+        return unchecked((sbyte)GetByte());
+    }
+
+    public ushort GetUInt16()
+    {
+        Span<byte> bytes = stackalloc byte[2];
+
+        GetBytes(bytes);
+
+        return _isBigEndian
+            ? BinaryPrimitives.ReadUInt16BigEndian(bytes)
+            : BinaryPrimitives.ReadUInt16LittleEndian(bytes);
+    }
+
+    public short GetInt16()
+    {
+        Span<byte> bytes = stackalloc byte[2];
+
+        GetBytes(bytes);
+
+        return _isBigEndian
+            ? BinaryPrimitives.ReadInt16BigEndian(bytes)
+            : BinaryPrimitives.ReadInt16LittleEndian(bytes);
+    }
+
+    public uint GetUInt32()
+    {
+        Span<byte> bytes = stackalloc byte[4];
+
+        GetBytes(bytes);
+
+        return _isBigEndian
+            ? BinaryPrimitives.ReadUInt32BigEndian(bytes)
+            : BinaryPrimitives.ReadUInt32LittleEndian(bytes);
+    }
+
+    public int GetInt32()
+    {
+        Span<byte> bytes = stackalloc byte[4];
+
+        GetBytes(bytes);
+
+        return _isBigEndian
+            ? BinaryPrimitives.ReadInt32BigEndian(bytes)
+            : BinaryPrimitives.ReadInt32LittleEndian(bytes);
+    }
+
+    public long GetInt64()
+    {
+        Span<byte> bytes = stackalloc byte[8];
+        GetBytes(bytes);
+
+        return _isBigEndian
+            ? BinaryPrimitives.ReadInt64BigEndian(bytes)
+            : BinaryPrimitives.ReadInt64LittleEndian(bytes);
+    }
+
+    public ulong GetUInt64()
+    {
+        Span<byte> bytes = stackalloc byte[8];
+        GetBytes(bytes);
+
+        return _isBigEndian
+            ? BinaryPrimitives.ReadUInt64BigEndian(bytes)
+            : BinaryPrimitives.ReadUInt64LittleEndian(bytes);
+    }
+
+    public string GetString(int bytesRequested, Encoding encoding)
+    {
+        // This check is important on .NET Framework
+        if (bytesRequested is 0)
+            return "";
+
+        Span<byte> bytes = bytesRequested < 256 ? stackalloc byte[bytesRequested] : new byte[bytesRequested];
+
+        GetBytes(bytes);
+
+        return encoding.GetString(bytes);
+    }
+}

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -69,14 +69,13 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public sbyte GetSByte()
     {
-        return unchecked((sbyte)GetByte());
+        return unchecked((sbyte)_bytes[_position++]);
     }
 
     public ushort GetUInt16()
     {
-        Span<byte> bytes = stackalloc byte[2];
-
-        GetBytes(bytes);
+        var bytes = _bytes.Slice(_position, 2);
+        _position += 2;
 
         return _isBigEndian
             ? BinaryPrimitives.ReadUInt16BigEndian(bytes)
@@ -85,9 +84,8 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public short GetInt16()
     {
-        Span<byte> bytes = stackalloc byte[2];
-
-        GetBytes(bytes);
+        var bytes = _bytes.Slice(_position, 2);
+        _position += 2;
 
         return _isBigEndian
             ? BinaryPrimitives.ReadInt16BigEndian(bytes)
@@ -96,9 +94,8 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public uint GetUInt32()
     {
-        Span<byte> bytes = stackalloc byte[4];
-
-        GetBytes(bytes);
+        var bytes = _bytes.Slice(_position, 4);
+        _position += 4;
 
         return _isBigEndian
             ? BinaryPrimitives.ReadUInt32BigEndian(bytes)
@@ -107,9 +104,8 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public int GetInt32()
     {
-        Span<byte> bytes = stackalloc byte[4];
-
-        GetBytes(bytes);
+        var bytes = _bytes.Slice(_position, 4);
+        _position += 4;
 
         return _isBigEndian
             ? BinaryPrimitives.ReadInt32BigEndian(bytes)
@@ -118,8 +114,8 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public long GetInt64()
     {
-        Span<byte> bytes = stackalloc byte[8];
-        GetBytes(bytes);
+        var bytes = _bytes.Slice(_position, 8);
+        _position += 8;
 
         return _isBigEndian
             ? BinaryPrimitives.ReadInt64BigEndian(bytes)
@@ -128,8 +124,8 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public ulong GetUInt64()
     {
-        Span<byte> bytes = stackalloc byte[8];
-        GetBytes(bytes);
+        var bytes = _bytes.Slice(_position, 8);
+        _position += 8;
 
         return _isBigEndian
             ? BinaryPrimitives.ReadUInt64BigEndian(bytes)

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -7,8 +7,9 @@ namespace MetadataExtractor.IO;
 internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 {
     private readonly ReadOnlySpan<byte> _bytes = bytes;
+    private readonly bool _isBigEndian = isBigEndian;
+
     private int _position = 0;
-    private bool _isBigEndian = isBigEndian;
 
     public readonly int Available => _bytes.Length - _position;
 

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -33,7 +33,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
         var bytes = new byte[count];
 
-        _bytes.Slice(0, count).CopyTo(bytes);
+        _bytes.Slice(_position, count).CopyTo(bytes);
         _position += count;
         return bytes;
     }

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -21,7 +21,8 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public void GetBytes(scoped Span<byte> bytes)
     {
-        Debug.Assert(_position + bytes.Length <= _bytes.Length, "attempted to read past end of data");
+        if (_position + bytes.Length > _bytes.Length)
+            throw new IOException("End of data reached.");
 
         _bytes.Slice(_position, bytes.Length).CopyTo(bytes);
         _position += bytes.Length;
@@ -29,7 +30,8 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public byte[] GetBytes(int count)
     {
-        Debug.Assert(_position + count <= _bytes.Length, "attempted to read past end of data");
+        if (_position + count > _bytes.Length)
+            throw new IOException("End of data reached.");
 
         var bytes = new byte[count];
 
@@ -43,7 +45,9 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     public void Advance(int n)
     {
         Debug.Assert(n >= 0, "n must be zero or greater");
-        Debug.Assert(_position + n <= _bytes.Length, "attempted to advance past end of data");
+
+        if (_position + n > _bytes.Length)
+            throw new IOException("End of data reached.");
 
         _position += n;
     }

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -14,14 +14,14 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public byte GetByte()
     {
-        Debug.Assert(_position >= _bytes.Length, "attempted to read past end of data");
+        Debug.Assert(_position < _bytes.Length, "attempted to read past end of data");
 
         return _bytes[_position++];
     }
 
     public void GetBytes(scoped Span<byte> bytes)
     {
-        Debug.Assert(_position + bytes.Length > _bytes.Length, "attempted to read past end of data");
+        Debug.Assert(_position + bytes.Length <= _bytes.Length, "attempted to read past end of data");
 
         _bytes.Slice(_position, bytes.Length).CopyTo(bytes);
         _position += bytes.Length;
@@ -29,7 +29,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public byte[] GetBytes(int count)
     {
-        Debug.Assert(_position + count > _bytes.Length, "attempted to read past end of data");
+        Debug.Assert(_position + count <= _bytes.Length, "attempted to read past end of data");
 
         var bytes = new byte[count];
 
@@ -42,15 +42,15 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public void Advance(int n)
     {
-        Debug.Assert(n < 0, "n must be zero or greater");
-        Debug.Assert(_position + n > _bytes.Length, "attempted to advance past end of data");
+        Debug.Assert(n >= 0, "n must be zero or greater");
+        Debug.Assert(_position + n <= _bytes.Length, "attempted to advance past end of data");
 
         _position += n;
     }
 
     public bool TryAdvance(int n)
     {
-        Debug.Assert(n < 0, "n must be zero or greater");
+        Debug.Assert(n >= 0, "n must be zero or greater");
 
         _position += n;
 

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -10,11 +10,14 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     private int _position = 0;
     private bool _isBigEndian = isBigEndian;
 
+    public readonly int Available => _bytes.Length - _position;
+
     public int Position => _position;
 
     public byte GetByte()
     {
-        Debug.Assert(_position < _bytes.Length, "attempted to read past end of data");
+        if (_position >= _bytes.Length)
+            throw new IOException("End of data reached.");
 
         return _bytes[_position++];
     }
@@ -39,8 +42,6 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
         _position += count;
         return bytes;
     }
-
-    public readonly int Available => _bytes.Length - _position;
 
     public void Advance(int n)
     {
@@ -75,7 +76,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     public ushort GetUInt16()
     {
         var bytes = _bytes.Slice(_position, 2);
-        _position += 2;
+        Advance(2);
 
         return _isBigEndian
             ? BinaryPrimitives.ReadUInt16BigEndian(bytes)
@@ -85,7 +86,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     public short GetInt16()
     {
         var bytes = _bytes.Slice(_position, 2);
-        _position += 2;
+        Advance(2);
 
         return _isBigEndian
             ? BinaryPrimitives.ReadInt16BigEndian(bytes)
@@ -95,7 +96,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     public uint GetUInt32()
     {
         var bytes = _bytes.Slice(_position, 4);
-        _position += 4;
+        Advance(4);
 
         return _isBigEndian
             ? BinaryPrimitives.ReadUInt32BigEndian(bytes)
@@ -105,7 +106,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     public int GetInt32()
     {
         var bytes = _bytes.Slice(_position, 4);
-        _position += 4;
+        Advance(4);
 
         return _isBigEndian
             ? BinaryPrimitives.ReadInt32BigEndian(bytes)
@@ -115,7 +116,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     public long GetInt64()
     {
         var bytes = _bytes.Slice(_position, 8);
-        _position += 8;
+        Advance(8);
 
         return _isBigEndian
             ? BinaryPrimitives.ReadInt64BigEndian(bytes)
@@ -125,7 +126,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
     public ulong GetUInt64()
     {
         var bytes = _bytes.Slice(_position, 8);
-        _position += 8;
+        Advance(8);
 
         return _isBigEndian
             ? BinaryPrimitives.ReadUInt64BigEndian(bytes)

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -38,26 +38,21 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
         return bytes;
     }
 
-    public int Available
+    public readonly int Available => _bytes.Length - _position;
+
+    public void Skip(int n)
     {
-        get => _bytes.Length - _position;
+        Debug.Assert(n < 0, "n must be zero or greater");
+        Debug.Assert(_position + n > _bytes.Length, "attempted to advance past end of data");
+
+        _position += n;
     }
 
-    public void Skip(long n)
+    public bool TrySkip(int n)
     {
-        Debug.Assert(n < 0, "n must be zero or greater.");
+        Debug.Assert(n < 0, "n must be zero or greater");
 
-        if (_position + n > _bytes.Length)
-            throw new IOException("End of data reached.");
-
-        _position += unchecked((int)n);
-    }
-
-    public bool TrySkip(long n)
-    {
-        Debug.Assert(n < 0, "n must be zero or greater.");
-
-        _position += unchecked((int)n);
+        _position += n;
 
         if (_position > _bytes.Length)
         {

--- a/MetadataExtractor/IO/BufferReader.cs
+++ b/MetadataExtractor/IO/BufferReader.cs
@@ -13,7 +13,7 @@ internal ref struct BufferReader(ReadOnlySpan<byte> bytes, bool isBigEndian)
 
     public readonly int Available => _bytes.Length - _position;
 
-    public int Position => _position;
+    public readonly int Position => _position;
 
     public byte GetByte()
     {


### PR DESCRIPTION
This PR introduces a ref struct based BufferReader that can operate directly over a span -- and applies it to eliminate a bunch of random allocations. 

This same approach can also be used to optimize various Extract functions with a public API change.