### PR TITLE
Allow filename to influence file type detection

### DIFF
--- a/MetadataExtractor/ImageMetadataReader.cs
+++ b/MetadataExtractor/ImageMetadataReader.cs
@@ -57,12 +57,13 @@ namespace MetadataExtractor
     {
         /// <summary>Reads metadata from an <see cref="Stream"/>.</summary>
         /// <param name="stream">A stream from which the file data may be read.  The stream must be positioned at the beginning of the file's data.</param>
+        /// <param name="fileName">The file name, if available. May contain path information if that's more convenient. The method will only inspect the extension of the path (i.e. <c>EndsWith</c>).</param>
         /// <returns>A list of <see cref="Directory"/> instances containing the various types of metadata found within the file's data.</returns>
         /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
         /// <exception cref="IOException"/>
-        public static IReadOnlyList<Directory> ReadMetadata(Stream stream)
+        public static IReadOnlyList<Directory> ReadMetadata(Stream stream, string? fileName = null)
         {
-            var fileType = FileTypeDetector.DetectFileType(stream);
+            var fileType = FileTypeDetector.DetectFileType(stream, fileName);
 
             var directories = new List<Directory>();
 
@@ -76,23 +77,29 @@ namespace MetadataExtractor
                 FileType.Bmp       => BmpMetadataReader.ReadMetadata(stream),
                 FileType.Crx       => QuickTimeMetadataReader.ReadMetadata(stream),
                 FileType.Cr2       => TiffMetadataReader.ReadMetadata(stream),
+                FileType.Dng       => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Eps       => EpsMetadataReader.ReadMetadata(stream),
                 FileType.Gif       => GifMetadataReader.ReadMetadata(stream),
+                FileType.GoPro     => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Heif      => HeifMetadataReader.ReadMetadata(stream),
                 FileType.Ico       => IcoMetadataReader.ReadMetadata(stream),
                 FileType.Jpeg      => JpegMetadataReader.ReadMetadata(stream),
+                FileType.Kdc       => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Mp3       => Mp3MetadataReader.ReadMetadata(stream),
                 FileType.Mp4       => QuickTimeMetadataReader.ReadMetadata(stream),
                 FileType.Nef       => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Netpbm    => [NetpbmMetadataReader.ReadMetadata(stream)],
                 FileType.Orf       => TiffMetadataReader.ReadMetadata(stream),
+                FileType.Pef       => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Pcx       => [PcxMetadataReader.ReadMetadata(stream)],
                 FileType.Png       => PngMetadataReader.ReadMetadata(stream),
                 FileType.Psd       => PsdMetadataReader.ReadMetadata(stream),
                 FileType.QuickTime => QuickTimeMetadataReader.ReadMetadata(stream),
                 FileType.Raf       => RafMetadataReader.ReadMetadata(stream),
                 FileType.Rw2       => TiffMetadataReader.ReadMetadata(stream),
+                FileType.Srw       => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Tga       => TgaMetadataReader.ReadMetadata(stream),
+                FileType.ThreeFR   => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Tiff      => TiffMetadataReader.ReadMetadata(stream),
                 FileType.Wav       => WavMetadataReader.ReadMetadata(stream),
                 FileType.WebP      => WebPMetadataReader.ReadMetadata(stream),
@@ -109,7 +116,7 @@ namespace MetadataExtractor
         }
 
         /// <summary>Reads metadata from a file.</summary>
-        /// <remarks>Unlike <see cref="ReadMetadata(Stream)"/>, this overload includes a <see cref="FileMetadataDirectory"/> in the output.</remarks>
+        /// <remarks>Unlike <see cref="ReadMetadata(Stream, string)"/>, this overload includes a <see cref="FileMetadataDirectory"/> in the output.</remarks>
         /// <param name="filePath">Location of a file from which data should be read.</param>
         /// <returns>A list of <see cref="Directory"/> instances containing the various types of metadata found within the file's data.</returns>
         /// <exception cref="ImageProcessingException">The file type is unknown, or processing errors occurred.</exception>
@@ -119,7 +126,7 @@ namespace MetadataExtractor
             var directories = new List<Directory>();
 
             using (var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read))
