### PR TITLE
SequentialStreamReader.cs: Cast numbers to ulong before bound check

### DIFF
--- a/MetadataExtractor/IO/SequentialStreamReader.cs
+++ b/MetadataExtractor/IO/SequentialStreamReader.cs
@@ -85,7 +85,7 @@ namespace MetadataExtractor.IO
             if (n < 0)
                 throw new ArgumentException("n must be zero or greater.");
 
-            if (_stream.Position + n > _stream.Length)
+            if ((ulong)(_stream.Position + n) > (ulong)(_stream.Length))
                 throw new IOException($"Unable to skip. Requested {n} bytes but only {_stream.Length - _stream.Position} remained.");
 
             _stream.Seek(n, SeekOrigin.Current);


### PR DESCRIPTION
Fixes #428

Skip Method: Avoid an integer overflow bug by explicitly casting to ulong before comparing the expression.