### PR TITLE
Remove obsolete members on Tag class

### DIFF
--- a/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -4002,11 +4002,8 @@ MetadataExtractor.Tag
 MetadataExtractor.Tag.Description.get -> string?
 MetadataExtractor.Tag.DirectoryName.get -> string!
 MetadataExtractor.Tag.HasName.get -> bool
-MetadataExtractor.Tag.HasTagName.get -> bool
 MetadataExtractor.Tag.Name.get -> string!
 MetadataExtractor.Tag.Tag(int type, MetadataExtractor.Directory! directory) -> void
-MetadataExtractor.Tag.TagName.get -> string!
-MetadataExtractor.Tag.TagType.get -> int
 MetadataExtractor.Tag.Type.get -> int
 MetadataExtractor.TagDescriptor<T>
 MetadataExtractor.TagDescriptor<T>.Directory.get -> T!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -3995,11 +3995,8 @@ MetadataExtractor.Tag
 MetadataExtractor.Tag.Description.get -> string?
 MetadataExtractor.Tag.DirectoryName.get -> string!
 MetadataExtractor.Tag.HasName.get -> bool
-MetadataExtractor.Tag.HasTagName.get -> bool
 MetadataExtractor.Tag.Name.get -> string!
 MetadataExtractor.Tag.Tag(int type, MetadataExtractor.Directory! directory) -> void
-MetadataExtractor.Tag.TagName.get -> string!
-MetadataExtractor.Tag.TagType.get -> int
 MetadataExtractor.Tag.Type.get -> int
 MetadataExtractor.TagDescriptor<T>
 MetadataExtractor.TagDescriptor<T>.Directory.get -> T!

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -3997,11 +3997,8 @@ MetadataExtractor.Tag
 MetadataExtractor.Tag.Description.get -> string?
 MetadataExtractor.Tag.DirectoryName.get -> string!
 MetadataExtractor.Tag.HasName.get -> bool
-MetadataExtractor.Tag.HasTagName.get -> bool
 MetadataExtractor.Tag.Name.get -> string!
 MetadataExtractor.Tag.Tag(int type, MetadataExtractor.Directory! directory) -> void
-MetadataExtractor.Tag.TagName.get -> string!
-MetadataExtractor.Tag.TagType.get -> int
 MetadataExtractor.Tag.Type.get -> int
 MetadataExtractor.TagDescriptor<T>
 MetadataExtractor.TagDescriptor<T>.Directory.get -> T!

--- a/MetadataExtractor/Tag.cs
+++ b/MetadataExtractor/Tag.cs
@@ -22,9 +22,6 @@ namespace MetadataExtractor
         /// <value>the tag type as an int</value>
         public int Type { get; }
 
-        [Obsolete("Use Type instead.")]
-        public int TagType => Type;
-
         /// <summary>
         /// Get a description of the tag's value, considering enumerated values
         /// and units.
@@ -39,16 +36,10 @@ namespace MetadataExtractor
         /// </remarks>
         public bool HasName => _directory.HasTagName(Type);
 
-        [Obsolete("Use HasName instead.")]
-        public bool HasTagName => HasName;
-
         /// <summary>
         /// Get the name of the tag, such as <c>Aperture</c>, or <c>InteropVersion</c>.
         /// </summary>
         public string Name => _directory.GetTagName(Type);
-
-        [Obsolete("Use Name instead")]
-        public string TagName => Name;
 
         /// <summary>
         /// Get the name of the <see cref="Directory"/> in which the tag exists, such as <c>Exif</c>, <c>GPS</c> or <c>Interoperability</c>.


### PR DESCRIPTION
These have been obsolete for a long time. Remove them as part of the API changes in 2.9.0.