-                directories.AddRange(ReadMetadata(stream));
+                directories.AddRange(ReadMetadata(stream, filePath));
 
             directories.Add(new FileMetadataReader().Read(filePath));
 

--- a/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net462/PublicAPI.Shipped.txt
@@ -4378,13 +4378,13 @@ static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSeconds(double value
 static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSecondsString(double value) -> string!
 static MetadataExtractor.GeoLocation.DegreesMinutesSecondsToDecimal(MetadataExtractor.Rational degs, MetadataExtractor.Rational mins, MetadataExtractor.Rational secs, bool isNegative) -> double?
 static MetadataExtractor.ImageMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
+static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream, string? fileName = null) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Rational.operator !=(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.Rational.operator ==(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.TagDescriptor<T>.ConvertBytesToVersionString(int[]? components, int majorDigits) -> string?
 static MetadataExtractor.TagDescriptor<T>.GetFocalLengthDescription(double mm) -> string!
 static MetadataExtractor.TagDescriptor<T>.GetFStopDescription(double fStop) -> string!
-static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream) -> MetadataExtractor.Util.FileType
+static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream, string? fileName = null) -> MetadataExtractor.Util.FileType
 static MetadataExtractor.Util.FileTypeExtensions.GetAllExtensions(this MetadataExtractor.Util.FileType fileType) -> System.Collections.Generic.IEnumerable<string!>?
 static MetadataExtractor.Util.FileTypeExtensions.GetCommonExtension(this MetadataExtractor.Util.FileType fileType) -> string?
 static MetadataExtractor.Util.FileTypeExtensions.GetLongName(this MetadataExtractor.Util.FileType fileType) -> string!

--- a/MetadataExtractor/PublicAPI/net462/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net462/PublicAPI.Unshipped.txt
@@ -115,6 +115,12 @@ MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Dng = 29 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.GoPro = 30 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Kdc = 31 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.ThreeFR = 32 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Pef = 33 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Srw = 34 -> MetadataExtractor.Util.FileType
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl1Descriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/PublicAPI/net8.0/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/net8.0/PublicAPI.Shipped.txt
@@ -4366,13 +4366,13 @@ static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSeconds(double value
 static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSecondsString(double value) -> string!
 static MetadataExtractor.GeoLocation.DegreesMinutesSecondsToDecimal(MetadataExtractor.Rational degs, MetadataExtractor.Rational mins, MetadataExtractor.Rational secs, bool isNegative) -> double?
 static MetadataExtractor.ImageMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
+static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream, string? fileName = null) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Rational.operator !=(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.Rational.operator ==(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.TagDescriptor<T>.ConvertBytesToVersionString(int[]? components, int majorDigits) -> string?
 static MetadataExtractor.TagDescriptor<T>.GetFocalLengthDescription(double mm) -> string!
 static MetadataExtractor.TagDescriptor<T>.GetFStopDescription(double fStop) -> string!
-static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream) -> MetadataExtractor.Util.FileType
+static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream, string? fileName = null) -> MetadataExtractor.Util.FileType
 static MetadataExtractor.Util.FileTypeExtensions.GetAllExtensions(this MetadataExtractor.Util.FileType fileType) -> System.Collections.Generic.IEnumerable<string!>?
 static MetadataExtractor.Util.FileTypeExtensions.GetCommonExtension(this MetadataExtractor.Util.FileType fileType) -> string?
 static MetadataExtractor.Util.FileTypeExtensions.GetLongName(this MetadataExtractor.Util.FileType fileType) -> string!

