### PR TITLE
Pool buffers in IndexedCapturingReader

### DIFF
--- a/MetadataExtractor/Formats/Png/PngMetadataReader.cs
+++ b/MetadataExtractor/Formats/Png/PngMetadataReader.cs
@@ -170,7 +170,8 @@ namespace MetadataExtractor.Formats.Png
                     try
                     {
                         using var inflaterStream = new DeflateStream(new MemoryStream(compressedProfile), CompressionMode.Decompress);
-                        iccDirectory = new IccReader().Extract(new IndexedCapturingReader(inflaterStream));
+                        using var iccReader = new IndexedCapturingReader(inflaterStream);
+                        iccDirectory = new IccReader().Extract(iccReader);
                         iccDirectory.Parent = directory;
                     }
                     catch (Exception e)

--- a/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffMetadataReader.cs
@@ -41,7 +41,9 @@ namespace MetadataExtractor.Formats.Tiff
             var directories = new List<Directory>();
 
             var handler = new ExifTiffHandler(directories, exifStartOffset: 0);
-            TiffReader.ProcessTiff(new IndexedCapturingReader(stream), handler);
+
+            using var reader = new IndexedCapturingReader(stream);
+            TiffReader.ProcessTiff(reader, handler);
 
             return directories;
         }

--- a/MetadataExtractor/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -111,6 +111,7 @@ MetadataExtractor.Formats.Png.PngDirectory.GetPngChunkType() -> MetadataExtracto
 MetadataExtractor.Formats.Png.PngDirectory.PngDirectory(MetadataExtractor.Formats.Png.PngChunkType pngChunkType) -> void
 MetadataExtractor.GeoLocation.Equals(MetadataExtractor.GeoLocation other) -> bool
 MetadataExtractor.GeoLocation.GeoLocation() -> void
+MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType

--- a/MetadataExtractor/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -110,6 +110,7 @@ MetadataExtractor.Formats.Png.PngDirectory.GetPngChunkType() -> MetadataExtracto
 MetadataExtractor.Formats.Png.PngDirectory.PngDirectory(MetadataExtractor.Formats.Png.PngChunkType pngChunkType) -> void
 MetadataExtractor.GeoLocation.Equals(MetadataExtractor.GeoLocation other) -> bool
 MetadataExtractor.GeoLocation.GeoLocation() -> void
+MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -111,6 +111,7 @@ MetadataExtractor.Formats.Png.PngDirectory.GetPngChunkType() -> MetadataExtracto
 MetadataExtractor.Formats.Png.PngDirectory.PngDirectory(MetadataExtractor.Formats.Png.PngChunkType pngChunkType) -> void
 MetadataExtractor.GeoLocation.Equals(MetadataExtractor.GeoLocation other) -> bool
 MetadataExtractor.GeoLocation.GeoLocation() -> void
+MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -110,6 +110,7 @@ MetadataExtractor.Formats.Png.PngDirectory.GetPngChunkType() -> MetadataExtracto
 MetadataExtractor.Formats.Png.PngDirectory.PngDirectory(MetadataExtractor.Formats.Png.PngChunkType pngChunkType) -> void
 MetadataExtractor.GeoLocation.Equals(MetadataExtractor.GeoLocation other) -> bool
 MetadataExtractor.GeoLocation.GeoLocation() -> void
+MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType


### PR DESCRIPTION
Looking at traces over the regression suite shows ~2% CPU spent allocating chunks for the `IndexedCapturingReader`.

We can pull these buffers from the array pool, and return them when we're done. When processing multiple items, reusing these arrays will improve overall performance.

![image](https://github.com/drewnoakes/metadata-extractor-dotnet/assets/350947/f5515c56-9189-469e-b245-b9c4173fcb36)
