### PR TITLE
Reduce overhead reading byte/sbyte arrays from IndexedReader

### DIFF
--- a/MetadataExtractor/Formats/Tiff/TiffReader.cs
+++ b/MetadataExtractor/Formats/Tiff/TiffReader.cs
@@ -1,5 +1,7 @@
 // Copyright (c) Drew Noakes and contributors. All Rights Reserved. Licensed under the Apache License, Version 2.0. See LICENSE in the project root for license information.
 
+using System.Runtime.InteropServices;
+
 namespace MetadataExtractor.Formats.Tiff
 {
     /// <summary>
@@ -384,8 +386,8 @@ namespace MetadataExtractor.Formats.Tiff
                     else
                     {
                         var array = new sbyte[componentCount];
-                        for (var i = 0; i < componentCount; i++)
-                            array[i] = reader.GetSByte(tagValueOffset + i);
+                        var bytes = MemoryMarshal.Cast<sbyte, byte>(array);
+                        reader.GetBytes(tagValueOffset, bytes);
                         handler.SetInt8SArray(tagId, array);
                     }
                     break;
@@ -399,8 +401,7 @@ namespace MetadataExtractor.Formats.Tiff
                     else
                     {
                         var array = new byte[componentCount];
-                        for (var i = 0; i < componentCount; i++)
-                            array[i] = reader.GetByte(tagValueOffset + i);
+                        reader.GetBytes(tagValueOffset, array);
                         handler.SetInt8UArray(tagId, array);
                     }
                     break;


### PR DESCRIPTION
Traces gathered over the test suite show:

- ~2.7% CPU spent in `IndexedReader.GetByte(int)`
- ~0.4% CPU spent in `IndexedReader.GetSByte(int)`

![image](https://github.com/drewnoakes/metadata-extractor-dotnet/assets/350947/d3edcc56-c3b0-4146-8bc5-922d22059be9)

![image](https://github.com/drewnoakes/metadata-extractor-dotnet/assets/350947/b346bb35-0a3c-45aa-93ce-4e269be4625e)


Looking at the main callers shows loops in `TiffReader` that call these methods in loops. This approach accrues overhead per-byte due to bounds checking and virtual dispatch.

Instead, use the `Span<byte>` overload of `GetBytes` that performs the bounds checking once, then copies data in a single call.

It may be possible to give a similar treatment to the handling of other TIFF format codes, though they're not currently showing up on traces and would be more complex to implement due to byte-ordering issues (`byte` and `sbyte` being immune from those).