--- a/MetadataExtractor/PublicAPI/net8.0/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/net8.0/PublicAPI.Unshipped.txt
@@ -114,6 +114,12 @@ MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Dng = 29 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.GoPro = 30 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Kdc = 31 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.ThreeFR = 32 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Pef = 33 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Srw = 34 -> MetadataExtractor.Util.FileType
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl1Descriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Shipped.txt
@@ -4371,13 +4371,13 @@ static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSeconds(double value
 static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSecondsString(double value) -> string!
 static MetadataExtractor.GeoLocation.DegreesMinutesSecondsToDecimal(MetadataExtractor.Rational degs, MetadataExtractor.Rational mins, MetadataExtractor.Rational secs, bool isNegative) -> double?
 static MetadataExtractor.ImageMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
+static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream, string? fileName = null) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Rational.operator !=(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.Rational.operator ==(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.TagDescriptor<T>.ConvertBytesToVersionString(int[]? components, int majorDigits) -> string?
 static MetadataExtractor.TagDescriptor<T>.GetFocalLengthDescription(double mm) -> string!
 static MetadataExtractor.TagDescriptor<T>.GetFStopDescription(double fStop) -> string!
-static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream) -> MetadataExtractor.Util.FileType
+static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream, string? fileName = null) -> MetadataExtractor.Util.FileType
 static MetadataExtractor.Util.FileTypeExtensions.GetAllExtensions(this MetadataExtractor.Util.FileType fileType) -> System.Collections.Generic.IEnumerable<string!>?
 static MetadataExtractor.Util.FileTypeExtensions.GetCommonExtension(this MetadataExtractor.Util.FileType fileType) -> string?
 static MetadataExtractor.Util.FileTypeExtensions.GetLongName(this MetadataExtractor.Util.FileType fileType) -> string!

--- a/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard1.3/PublicAPI.Unshipped.txt
@@ -115,6 +115,12 @@ MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Dng = 29 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.GoPro = 30 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Kdc = 31 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.ThreeFR = 32 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Pef = 33 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Srw = 34 -> MetadataExtractor.Util.FileType
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl1Descriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Shipped.txt
@@ -4373,13 +4373,13 @@ static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSeconds(double value
 static MetadataExtractor.GeoLocation.DecimalToDegreesMinutesSecondsString(double value) -> string!
 static MetadataExtractor.GeoLocation.DegreesMinutesSecondsToDecimal(MetadataExtractor.Rational degs, MetadataExtractor.Rational mins, MetadataExtractor.Rational secs, bool isNegative) -> double?
 static MetadataExtractor.ImageMetadataReader.ReadMetadata(string! filePath) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
-static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
+static MetadataExtractor.ImageMetadataReader.ReadMetadata(System.IO.Stream! stream, string? fileName = null) -> System.Collections.Generic.IReadOnlyList<MetadataExtractor.Directory!>!
 static MetadataExtractor.Rational.operator !=(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.Rational.operator ==(MetadataExtractor.Rational a, MetadataExtractor.Rational b) -> bool
 static MetadataExtractor.TagDescriptor<T>.ConvertBytesToVersionString(int[]? components, int majorDigits) -> string?
 static MetadataExtractor.TagDescriptor<T>.GetFocalLengthDescription(double mm) -> string!
 static MetadataExtractor.TagDescriptor<T>.GetFStopDescription(double fStop) -> string!
-static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream) -> MetadataExtractor.Util.FileType
+static MetadataExtractor.Util.FileTypeDetector.DetectFileType(System.IO.Stream! stream, string? fileName = null) -> MetadataExtractor.Util.FileType
 static MetadataExtractor.Util.FileTypeExtensions.GetAllExtensions(this MetadataExtractor.Util.FileType fileType) -> System.Collections.Generic.IEnumerable<string!>?
 static MetadataExtractor.Util.FileTypeExtensions.GetCommonExtension(this MetadataExtractor.Util.FileType fileType) -> string?
 static MetadataExtractor.Util.FileTypeExtensions.GetLongName(this MetadataExtractor.Util.FileType fileType) -> string!

--- a/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
+++ b/MetadataExtractor/PublicAPI/netstandard2.1/PublicAPI.Unshipped.txt
@@ -114,6 +114,12 @@ MetadataExtractor.IO.IndexedCapturingReader.Dispose() -> void
 MetadataExtractor.IO.IndexedReader.GetByte(int index) -> byte
 MetadataExtractor.IO.IndexedReader.GetBytes(int index, int count) -> byte[]!
 MetadataExtractor.Util.FileType.Avif = 28 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Dng = 29 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.GoPro = 30 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Kdc = 31 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.ThreeFR = 32 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Pef = 33 -> MetadataExtractor.Util.FileType
+MetadataExtractor.Util.FileType.Srw = 34 -> MetadataExtractor.Util.FileType
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDescriptor.GetDescription(int tagType) -> string?
 override MetadataExtractor.Formats.Exif.Makernotes.AppleRunTimeMakernoteDirectory.Name.get -> string!
 override MetadataExtractor.Formats.Exif.Makernotes.NikonPictureControl1Descriptor.GetDescription(int tagType) -> string?

--- a/MetadataExtractor/Util/FileType.cs
+++ b/MetadataExtractor/Util/FileType.cs
@@ -78,7 +78,7 @@ namespace MetadataExtractor.Util
         /// <summary>Encapsulated PostScript.</summary>
         Eps = 23,
 
-        /// <summary>Truevision graphics.</summary>
+        /// <summary>Truevision graphics (Targa).</summary>
         Tga = 24,
 
         /// <summary>MPEG-1 / MPEG-2 Audio Layer III.</summary>
@@ -91,7 +91,25 @@ namespace MetadataExtractor.Util
         Mp4 = 27,
 
         /// <summary>AV1 Image File Format.</summary>
-        Avif = 28
+        Avif = 28,
+
+        /// <summary>DNG Image File Format.</summary>
+        Dng = 29,
+
+        /// <summary>GPR (GoPro) Image File Format.</summary>
+        GoPro = 30,
+
+        /// <summary>KDC (Kodak) Image File Format.</summary>
+        Kdc = 31,
+
+        /// <summary>3FR (Hasselblad) Image File Format.</summary>
+        ThreeFR = 32,
+
+        /// <summary>PEF (Pentax) Image File Format.</summary>
+        Pef = 33,
+
+        /// <summary>SRW (Samsung) Image File Format.</summary>
+        Srw = 34,
     }
 
     public static class FileTypeExtensions
@@ -126,7 +144,13 @@ namespace MetadataExtractor.Util
             "MP3",
             "HEIF",
             "MP4",
-            "AVIF"
+            "AVIF",
+            "DNG",
+            "GPR",
+            "KDC",
+            "3FR",
+            "PEF",
+            "SRW",
         ];
 
         private static readonly string[] _longNames =
@@ -160,6 +184,12 @@ namespace MetadataExtractor.Util
             "High Efficiency Image File Format",
             "MPEG-4 Part 14",
             "AV1 Image File Format",
+            "Digital Negative",
+            "GoPro Raw",
+            "Kodak Raw",
+            "Hasselblad Raw",
+            "Pentax Raw",
+            "Samsung Raw",
         ];
 
         private static readonly string?[] _mimeTypes =
@@ -177,12 +207,12 @@ namespace MetadataExtractor.Util
             "audio/vnd.wave",
             "video/vnd.avi",
             "image/webp",
-            null, // Sony RAW
-            null,
-            null,
-            null,
-            null,
-            null,
+            "image/x-sony-arw", // https://stackoverflow.com/a/47612661/24874
+            "image/x-canon-crw",
+            "image/x-canon-cr2",
+            "image/x-nikon-nef",
+            "image/x-olympus-orf",
+            "image/x-fuji-raf",
             null,
             "video/quicktime",
             "image/x-portable-graymap",
@@ -192,7 +222,13 @@ namespace MetadataExtractor.Util
             "audio/mpeg",
             "image/heic",
             "video/mp4",
-            "image/avif"
+            "image/avif",
+            "image/x-adobe-dng",
+            "image/x-gopro-gpr",
+            "image/x-kodak-kdc",
+            "image/x-hasselblad-3fr",
+            "image/x-pentax-pef",
+            "image/x-samsung-srw",
         ];
 
         private static readonly string[]?[] _extensions =
@@ -225,7 +261,13 @@ namespace MetadataExtractor.Util
             ["mp3"],
             ["heic", "heif", "avci"],
             ["mp4", "m4a", "m4p", "m4b", "m4r", "m4v"],
-            ["avif"]
+            ["avif"],
+            ["dng"],
+            ["gpr"],
+            ["kdc"],
+            ["3fr"],
+            ["pef"],
+            ["srw"],
         ];
 
         public static string GetName(this FileType fileType)


### PR DESCRIPTION
Several camera raw files share the same opening bytes, and our current prefix detection cannot differentiate between then. This change allows the file path to be provided, to be used when certain byte prefixes are seen.